### PR TITLE
Make muscle-group distribution chart accessible

### DIFF
--- a/LOGIT/SharedUI/Charts/MuscleGroupOccurancesChart.swift
+++ b/LOGIT/SharedUI/Charts/MuscleGroupOccurancesChart.swift
@@ -12,6 +12,8 @@ struct MuscleGroupOccurancesChart: View {
     let muscleGroupOccurances: [(MuscleGroup, Int)]
     let selectedMuscleGroup: MuscleGroup?
 
+    @Environment(\.accessibilityDifferentiateWithoutColor) private var differentiateWithoutColor
+
     init(muscleGroupOccurances: [(MuscleGroup, Int)], selectedMuscleGroup: MuscleGroup? = nil) {
         self.muscleGroupOccurances = muscleGroupOccurances
         self.selectedMuscleGroup = selectedMuscleGroup
@@ -25,14 +27,18 @@ struct MuscleGroupOccurancesChart: View {
                     innerRadius: .ratio(0.65)
                 )
                 .foregroundStyle(Color.fill.gradient)
+                .accessibilityHidden(true)
             } else {
                 ForEach(muscleGroupOccurances, id: \.0) { muscleGroupOccurance in
                     SectorMark(
                         angle: .value("Value", muscleGroupOccurance.1),
                         innerRadius: .ratio(0.65),
-                        angularInset: 1
+                        // Wider gaps when the user can't rely on hue to tell slices apart.
+                        angularInset: differentiateWithoutColor ? 2.5 : 1
                     )
                     .foregroundStyle(foregroundStyle(for: muscleGroupOccurance.0))
+                    .accessibilityLabel(muscleGroupOccurance.0.description)
+                    .accessibilityValue(Text("\(muscleGroupOccurance.1)"))
                 }
             }
         }


### PR DESCRIPTION
## Summary
The muscle-group distribution donut (`MuscleGroupOccurancesChart`) is the one place in the app where color is the **sole** differentiator between muscles — every other multi-color surface (selector chips, workout legend, template breakdown) already pairs each color with a text label. It was also opaque to VoiceOver.

This PR makes the chart accessible:
- **VoiceOver:** per-slice `accessibilityLabel` (muscle name) + `accessibilityValue` (set count), so each slice is announced. The empty-state placeholder slice is now `accessibilityHidden`.
- **Differentiate Without Color:** when that setting is on, the gaps between slices widen (`angularInset` 1 → 2.5) so slices read as distinct shapes instead of relying on hue.

This completes the accessibility follow-up for the new muscle-group color palette (the palette itself is already on `main`).

## Notes
- The chart renders as small as 70×70 (home tile), so in-slice text labels aren't feasible; muscle identity for sighted color-blind users comes from the text/legends that already accompany every embedding.
- Rendering is unchanged when Differentiate Without Color is off (inset stays at 1; the a11y modifiers don't affect layout).

## Testing
- `xcodebuild` succeeds, zero warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)