### PR TITLE
Fix launch crash from CloudKit-incompatible Core Data migration

### DIFF
--- a/LOGIT/Data/Database/Database.swift
+++ b/LOGIT/Data/Database/Database.swift
@@ -34,17 +34,48 @@ public class Database: ObservableObject {
         if isPreview {
             container.persistentStoreDescriptions.first!.url = URL(fileURLWithPath: "/dev/null")
         }
-        container.loadPersistentStores(completionHandler: { _, error in
-            if let error = error as NSError? {
-                fatalError("Unresolved error \(error), \(error.userInfo)")
-            }
-        })
+        loadStores()
         if isPreview {
             setupPreviewDatabase()
         }
 
         container.viewContext.undoManager = UndoManager()
         observeUndoManager()
+    }
+
+    // MARK: - Store Loading
+
+    /// Loads the persistent stores, recovering from incompatible-model errors in DEBUG builds.
+    ///
+    /// The Core Data model is iterated on frequently during development. Because the store is backed
+    /// by `NSPersistentCloudKitContainer`, properties cannot be renamed or removed in place — CloudKit
+    /// only permits additive schema changes. A store left over from an earlier model revision (e.g. one
+    /// that still had `Exercise.name_`) therefore fails to migrate and crashes on every launch with
+    /// `NSCocoaErrorDomain` 134110. In DEBUG we recreate the offending store once and retry; release
+    /// builds keep the hard failure so real user data is never silently discarded.
+    private func loadStores(recreatingIncompatibleStoreOnFailure recreate: Bool = true) {
+        container.loadPersistentStores { [weak self] description, error in
+            guard let error = error as NSError? else { return }
+            #if DEBUG
+            if recreate, let self, self.isIncompatibleStoreError(error), let url = description.url {
+                os_log(
+                    "Database: Incompatible store at %{public}@ (Core Data error %d). Recreating it for development.",
+                    type: .error, url.absoluteString, error.code
+                )
+                try? self.container.persistentStoreCoordinator.destroyPersistentStore(
+                    at: url, ofType: NSSQLiteStoreType, options: nil
+                )
+                self.loadStores(recreatingIncompatibleStoreOnFailure: false)
+                return
+            }
+            #endif
+            fatalError("Unresolved error \(error), \(error.userInfo)")
+        }
+    }
+
+    /// `true` for Core Data migration / incompatible-model-version errors (`NSCocoaErrorDomain` 134100–134170).
+    private func isIncompatibleStoreError(_ error: NSError) -> Bool {
+        error.domain == NSCocoaErrorDomain && (134100...134170).contains(error.code)
     }
 
     // MARK: - Computed Properties


### PR DESCRIPTION
## Problem

Launching the app on a simulator/device whose Core Data store predates the `Exercise.name_` → `name` revert crashed on every launch:

```
NSCocoaErrorDomain Code=134110 "An error occurred during persistent store migration."
reason=Cannot migrate store in-place: Properties cannot be renamed in stores that are
used with CloudKit. Cannot rename 'Exercise.name_' to 'Exercise.name'.
```

`NSPersistentCloudKitContainer` only allows **additive** schema changes, so it cannot migrate a store in place once a property has been renamed or removed. The affected store was created while the model still had `Exercise.name_`; commit `766398b1` ("Changed back to old CD model") later reverted it to `name`. The unconditional `fatalError` in `loadPersistentStores` then turned the migration failure into a hard crash.

The committed model is correct (every version uses `name`), so fresh installs are unaffected — only stores left over from the transient `name_` revision fail to migrate.

## Fix

Replace the blanket `fatalError` with a `loadStores()` helper that, **in DEBUG builds only**, recreates a store that fails with an incompatible-model error (`NSCocoaErrorDomain` 134100–134170) and retries once. Release builds keep the hard failure so real user data is never silently discarded.

## Verification

Built and launched on the iPhone 17 simulator — the exact device that was crashing, with its stale `ZNAME_` store still in place. The incompatible store is recreated automatically and the app launches to the Summary screen instead of crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
