### PR TITLE
Restrict Core Data store auto-recovery to the simulator

### DIFF
--- a/LOGIT/Data/Database/Database.swift
+++ b/LOGIT/Data/Database/Database.swift
@@ -45,18 +45,20 @@ public class Database: ObservableObject {
 
     // MARK: - Store Loading
 
-    /// Loads the persistent stores, recovering from incompatible-model errors in DEBUG builds.
+    /// Loads the persistent stores, recovering from incompatible-model errors on the **simulator only**.
     ///
     /// The Core Data model is iterated on frequently during development. Because the store is backed
     /// by `NSPersistentCloudKitContainer`, properties cannot be renamed or removed in place — CloudKit
     /// only permits additive schema changes. A store left over from an earlier model revision (e.g. one
     /// that still had `Exercise.name_`) therefore fails to migrate and crashes on every launch with
-    /// `NSCocoaErrorDomain` 134110. In DEBUG we recreate the offending store once and retry; release
-    /// builds keep the hard failure so real user data is never silently discarded.
+    /// `NSCocoaErrorDomain` 134110. On the simulator we recreate the offending store once and retry so
+    /// stale development stores self-heal. On a real device we keep the hard failure: a user's workout
+    /// history must never be silently discarded, so an incompatible store there is handled deliberately
+    /// (and is normally recoverable from the CloudKit mirror).
     private func loadStores(recreatingIncompatibleStoreOnFailure recreate: Bool = true) {
         container.loadPersistentStores { [weak self] description, error in
             guard let error = error as NSError? else { return }
-            #if DEBUG
+            #if targetEnvironment(simulator)
             if recreate, let self, self.isIncompatibleStoreError(error), let url = description.url {
                 os_log(
                     "Database: Incompatible store at %{public}@ (Core Data error %d). Recreating it for development.",
@@ -73,10 +75,12 @@ public class Database: ObservableObject {
         }
     }
 
+    #if targetEnvironment(simulator)
     /// `true` for Core Data migration / incompatible-model-version errors (`NSCocoaErrorDomain` 134100–134170).
     private func isIncompatibleStoreError(_ error: NSError) -> Bool {
         error.domain == NSCocoaErrorDomain && (134100...134170).contains(error.code)
     }
+    #endif
 
     // MARK: - Computed Properties
 


### PR DESCRIPTION
## Background

PR #12 added DEBUG-only recovery that recreates a Core Data store which fails an incompatible-model migration (the CloudKit "cannot rename in place" crash). That gate was `#if DEBUG`.

## Problem

Xcode's "Run" action builds **Debug** by default — including when running on a physical device. So the auto-recreate would also fire on a real device: an un-migratable store (e.g. one left over from the transient `Exercise.name_` revision) would be **destroyed and recreated, silently discarding the user's local workout history**.

## Fix

Gate the recovery on `#if targetEnvironment(simulator)` instead of `#if DEBUG`, and compile the `isIncompatibleStoreError` helper only there.

- **Simulator** (any config): stale/incompatible dev stores still self-heal — unchanged from #12.
- **Real device** (Debug or Release): the recovery code is **not compiled at all**; an un-migratable store keeps the original hard `fatalError`, so real workout data is never silently wiped (and is normally recoverable from the CloudKit mirror).

## Verification

- `BUILD SUCCEEDED` for the iPhone 17 **simulator** (Debug) — zero warnings.
- `BUILD SUCCEEDED` for a **generic iOS device** (`generic/platform=iOS`, signing disabled) — confirms the device variant compiles cleanly with the recovery excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
