### PR TITLE
Gate the workout personal-records detail screen behind Pro

### DIFF
--- a/LOGIT/Features/Workout/WorkoutProgressSection.swift
+++ b/LOGIT/Features/Workout/WorkoutProgressSection.swift
@@ -295,6 +295,10 @@ struct WorkoutPersonalBestsTile: View {
 /// this workout, each with the value it beat and a line chart of the exercise's entire history for
 /// that metric cresting at the new best. The tile shows only the first few and the count; this is
 /// where they all live, with the basis spelled out at the bottom.
+///
+/// Pro-gated (blur + crown, like the other metric detail screens): the records *tile* on the workout
+/// detail stays free — the PR celebration is the teaser that sells Pro — but the full per-record
+/// history charts here are the analytics behind the wall.
 struct WorkoutPersonalRecordsScreen: View {
     @ObservedObject var workout: Workout
     let report: WorkoutProgressReport
@@ -314,6 +318,7 @@ struct WorkoutPersonalRecordsScreen: View {
             .padding(.top)
             .padding(.bottom, SCROLLVIEW_BOTTOM_PADDING)
         }
+        .isBlockedWithoutPro()
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: .principal) {


### PR DESCRIPTION
## What
Adds `.isBlockedWithoutPro()` to `WorkoutPersonalRecordsScreen` so the full per-record all-time history charts blur behind the Pro paywall, matching the seven other gated metric detail screens.

## Why
The PR **tile** on the workout detail stays free — it's the celebration/teaser that sells Pro — but the detailed per-record history charts are analytics that belong behind the wall, consistent with the rest of the app (weight/e1RM/volume tiles, the in-workout metric panel, etc.).

## Notes
- Tile unchanged (still free); only the pushed-to detail screen is gated.
- Placement mirrors `ExerciseE1RMScreen`/`VolumeScreen`: modifier on the `ScrollView` before `.navigationBarTitleDisplayMode`, so the nav title stays readable while the content blurs.
- Verified: incremental build succeeds with 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)