### PR TITLE
Keep the progress pill on one line, truncating neighbors instead

### DIFF
--- a/LOGIT/SharedUI/Views/ProgressIndicatorPill.swift
+++ b/LOGIT/SharedUI/Views/ProgressIndicatorPill.swift
@@ -92,6 +92,11 @@ struct ProgressIndicatorPill<Label: View>: View {
         .padding(.horizontal, size.horizontalPadding)
         .padding(.vertical, size.verticalPadding)
         .background(Capsule().fill(style.opacity(0.15)))
+        // The pill always takes its ideal width, so its label never compresses: a percent like
+        // "100 %" can't wrap to two lines or ellipsize. Being rigid, the pill also claims its space
+        // first in any HStack, so a neighbor (a tile title, an exercise name) truncates around it
+        // rather than squeezing it. Vertical stays flexible for the metric badge's two-line label.
+        .fixedSize(horizontal: true, vertical: false)
     }
 }
 


### PR DESCRIPTION
## What
The shared `ProgressIndicatorPill` — every trend/record/gain/lapsed pill — let its label compress. In a tight row (a half-width metric tile next to a long title) a wide value like "100 %" wrapped to two lines ("100" / "%").

## Fix
One line in the single shared component:
```swift
.fixedSize(horizontal: true, vertical: false)
```
The pill now always takes its ideal width, so its label can never wrap or ellipsize. Being rigid, it also claims its `HStack` space first, so a neighbor (a tile title, an exercise name) truncates *around* it. `vertical: false` preserves `MetricBadgeView`'s deliberate two-line label (an explicit `VStack`, not a wrapping string).

## Verification
Zero-warning build on the iPhone 17 Pro sim plus a screenshot reproducing the exact condition: a long title beside a "100 %" pill now renders the pill on one line while the title ellipsizes to "Set Volum…".

🤖 Generated with [Claude Code](https://claude.com/claude-code)