### PR TITLE
Redesign workout stat detail header and refine chart-detail pills

### DIFF
--- a/LOGIT/Features/Exercise/ExerciseDetail/ExerciseSetsScreen.swift
+++ b/LOGIT/Features/Exercise/ExerciseDetail/ExerciseSetsScreen.swift
@@ -208,12 +208,14 @@ struct ExerciseSetsScreen: View {
 
     /// Percent change of the total set count in the visible chart window versus a comparable window
     /// before it — the window right before, or the last window with training when that's empty
-    /// (see `exerciseWindowTrendPercentage`). Nil only when there's no earlier history at all.
+    /// (see `exerciseWindowTrendPercentage`). A window with no sets yet reads as down 100% once
+    /// there's any earlier history to fall from; nil only when there's no earlier history at all.
     private func trendPercentage(in workoutSets: [WorkoutSet]) -> Double? {
         exerciseWindowTrendPercentage(
             sets: workoutSets,
             windowStart: chartScrollPosition,
-            windowSeconds: visibleChartDomainInSeconds
+            windowSeconds: visibleChartDomainInSeconds,
+            emptyCurrentMeansDecline: true
         ) { start, end in
             let inRange = workoutSets.filter { ($0.workout?.date).map { $0 >= start && $0 <= end } ?? false }
             return inRange.isEmpty ? nil : Double(setCount(for: inRange))

--- a/LOGIT/Features/Exercise/ExerciseDetail/ExerciseVolumeScreen.swift
+++ b/LOGIT/Features/Exercise/ExerciseDetail/ExerciseVolumeScreen.swift
@@ -210,12 +210,14 @@ struct ExerciseVolumeScreen: View {
 
     /// Percent change of the total volume in the visible chart window versus a comparable window
     /// before it — the window right before, or the last window with training when that's empty
-    /// (see `exerciseWindowTrendPercentage`). Nil only when there's no earlier history at all.
+    /// (see `exerciseWindowTrendPercentage`). A window with no volume yet reads as down 100% once
+    /// there's any earlier history to fall from; nil only when there's no earlier history at all.
     private func trendPercentage(in workoutSets: [WorkoutSet]) -> Double? {
         exerciseWindowTrendPercentage(
             sets: workoutSets,
             windowStart: chartScrollPosition,
-            windowSeconds: visibleChartDomainInSeconds
+            windowSeconds: visibleChartDomainInSeconds,
+            emptyCurrentMeansDecline: true
         ) { start, end in
             let inRange = workoutSets.filter { ($0.workout?.date).map { $0 >= start && $0 <= end } ?? false }
             return inRange.isEmpty ? nil : Double(getVolume(of: inRange, for: exercise))

--- a/LOGIT/Features/Exercise/ExerciseDetail/Tiles/ExerciseMetricTile.swift
+++ b/LOGIT/Features/Exercise/ExerciseDetail/Tiles/ExerciseMetricTile.swift
@@ -86,15 +86,22 @@ struct ExerciseTileTrend {
 /// detail's previous-runs → recent fallback). `aggregate(start, end)` reduces the metric over
 /// `[start, end]` to one comparable number — a best for "max" metrics, a total for weekly sums —
 /// returning nil when that span has nothing to compare.
+///
+/// `emptyCurrentMeansDecline` decides what an empty *current* window means. For a "max" metric an
+/// empty window has simply nothing to plot — leave it off and the pill hides. For a cumulative
+/// metric (volume, sets) an empty window genuinely did zero work, so turn it on: once there's a
+/// baseline to fall from, that's a real "down 100%" reported rather than hidden.
 func exerciseWindowTrendPercentage(
     sets: [WorkoutSet],
     windowStart: Date,
     windowSeconds: Int,
+    emptyCurrentMeansDecline: Bool = false,
     aggregate: (_ start: Date, _ end: Date) -> Double?
 ) -> Double? {
     let calendar = Calendar.current
     let windowEnd = calendar.date(byAdding: .second, value: windowSeconds, to: windowStart) ?? windowStart
-    guard let current = aggregate(windowStart, windowEnd), current > 0 else { return nil }
+    let current = aggregate(windowStart, windowEnd) ?? 0
+    if current <= 0 && !emptyCurrentMeansDecline { return nil }
     let priorStart = calendar.date(byAdding: .second, value: -windowSeconds, to: windowStart) ?? windowStart
     var baseline = aggregate(priorStart, windowStart)
     if baseline == nil || baseline == 0 {

--- a/LOGIT/Features/Exercise/ExerciseDetail/Tiles/ExerciseSetsTile.swift
+++ b/LOGIT/Features/Exercise/ExerciseDetail/Tiles/ExerciseSetsTile.swift
@@ -48,7 +48,10 @@ struct ExerciseSetsTile: View {
             // and an empty unit renders as nothing through UnitView.
             unit: "",
             color: exercise.muscleGroup?.color ?? .accentColor,
-            percentChange: thisWeekCount > 0 && countBaseline > 0
+            // This week against the baseline. With a real baseline but nothing logged this week yet,
+            // that's a genuine "down 100%" — zero work, not missing data — so the pill says so rather
+            // than disappearing. A fully lapsed exercise keeps its "time since" pill (lapsedSince).
+            percentChange: countBaseline > 0 && !isLapsed
                 ? (Double(thisWeekCount) - Double(countBaseline)) / Double(countBaseline) * 100
                 : nil,
             isRecord: isRecordWeek(count: thisWeekCount, in: weeklySets),

--- a/LOGIT/Features/Exercise/ExerciseDetail/Tiles/ExerciseVolumeTile.swift
+++ b/LOGIT/Features/Exercise/ExerciseDetail/Tiles/ExerciseVolumeTile.swift
@@ -46,7 +46,10 @@ struct ExerciseVolumeTile: View {
                 : formatWeightForDisplay(isLapsed ? weeklyVolumes.map(\.volume).max() ?? 0 : thisWeekVolume),
             unit: WeightUnit.used.rawValue,
             color: exercise.muscleGroup?.color ?? .accentColor,
-            percentChange: thisWeekVolume > 0 && volumeBaseline > 0
+            // This week against the baseline. With a real baseline but nothing logged this week yet,
+            // that's a genuine "down 100%" — zero work, not missing data — so the pill says so rather
+            // than disappearing. A fully lapsed exercise keeps its "time since" pill (lapsedSince).
+            percentChange: volumeBaseline > 0 && !isLapsed
                 ? (Double(thisWeekVolume) - Double(volumeBaseline)) / Double(volumeBaseline) * 100
                 : nil,
             isRecord: isRecordWeek(volume: thisWeekVolume, in: weeklyVolumes),

--- a/LOGIT/Features/Home/OverallSetsScreen.swift
+++ b/LOGIT/Features/Home/OverallSetsScreen.swift
@@ -37,21 +37,31 @@ struct OverallSetsScreen: View {
                         chartScrollPosition = initialScrollPosition
                     }
 
-                    VStack(alignment: .leading) {
-                        Text(NSLocalizedString("total", comment: ""))
-                            .font(.footnote)
-                            .fontWeight(.semibold)
-                            .textCase(.uppercase)
-                            .foregroundStyle(.secondary)
-                        UnitView(
-                            value: "\(totalSetsInTimeFrame(workouts))",
-                            unit: NSLocalizedString("sets", comment: "")
-                        )
-                        .foregroundStyle(.tint)
-                        Text(visibleDomainDescription)
-                            .fontWeight(.bold)
-                            .fontDesign(.rounded)
-                            .foregroundStyle(.secondary)
+                    HStack {
+                        VStack(alignment: .leading) {
+                            Text(NSLocalizedString("total", comment: ""))
+                                .font(.footnote)
+                                .fontWeight(.semibold)
+                                .textCase(.uppercase)
+                                .foregroundStyle(.secondary)
+                            UnitView(
+                                value: "\(totalSetsInTimeFrame(workouts))",
+                                unit: NSLocalizedString("sets", comment: "")
+                            )
+                            .foregroundStyle(.tint)
+                            Text(visibleDomainDescription)
+                                .fontWeight(.bold)
+                                .fontDesign(.rounded)
+                                .foregroundStyle(.secondary)
+                        }
+                        Spacer()
+                        if let trend = trendPercentage() {
+                            TrendIndicatorView(
+                                percentChange: trend,
+                                positiveColor: .accentColor
+                            )
+                            .animation(.snappy, value: trend)
+                        }
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
 
@@ -205,6 +215,20 @@ struct OverallSetsScreen: View {
             return d >= chartScrollPosition && d <= endDate
         }
         return sets.count
+    }
+
+    /// Percent change of the visible window's set count over the equal window before it — the header
+    /// trend pill, mirroring the other stat screens.
+    private func trendPercentage() -> Double? {
+        let sets = workouts.flatMap { $0.sets }
+        return exerciseWindowTrendPercentage(
+            sets: sets,
+            windowStart: chartScrollPosition,
+            windowSeconds: visibleChartDomainInSeconds
+        ) { start, end in
+            let count = sets.filter { ($0.workout?.date).map { $0 >= start && $0 <= end } ?? false }.count
+            return count == 0 ? nil : Double(count)
+        }
     }
 
     private var scrollAlignmentComponents: DateComponents {

--- a/LOGIT/Features/Home/VolumeScreen.swift
+++ b/LOGIT/Features/Home/VolumeScreen.swift
@@ -35,21 +35,31 @@ struct VolumeScreen: View {
                     .pickerStyle(.segmented)
                     .padding(.bottom)
                     .padding(.horizontal)
-                    VStack(alignment: .leading) {
-                        Text(NSLocalizedString("total", comment: ""))
-                            .font(.footnote)
-                            .fontWeight(.semibold)
-                            .textCase(.uppercase)
-                            .foregroundStyle(.secondary)
-                        UnitView(
-                            value: totalVolumeInTimeFrame(workoutSets),
-                            unit: WeightUnit.used.rawValue
-                        )
-                        .foregroundStyle((selectedMuscleGroup?.color ?? Color.accentColor).gradient)
-                        Text("\(visibleDomainDescription)")
-                            .fontWeight(.bold)
-                            .fontDesign(.rounded)
-                            .foregroundStyle(.secondary)
+                    HStack {
+                        VStack(alignment: .leading) {
+                            Text(NSLocalizedString("total", comment: ""))
+                                .font(.footnote)
+                                .fontWeight(.semibold)
+                                .textCase(.uppercase)
+                                .foregroundStyle(.secondary)
+                            UnitView(
+                                value: totalVolumeInTimeFrame(workoutSets),
+                                unit: WeightUnit.used.rawValue
+                            )
+                            .foregroundStyle((selectedMuscleGroup?.color ?? Color.accentColor).gradient)
+                            Text("\(visibleDomainDescription)")
+                                .fontWeight(.bold)
+                                .fontDesign(.rounded)
+                                .foregroundStyle(.secondary)
+                        }
+                        Spacer()
+                        if let trend = trendPercentage() {
+                            TrendIndicatorView(
+                                percentChange: trend,
+                                positiveColor: selectedMuscleGroup?.color ?? .accentColor
+                            )
+                            .animation(.snappy, value: trend)
+                        }
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(.horizontal)
@@ -220,6 +230,20 @@ struct VolumeScreen: View {
             return "\(chartScrollPosition.isInCurrentYear ? chartScrollPosition.formatted(.dateTime.day().month()) : chartScrollPosition.formatted(.dateTime.day().month().year())) - \(endDate.isInCurrentYear ? endDate.formatted(.dateTime.day().month()) : endDate.formatted(.dateTime.day().month().year()))"
         case .year:
             return "\(chartScrollPosition.formatted(.dateTime.month().year())) - \(endDate.formatted(.dateTime.month().year()))"
+        }
+    }
+
+    /// Percent change of the visible window's total volume over the equal window before it — the
+    /// header trend pill, mirroring the exercise volume screen. Respects the selected muscle group,
+    /// so the pill tracks whatever the header value above it is showing.
+    private func trendPercentage() -> Double? {
+        exerciseWindowTrendPercentage(
+            sets: workoutSets,
+            windowStart: chartScrollPosition,
+            windowSeconds: visibleChartDomainInSeconds
+        ) { start, end in
+            let inRange = workoutSets.filter { ($0.workout?.date).map { $0 >= start && $0 <= end } ?? false }
+            return inRange.isEmpty ? nil : volume(for: inRange, muscleGroup: selectedMuscleGroup)
         }
     }
 

--- a/LOGIT/Features/Workout/WorkoutStatScreen.swift
+++ b/LOGIT/Features/Workout/WorkoutStatScreen.swift
@@ -10,12 +10,17 @@ import SwiftUI
 
 /// Detail screen behind a workout stat tile: the stat across *every* workout over time — the tile
 /// zooms into this workout's recent runs, the screen zooms out to the whole landscape. One bar per
-/// workout in the month view, each colored by its workout's most-trained muscle group (the colors
-/// draw the push/pull/legs rhythm); the year view averages each month into one bar. The header
-/// shows the average per workout over the visible period with a trend against the period before,
-/// matching the exercise chart screens' anatomy (picker, header, scrollable chart with
-/// tap-to-inspect, highlights, about). One screen serves all four stats — `WorkoutStatMetric`
-/// supplies values, formatting, and texts.
+/// workout in the month view (the year view averages each month into one bar); the bar for the
+/// workout the screen was opened from wears the workout's muscle-group gradient (its identity
+/// color), a tapped bar lights up white, every other stays a quiet gray. The header is a two-value
+/// scoreboard like the in-workout metric popover: the average per workout across the *shown* time
+/// frame (the reference — neutral, and it moves as you scroll) on one side, this workout's own value
+/// (the bold white constant) on the other, and a pill between them reading this workout against that
+/// average. Scroll the chart and the average + pill retarget while this workout stays the anchor —
+/// we're in its detail, after all. The muscle color lives on the accents: the current chart bar, the
+/// highlights' current bar, and the pill. Otherwise the exercise chart screens' anatomy (picker,
+/// header, scrollable chart with tap-to-inspect, highlights, about). One screen serves all four
+/// stats — `WorkoutStatMetric` supplies values, formatting, and texts.
 struct WorkoutStatScreen: View {
     private enum ChartGranularity {
         case month, year
@@ -30,7 +35,9 @@ struct WorkoutStatScreen: View {
         let rawValue: Double
         /// Display units for the chart's y-axis.
         let value: Double
-        let color: Color
+        /// The bar for the workout the screen was opened from — drawn with the workout's muscle-group
+        /// gradient; every other bar stays a quiet gray (a tapped bar lights up white).
+        let isCurrent: Bool
         /// The single workout behind this bar — nil for a year-granularity month bar.
         let workout: Workout?
         let workoutCount: Int
@@ -69,8 +76,9 @@ struct WorkoutStatScreen: View {
     private func screen(workouts: [Workout]) -> some View {
         let points = statPoints(in: workouts)
         let snappedPoint = selectedDate != nil ? nearestPoint(to: selectedDate, in: points) : nil
+        // The average per workout across the visible window — recomputed as the chart scrolls, so the
+        // header's reference value and its pill always describe the period currently on screen.
         let visibleAverage = averageRaw(in: workouts, from: chartScrollPosition, to: visibleEndDate)
-        let visibleTrendPercentage = trendPercentage(in: workouts)
         return ScrollView {
             VStack(spacing: SECTION_SPACING) {
                 VStack {
@@ -83,7 +91,7 @@ struct WorkoutStatScreen: View {
                     .pickerStyle(.segmented)
                     .padding(.vertical)
                     .padding(.horizontal)
-                    header(visibleAverage: visibleAverage, trendPercentage: visibleTrendPercentage)
+                    header(visibleAverage: visibleAverage)
                     chart(points: points, snappedPoint: snappedPoint)
                 }
 
@@ -136,28 +144,68 @@ struct WorkoutStatScreen: View {
 
     // MARK: - Header
 
-    private func header(visibleAverage: Double?, trendPercentage: Double?) -> some View {
-        HStack {
-            VStack(alignment: .leading) {
-                AverageLabel()
+    /// A scoreboard like the in-workout metric popover: the average across the shown period (the
+    /// reference, neutral, moving with the scroll) on the left, this workout's own value (the bold
+    /// white constant) on the right, the pill between them reading this workout against that average.
+    /// We're in the workout detail, so this workout is always the subject — scrolling retargets the
+    /// average and the pill, never the side they're compared to.
+    private func header(visibleAverage: Double?) -> some View {
+        // This workout's own value for the metric — "––" when it has none (e.g. duration with no end).
+        let raw = metric.rawValue(of: workout)
+        // This workout vs the visible period's average — positive when this session beat it. Duration
+        // stays neutral gray (longer is neither better nor worse), matching its tile.
+        let percentChange: Double? = {
+            guard let average = visibleAverage, average > 0, raw > 0 else { return nil }
+            return (Double(raw) - average) / average * 100
+        }()
+        return HStack(alignment: .center, spacing: 12) {
+            VStack(alignment: .leading, spacing: 1) {
+                Text(NSLocalizedString("average", comment: ""))
+                    .font(.footnote)
+                    .fontWeight(.semibold)
+                    .textCase(.uppercase)
+                    .foregroundStyle(.secondary)
                 UnitView(
                     value: visibleAverage.map { metric.formattedAverage(rawAverage: $0) } ?? "––",
-                    unit: metric.unit
+                    unit: metric.unit,
+                    unitColor: .secondaryLabel
                 )
-                .muscleGroupGradientStyle(for: workout.muscleGroups)
-                Text(chartHeaderTitle)
+                .foregroundStyle(.secondary)
+                Text(visibleDomainDescription)
+                    .font(.caption)
                     .fontWeight(.bold)
-                    .foregroundStyle(.secondary)
+                    .fontDesign(.rounded)
+                    .foregroundStyle(.tertiary)
             }
-            Spacer()
-            if let trendPercentage {
+            Spacer(minLength: 0)
+            if let percentChange {
                 TrendIndicatorView(
-                    percentChange: trendPercentage,
-                    // A longer workout is neither better nor worse — duration's pill stays
-                    // neutral gray in both directions, like its tile.
-                    positiveColor: metric == .duration ? .secondary : dominantMuscleGroupColor
+                    percentChange: percentChange,
+                    positiveColor: metric == .duration ? .secondary : dominantMuscleGroupColor,
+                    positiveStyle: metric == .duration ? nil : workout.muscleGroups.gradientStyle()
                 )
-                .animation(.snappy, value: trendPercentage)
+                .animation(.snappy, value: percentChange)
+            }
+            Spacer(minLength: 0)
+            VStack(alignment: .trailing, spacing: 1) {
+                Text(NSLocalizedString("thisWorkout", comment: ""))
+                    .font(.footnote)
+                    .fontWeight(.semibold)
+                    .textCase(.uppercase)
+                    .foregroundStyle(.secondary)
+                UnitView(
+                    value: raw > 0 ? metric.formattedValue(fromRaw: raw) : "––",
+                    unit: metric.unit,
+                    unitColor: .secondaryLabel
+                )
+                .foregroundStyle(Color.label)
+                if let date = workout.date {
+                    Text(date.formatted(.dateTime.day().month()))
+                        .font(.caption)
+                        .fontWeight(.bold)
+                        .fontDesign(.rounded)
+                        .foregroundStyle(.tertiary)
+                }
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -171,7 +219,7 @@ struct WorkoutStatScreen: View {
         return Chart {
             if let snappedPoint {
                 RuleMark(x: .value("Selected", snappedPoint.date, unit: barUnit))
-                    .foregroundStyle(snappedPoint.color.opacity(0.35))
+                    .foregroundStyle(Color.label.opacity(0.35))
                     .lineStyle(StrokeStyle(lineWidth: 2))
                     .annotation(
                         position: .top,
@@ -186,7 +234,7 @@ struct WorkoutStatScreen: View {
                     y: .value("Value", point.value),
                     width: .ratio(chartGranularity == .month ? 0.6 : 0.5)
                 )
-                .foregroundStyle(point.color.gradient)
+                .foregroundStyle(barStyle(for: point, snappedPoint: snappedPoint))
                 .clipShape(RoundedRectangle(cornerRadius: 3, style: .continuous))
                 .opacity(snappedPoint == nil || snappedPoint?.id == point.id ? 1.0 : 0.4)
             }
@@ -231,8 +279,8 @@ struct WorkoutStatScreen: View {
 
     private func annotationCard(for point: StatPoint) -> some View {
         VStack(alignment: .leading) {
-            UnitView(value: annotationValue(for: point), unit: metric.unit)
-                .foregroundStyle(point.color.gradient)
+            UnitView(value: annotationValue(for: point), unit: metric.unit, unitColor: .secondaryLabel)
+                .foregroundStyle(Color.label)
             Text(annotationSubtitle(for: point))
                 .fontWeight(.bold)
                 .fontDesign(.rounded)
@@ -274,7 +322,7 @@ struct WorkoutStatScreen: View {
                     date: workout.date ?? .now,
                     rawValue: Double(raw),
                     value: metric.displayValue(fromRaw: raw),
-                    color: dominantMuscleGroupColor(of: workout),
+                    isCurrent: workout.objectID == self.workout.objectID,
                     workout: workout,
                     workoutCount: 1
                 )
@@ -290,8 +338,7 @@ struct WorkoutStatScreen: View {
                         date: month,
                         rawValue: rawAverage,
                         value: metric.displayValue(fromRaw: Int(rawAverage.rounded())),
-                        color: muscleGroupService.getMuscleGroupOccurances(in: monthWorkouts).first?.0.color
-                            ?? .accentColor,
+                        isCurrent: workout.date?.startOfMonth == month,
                         workout: nil,
                         workoutCount: monthWorkouts.count
                     )
@@ -319,24 +366,6 @@ struct WorkoutStatScreen: View {
         return Double(values.reduce(0, +)) / Double(values.count)
     }
 
-    /// Percent change of the visible window's average over the equal-length window before it —
-    /// the same window-vs-window comparison as the exercise chart screens' pill, on averages
-    /// because sessions are discrete amounts (a single best would just crown the biggest day).
-    private func trendPercentage(in workouts: [Workout]) -> Double? {
-        let windowStart = chartScrollPosition
-        let previousStart = Calendar.current.date(
-            byAdding: .second,
-            value: -visibleChartDomainInSeconds,
-            to: windowStart
-        )!
-        guard
-            let current = averageRaw(in: workouts, from: windowStart, to: visibleEndDate),
-            let previous = averageRaw(in: workouts, from: previousStart, to: windowStart),
-            previous > 0
-        else { return nil }
-        return (current - previous) / previous * 100
-    }
-
     // MARK: - Highlights
 
     @ViewBuilder
@@ -357,7 +386,8 @@ struct WorkoutStatScreen: View {
             currentNumericValue: currentAverage,
             previousNumericValue: previousAverage,
             granularity: granularity,
-            accentColor: dominantMuscleGroupColor
+            accentColor: dominantMuscleGroupColor,
+            accentGradient: workout.muscleGroups.gradient()
         )
         .padding(.horizontal)
     }
@@ -372,6 +402,18 @@ struct WorkoutStatScreen: View {
         Calendar.current.date(byAdding: .second, value: visibleChartDomainInSeconds, to: chartScrollPosition)!
     }
 
+    /// The shown period as a date range ("25 May - 29 Jun") — the time frame the header's average is
+    /// taken over, captioned beneath it; moves with the scroll.
+    private var visibleDomainDescription: String {
+        let endDate = visibleEndDate
+        switch chartGranularity {
+        case .month:
+            return "\(chartScrollPosition.isInCurrentYear ? chartScrollPosition.formatted(.dateTime.day().month()) : chartScrollPosition.formatted(.dateTime.day().month().year())) - \(endDate.isInCurrentYear ? endDate.formatted(.dateTime.day().month()) : endDate.formatted(.dateTime.day().month().year()))"
+        case .year:
+            return "\(chartScrollPosition.formatted(.dateTime.month().year())) - \(endDate.formatted(.dateTime.month().year()))"
+        }
+    }
+
     private func xDomain(for points: [StatPoint]) -> some ScaleDomain {
         let maxStartDate = Calendar.current.date(
             byAdding: chartGranularity == .month ? .month : .year,
@@ -383,16 +425,6 @@ struct WorkoutStatScreen: View {
         else { return maxStartDate ... endDate }
         let startDate = chartGranularity == .month ? firstDate.startOfMonth : firstDate.startOfYear
         return startDate ... endDate
-    }
-
-    private var chartHeaderTitle: String {
-        let endDate = visibleEndDate
-        switch chartGranularity {
-        case .month:
-            return "\(chartScrollPosition.isInCurrentYear ? chartScrollPosition.formatted(.dateTime.day().month()) : chartScrollPosition.formatted(.dateTime.day().month().year())) - \(endDate.isInCurrentYear ? endDate.formatted(.dateTime.day().month()) : endDate.formatted(.dateTime.day().month().year()))"
-        case .year:
-            return "\(chartScrollPosition.formatted(.dateTime.month().year())) - \(endDate.formatted(.dateTime.month().year()))"
-        }
     }
 
     private func xAxisDateString(for date: Date) -> String {
@@ -437,45 +469,22 @@ struct WorkoutStatScreen: View {
 
     // MARK: - Colors
 
+    /// The bar for the workout the screen was opened from wears the workout's own muscle-group
+    /// gradient — its identity color, the screen's accent. A bar tapped to inspect lights up white
+    /// ("now showing this"); every other bar stays a quiet gray. `isCurrent` wins when the current
+    /// bar is itself the tapped one — its gradient already stands out.
+    private func barStyle(for point: StatPoint, snappedPoint: StatPoint?) -> AnyShapeStyle {
+        if point.isCurrent { return workout.muscleGroups.gradientStyle(startPoint: .bottom, endPoint: .top) }
+        if snappedPoint?.id == point.id { return AnyShapeStyle(Color.label) }
+        return AnyShapeStyle(Color.fill)
+    }
+
     private func dominantMuscleGroupColor(of workout: Workout) -> Color {
         muscleGroupService.getMuscleGroupOccurances(in: workout).first?.0.color ?? .accentColor
     }
 
     private var dominantMuscleGroupColor: Color {
         dominantMuscleGroupColor(of: workout)
-    }
-}
-
-// MARK: - Average Label
-
-/// The "Average" header label on the stat screens — `CurrentBestLabel`'s anatomy with the stat
-/// vocabulary: explains that the value is the mean per workout over the visible period and what
-/// the trend pill compares it against.
-private struct AverageLabel: View {
-    @State private var isShowingInfo = false
-
-    var body: some View {
-        HStack(spacing: 4) {
-            Text(NSLocalizedString("average", comment: ""))
-                .fontWeight(.medium)
-                .textCase(.uppercase)
-            Button {
-                isShowingInfo = true
-            } label: {
-                Image(systemName: "info.circle")
-            }
-            .popover(isPresented: $isShowingInfo) {
-                Text(NSLocalizedString("workoutStatAverageInfo", comment: ""))
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
-                    .padding()
-                    .frame(width: 300)
-                    .presentationCompactAdaptation(.popover)
-            }
-        }
-        .font(.footnote)
-        .foregroundStyle(.secondary)
     }
 }
 

--- a/LOGIT/SharedUI/Styles/MuscleGroupGradientStyle.swift
+++ b/LOGIT/SharedUI/Styles/MuscleGroupGradientStyle.swift
@@ -29,16 +29,24 @@ extension View {
 }
 
 extension Sequence where Element == MuscleGroup {
+    /// The muscle-group gradient as a concrete `LinearGradient` value — the muscle colors in order,
+    /// falling back to the accent color when there are none. For call sites that need a real
+    /// `LinearGradient` rather than a type-erased style (e.g. `ComparisonBar`'s workout-themed fill);
+    /// `gradientStyle()` wraps this for `ShapeStyle` call sites.
+    func gradient(startPoint: UnitPoint = .leading, endPoint: UnitPoint = .trailing) -> LinearGradient {
+        let colors = map(\.color)
+        return LinearGradient(
+            colors: colors.isEmpty ? [.accentColor] : colors,
+            startPoint: startPoint,
+            endPoint: endPoint
+        )
+    }
+
     /// The muscle-group gradient as a `ShapeStyle` value — the value-typed counterpart to the
     /// `muscleGroupGradientStyle` foreground modifier — for tinting a `ProgressIndicatorPill`: the
     /// muscle colors left to right, falling back to the accent color when there are none. A single
     /// `Color` can't carry a multi-muscle workout's gradient, so the pills take an `AnyShapeStyle`.
     func gradientStyle(startPoint: UnitPoint = .leading, endPoint: UnitPoint = .trailing) -> AnyShapeStyle {
-        let colors = map(\.color)
-        return AnyShapeStyle(.linearGradient(
-            colors: colors.isEmpty ? [.accentColor] : colors,
-            startPoint: startPoint,
-            endPoint: endPoint
-        ))
+        AnyShapeStyle(gradient(startPoint: startPoint, endPoint: endPoint))
     }
 }

--- a/LOGIT/SharedUI/Views/HighlightView.swift
+++ b/LOGIT/SharedUI/Views/HighlightView.swift
@@ -28,6 +28,9 @@ struct HighlightView: View {
     let previousNumericValue: Double
     /// Accent color for the current period bar (defaults to .accentColor)
     var accentColor: Color = .accentColor
+    /// Optional gradient for the current period bar, overriding `accentColor` — used where the bar
+    /// stands for a whole workout (its muscle-group gradient) rather than a single metric.
+    var accentGradient: LinearGradient? = nil
 
     private var maxBar: Double {
         max(max(currentNumericValue, previousNumericValue), 1.0)
@@ -60,7 +63,7 @@ struct HighlightView: View {
                     // Current period
                     VStack(alignment: .leading, spacing: 6) {
                         UnitView(value: currentValue, unit: unit, configuration: .large, unitColor: Color.secondaryLabel)
-                        ComparisonBar(value: currentNumericValue, maxValue: maxBar, tint: accentColor, label: currentLabel)
+                        ComparisonBar(value: currentNumericValue, maxValue: maxBar, tint: accentColor, label: currentLabel, gradient: accentGradient)
                             .frame(height: 30)
                             .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
                     }
@@ -85,7 +88,7 @@ struct HighlightView: View {
                 VStack(alignment: .leading, spacing: 14) {
                     VStack(alignment: .leading, spacing: 6) {
                         UnitView(value: value, unit: unit, configuration: .large, unitColor: Color.secondaryLabel)
-                        ComparisonBar(value: numericValue, maxValue: numericValue, tint: accentColor, label: label)
+                        ComparisonBar(value: numericValue, maxValue: numericValue, tint: accentColor, label: label, gradient: hasCurrentData ? accentGradient : nil)
                             .frame(height: 30)
                             .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
                     }
@@ -173,7 +176,8 @@ extension HighlightView {
         currentNumericValue: Double,
         previousNumericValue: Double,
         granularity: Granularity,
-        accentColor: Color = .accentColor
+        accentColor: Color = .accentColor,
+        accentGradient: LinearGradient? = nil
     ) {
         self.headline = headline
         self.currentValue = currentValue
@@ -184,6 +188,7 @@ extension HighlightView {
         self.currentNumericValue = currentNumericValue
         self.previousNumericValue = previousNumericValue
         self.accentColor = accentColor
+        self.accentGradient = accentGradient
     }
 }
 


### PR DESCRIPTION
## Summary
Redesigns the workout stat detail screen header and refines the trend pills across the chart detail screens.

### WorkoutStatScreen header → two-value scoreboard
The header now mirrors the in-workout metric popover: **this workout's** own value beside the **average across the shown time frame**, with a pill comparing this workout to that average. Scrolling the chart retargets the average and the pill while this workout stays the anchor. The current chart bar and the highlights' current-period bar wear the workout's muscle gradient; the header values stay white/gray, so the gradient lives on the accents.

### Trend pills on the home stat screens
Adds the top-right trend pill to **Volume** and **Overall Sets**, computed via the shared `exerciseWindowTrendPercentage` helper.

### "Empty window = down 100%" for cumulative metrics
`exerciseWindowTrendPercentage` gains `emptyCurrentMeansDecline`: a cumulative metric (volume, sets) with a baseline but nothing logged this period now reads as **down 100%** instead of hiding the pill. Applied to the volume/sets tiles and their exercise detail screens.

### Plumbing
Adds `MuscleGroup.gradient()` (a concrete `LinearGradient`) and routes `HighlightView`'s current-period bar through it via `accentGradient`.

## Testing
- `xcodebuild build` succeeds with zero warnings (iPhone 17 Pro simulator).
- Verified the new scoreboard header, the gradient current bar, and the home-screen pills via simulator screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
