### PR TITLE
Drop the leading minus icon from the "0 improved" pill

### DIFF
--- a/LOGIT/Features/Workout/WorkoutDetailScreen.swift
+++ b/LOGIT/Features/Workout/WorkoutDetailScreen.swift
@@ -243,7 +243,7 @@ struct WorkoutDetailScreen: View {
         let style = improved > 0
             ? workout.muscleGroups.gradientStyle()
             : AnyShapeStyle(Color.secondary)
-        return ProgressIndicatorPill(symbol: improved > 0 ? "chevron.up" : "minus", style: style) {
+        return ProgressIndicatorPill(symbol: improved > 0 ? "chevron.up" : nil, style: style) {
             Text(String(format: NSLocalizedString("improvedCount", comment: ""), improved))
                 .font(.system(.footnote, design: .rounded, weight: .bold))
                 .monospacedDigit()


### PR DESCRIPTION
## Summary
The exercises-improved pill (beside the **Exercises** section title on the workout detail screen) showed a `minus` SF Symbol whenever no exercises improved, rendering as a stray `-` in front of `0 improved`. This passes `nil` for the symbol in that case so the pill displays just the count with no leading icon. When at least one exercise improved, the `chevron.up` icon and muscle-group gradient are unchanged.

## Change
- `WorkoutDetailScreen.exercisesImprovedPill`: `symbol: improved > 0 ? "chevron.up" : "minus"` → `symbol: improved > 0 ? "chevron.up" : nil`

`ProgressIndicatorPill.symbol` is already `String?` and renders no `Image` when nil, so no component change was needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)