### PR TITLE
Remove the highlights section from all chart detail screens

### DIFF
--- a/LOGIT/Features/Exercise/ExerciseDetail/ExerciseE1RMScreen.swift
+++ b/LOGIT/Features/Exercise/ExerciseDetail/ExerciseE1RMScreen.swift
@@ -213,9 +213,6 @@ struct ExerciseE1RMScreen: View {
                     .padding(.trailing, 5)
                 }
 
-                // MARK: - Highlights Section
-                highlightsSection(allDailyMaxSets: allDailyMaxSets)
-
                 // MARK: - About Section
                 AboutSection(
                     metricTitle: NSLocalizedString("estimatedOneRepMax", comment: ""),
@@ -393,59 +390,6 @@ struct ExerciseE1RMScreen: View {
         }
     }
 
-    // MARK: - Highlights
-
-    @ViewBuilder
-    private func highlightsSection(allDailyMaxSets: [WorkoutSet]) -> some View {
-        let ranges = periodRanges()
-        let currentMax = maxE1RM(in: ranges.current, sets: allDailyMaxSets)
-        let previousMax = maxE1RM(in: ranges.previous, sets: allDailyMaxSets)
-        let headlineKey = e1RMHeadlineKey(isHigher: currentMax >= previousMax)
-        let unit = WeightUnit.used.rawValue
-
-        HighlightView(
-            headline: NSLocalizedString(headlineKey, comment: ""),
-            currentValue: currentMax > 0 ? formatEstimatedOneRepMax(currentMax) : "––",
-            previousValue: previousMax > 0 ? formatEstimatedOneRepMax(previousMax) : "––",
-            unit: unit,
-            currentNumericValue: Double(convertWeightForDisplaying(currentMax)),
-            previousNumericValue: Double(convertWeightForDisplaying(previousMax)),
-            granularity: chartGranularity == .month ? .month : .year,
-            accentColor: exerciseMuscleGroupColor
-        )
-        .padding(.horizontal)
-    }
-
-    private func periodRanges() -> (current: (start: Date, end: Date), previous: (start: Date, end: Date)) {
-        switch chartGranularity {
-        case .month:
-            let current = (Date.now.startOfMonth, Date.now.endOfMonth)
-            let lastStart = Calendar.current.date(byAdding: .month, value: -1, to: .now.startOfMonth)!
-            let previous = (lastStart, lastStart.endOfMonth)
-            return (current, previous)
-        case .year:
-            let current = (Date.now.startOfYear, Date.now.endOfYear)
-            let lastStart = Calendar.current.date(byAdding: .year, value: -1, to: .now.startOfYear)!
-            let previous = (lastStart, lastStart.endOfYear)
-            return (current, previous)
-        }
-    }
-
-    private func maxE1RM(in range: (start: Date, end: Date), sets: [WorkoutSet]) -> Int {
-        let s = range.start, e = range.end
-        let setsInRange = sets.filter {
-            guard let d = $0.workout?.date else { return false }
-            return d >= s && d <= e
-        }
-        return setsInRange.map { $0.estimatedOneRepMax(for: exercise) }.max() ?? 0
-    }
-
-    private func e1RMHeadlineKey(isHigher: Bool) -> String {
-        switch chartGranularity {
-        case .month: return isHigher ? "higherMaxE1RMThisMonthThanLastMonth" : "lowerMaxE1RMThisMonthThanLastMonth"
-        case .year: return isHigher ? "higherMaxE1RMThisYearThanLastYear" : "lowerMaxE1RMThisYearThanLastYear"
-        }
-    }
 }
 
 private struct PreviewWrapperView: View {

--- a/LOGIT/Features/Exercise/ExerciseDetail/ExerciseRepetitionsScreen.swift
+++ b/LOGIT/Features/Exercise/ExerciseDetail/ExerciseRepetitionsScreen.swift
@@ -213,9 +213,6 @@ struct ExerciseRepetitionsScreen: View {
                 .padding(.trailing, 5)
                 }
                 
-                // MARK: - Highlights Section
-                highlightsSection(allDailyMaxRepsSets: allDailyMaxRepsSets)
-
                 // MARK: - About Section
                 AboutSection(
                     metricTitle: NSLocalizedString("repetitions", comment: ""),
@@ -398,59 +395,6 @@ struct ExerciseRepetitionsScreen: View {
         }
     }
 
-    // MARK: - Highlights
-
-    @ViewBuilder
-    private func highlightsSection(allDailyMaxRepsSets: [WorkoutSet]) -> some View {
-        let ranges = periodRanges()
-        let currentMax = maxReps(in: ranges.current, sets: allDailyMaxRepsSets)
-        let previousMax = maxReps(in: ranges.previous, sets: allDailyMaxRepsSets)
-        let headlineKey = repsHeadlineKey(isHigher: currentMax >= previousMax)
-        let unit = NSLocalizedString("rps", comment: "")
-
-        HighlightView(
-            headline: NSLocalizedString(headlineKey, comment: ""),
-            currentValue: currentMax > 0 ? String(currentMax) : "––",
-            previousValue: previousMax > 0 ? String(previousMax) : "––",
-            unit: unit,
-            currentNumericValue: Double(currentMax),
-            previousNumericValue: Double(previousMax),
-            granularity: chartGranularity == .month ? .month : .year,
-            accentColor: exerciseMuscleGroupColor
-        )
-        .padding(.horizontal)
-    }
-
-    private func periodRanges() -> (current: (start: Date, end: Date), previous: (start: Date, end: Date)) {
-        switch chartGranularity {
-        case .month:
-            let current = (Date.now.startOfMonth, Date.now.endOfMonth)
-            let lastStart = Calendar.current.date(byAdding: .month, value: -1, to: .now.startOfMonth)!
-            let previous = (lastStart, lastStart.endOfMonth)
-            return (current, previous)
-        case .year:
-            let current = (Date.now.startOfYear, Date.now.endOfYear)
-            let lastStart = Calendar.current.date(byAdding: .year, value: -1, to: .now.startOfYear)!
-            let previous = (lastStart, lastStart.endOfYear)
-            return (current, previous)
-        }
-    }
-
-    private func maxReps(in range: (start: Date, end: Date), sets: [WorkoutSet]) -> Int {
-        let s = range.start, e = range.end
-        let setsInRange = sets.filter {
-            guard let d = $0.workout?.date else { return false }
-            return d >= s && d <= e
-        }
-        return setsInRange.map { $0.maximum(.repetitions, for: exercise) }.max() ?? 0
-    }
-
-    private func repsHeadlineKey(isHigher: Bool) -> String {
-        switch chartGranularity {
-        case .month: return isHigher ? "higherMaxRepsThisMonthThanLastMonth" : "lowerMaxRepsThisMonthThanLastMonth"
-        case .year: return isHigher ? "higherMaxRepsThisYearThanLastYear" : "lowerMaxRepsThisYearThanLastYear"
-        }
-    }
 }
 
 private struct PreviewWrapperView: View {

--- a/LOGIT/Features/Exercise/ExerciseDetail/ExerciseSetVolumeScreen.swift
+++ b/LOGIT/Features/Exercise/ExerciseDetail/ExerciseSetVolumeScreen.swift
@@ -210,9 +210,6 @@ struct ExerciseSetVolumeScreen: View {
                     .padding(.trailing, 5)
                 }
 
-                // MARK: - Highlights Section
-                highlightsSection(allDailyMaxSets: allDailyMaxSets)
-
                 // MARK: - About Section
                 AboutSection(
                     metricTitle: NSLocalizedString("setVolume", comment: ""),
@@ -394,59 +391,6 @@ struct ExerciseSetVolumeScreen: View {
         }
     }
 
-    // MARK: - Highlights
-
-    @ViewBuilder
-    private func highlightsSection(allDailyMaxSets: [WorkoutSet]) -> some View {
-        let ranges = periodRanges()
-        let currentMax = maxSetVolume(in: ranges.current, sets: allDailyMaxSets)
-        let previousMax = maxSetVolume(in: ranges.previous, sets: allDailyMaxSets)
-        let headlineKey = setVolumeHeadlineKey(isHigher: currentMax >= previousMax)
-        let unit = WeightUnit.used.rawValue
-
-        HighlightView(
-            headline: NSLocalizedString(headlineKey, comment: ""),
-            currentValue: currentMax > 0 ? formatWeightForDisplay(currentMax) : "––",
-            previousValue: previousMax > 0 ? formatWeightForDisplay(previousMax) : "––",
-            unit: unit,
-            currentNumericValue: Double(convertWeightForDisplaying(currentMax)),
-            previousNumericValue: Double(convertWeightForDisplaying(previousMax)),
-            granularity: chartGranularity == .month ? .month : .year,
-            accentColor: exerciseMuscleGroupColor
-        )
-        .padding(.horizontal)
-    }
-
-    private func periodRanges() -> (current: (start: Date, end: Date), previous: (start: Date, end: Date)) {
-        switch chartGranularity {
-        case .month:
-            let current = (Date.now.startOfMonth, Date.now.endOfMonth)
-            let lastStart = Calendar.current.date(byAdding: .month, value: -1, to: .now.startOfMonth)!
-            let previous = (lastStart, lastStart.endOfMonth)
-            return (current, previous)
-        case .year:
-            let current = (Date.now.startOfYear, Date.now.endOfYear)
-            let lastStart = Calendar.current.date(byAdding: .year, value: -1, to: .now.startOfYear)!
-            let previous = (lastStart, lastStart.endOfYear)
-            return (current, previous)
-        }
-    }
-
-    private func maxSetVolume(in range: (start: Date, end: Date), sets: [WorkoutSet]) -> Int {
-        let s = range.start, e = range.end
-        let setsInRange = sets.filter {
-            guard let d = $0.workout?.date else { return false }
-            return d >= s && d <= e
-        }
-        return setsInRange.map { $0.volume(for: exercise) }.max() ?? 0
-    }
-
-    private func setVolumeHeadlineKey(isHigher: Bool) -> String {
-        switch chartGranularity {
-        case .month: return isHigher ? "higherMaxSetVolumeThisMonthThanLastMonth" : "lowerMaxSetVolumeThisMonthThanLastMonth"
-        case .year: return isHigher ? "higherMaxSetVolumeThisYearThanLastYear" : "lowerMaxSetVolumeThisYearThanLastYear"
-        }
-    }
 }
 
 private struct PreviewWrapperView: View {

--- a/LOGIT/Features/Exercise/ExerciseDetail/ExerciseSetsScreen.swift
+++ b/LOGIT/Features/Exercise/ExerciseDetail/ExerciseSetsScreen.swift
@@ -10,7 +10,7 @@ import SwiftUI
 
 /// Sets-per-week over time for a single exercise — the detail screen behind the weekly Sets tile.
 /// Structurally the twin of `ExerciseVolumeScreen` (same scrollable weekly bar chart, month/year
-/// granularity, selection and highlights), but it counts working sets per week instead of summing
+/// granularity and selection), but it counts working sets per week instead of summing
 /// weight: how many sets you logged is the standard training-volume landmark, alongside tonnage.
 struct ExerciseSetsScreen: View {
     private enum ChartGranularity {
@@ -139,9 +139,6 @@ struct ExerciseSetsScreen: View {
                 .padding(.leading)
                 .padding(.trailing, 5)
                 }
-
-                // MARK: - Highlights Section
-                highlightsSection
 
                 // MARK: - About Section
                 AboutSection(
@@ -287,65 +284,6 @@ struct ExerciseSetsScreen: View {
         }
     }
 
-    // MARK: - Highlights
-
-    @ViewBuilder
-    private var highlightsSection: some View {
-        let ranges = periodRanges()
-        let currentAvg = averageSetsPerWorkout(in: ranges.current)
-        let previousAvg = averageSetsPerWorkout(in: ranges.previous)
-        let headlineKey = exerciseSetsHeadlineKey(isMore: currentAvg >= previousAvg)
-        let unit = "\(NSLocalizedString("sets", comment: ""))/\(NSLocalizedString("workout", comment: ""))"
-
-        HighlightView(
-            headline: NSLocalizedString(headlineKey, comment: ""),
-            currentValue: HighlightView.formatNumber(currentAvg),
-            previousValue: HighlightView.formatNumber(previousAvg),
-            unit: unit,
-            currentNumericValue: currentAvg,
-            previousNumericValue: previousAvg,
-            granularity: chartGranularity == .month ? .month : .year,
-            accentColor: exercise.muscleGroup?.color ?? .accentColor
-        )
-        .padding(.horizontal)
-    }
-
-    private func periodRanges() -> (current: (start: Date, end: Date), previous: (start: Date, end: Date)) {
-        switch chartGranularity {
-        case .month:
-            let current = (Date.now.startOfMonth, Date.now.endOfMonth)
-            let lastStart = Calendar.current.date(byAdding: .month, value: -1, to: .now.startOfMonth)!
-            let previous = (lastStart, lastStart.endOfMonth)
-            return (current, previous)
-        case .year:
-            let current = (Date.now.startOfYear, Date.now.endOfYear)
-            let lastStart = Calendar.current.date(byAdding: .year, value: -1, to: .now.startOfYear)!
-            let previous = (lastStart, lastStart.endOfYear)
-            return (current, previous)
-        }
-    }
-
-    private func averageSetsPerWorkout(in range: (start: Date, end: Date)) -> Double {
-        let s = range.start, e = range.end
-        let setsInRange = workoutSets.filter {
-            guard let d = $0.workout?.date else { return false }
-            return d >= s && d <= e
-        }
-        let totalSets = Double(setCount(for: setsInRange))
-        let workoutsInRange = Set(setsInRange.compactMap { $0.workout }).filter {
-            guard let d = $0.date else { return false }
-            return d >= s && d <= e
-        }
-        let workoutCount = max(workoutsInRange.count, 1)
-        return totalSets / Double(workoutCount)
-    }
-
-    private func exerciseSetsHeadlineKey(isMore: Bool) -> String {
-        switch chartGranularity {
-        case .month: return isMore ? "avgMoreExerciseSetsThisMonthThanLastMonth" : "avgLessExerciseSetsThisMonthThanLastMonth"
-        case .year: return isMore ? "avgMoreExerciseSetsThisYearThanLastYear" : "avgLessExerciseSetsThisYearThanLastYear"
-        }
-    }
 }
 
 private struct PreviewWrapperView: View {

--- a/LOGIT/Features/Exercise/ExerciseDetail/ExerciseVolumeScreen.swift
+++ b/LOGIT/Features/Exercise/ExerciseDetail/ExerciseVolumeScreen.swift
@@ -143,9 +143,6 @@ struct ExerciseVolumeScreen: View {
                 .padding(.trailing, 5)
                 }
                 
-                // MARK: - Highlights Section
-                highlightsSection
-
                 // MARK: - About Section
                 AboutSection(
                     metricTitle: NSLocalizedString("volume", comment: ""),
@@ -289,65 +286,6 @@ struct ExerciseVolumeScreen: View {
         }
     }
 
-    // MARK: - Highlights
-
-    @ViewBuilder
-    private var highlightsSection: some View {
-        let ranges = periodRanges()
-        let currentAvg = averageVolumePerWorkout(in: ranges.current)
-        let previousAvg = averageVolumePerWorkout(in: ranges.previous)
-        let headlineKey = exerciseVolumeHeadlineKey(isMore: currentAvg >= previousAvg)
-        let unit = "\(WeightUnit.used.rawValue)/\(NSLocalizedString("workout", comment: ""))"
-
-        HighlightView(
-            headline: NSLocalizedString(headlineKey, comment: ""),
-            currentValue: HighlightView.formatNumber(currentAvg),
-            previousValue: HighlightView.formatNumber(previousAvg),
-            unit: unit,
-            currentNumericValue: currentAvg,
-            previousNumericValue: previousAvg,
-            granularity: chartGranularity == .month ? .month : .year,
-            accentColor: exercise.muscleGroup?.color ?? .accentColor
-        )
-        .padding(.horizontal)
-    }
-
-    private func periodRanges() -> (current: (start: Date, end: Date), previous: (start: Date, end: Date)) {
-        switch chartGranularity {
-        case .month:
-            let current = (Date.now.startOfMonth, Date.now.endOfMonth)
-            let lastStart = Calendar.current.date(byAdding: .month, value: -1, to: .now.startOfMonth)!
-            let previous = (lastStart, lastStart.endOfMonth)
-            return (current, previous)
-        case .year:
-            let current = (Date.now.startOfYear, Date.now.endOfYear)
-            let lastStart = Calendar.current.date(byAdding: .year, value: -1, to: .now.startOfYear)!
-            let previous = (lastStart, lastStart.endOfYear)
-            return (current, previous)
-        }
-    }
-
-    private func averageVolumePerWorkout(in range: (start: Date, end: Date)) -> Double {
-        let s = range.start, e = range.end
-        let setsInRange = workoutSets.filter {
-            guard let d = $0.workout?.date else { return false }
-            return d >= s && d <= e
-        }
-        let totalVolume = convertWeightForDisplayingDecimal(getVolume(of: setsInRange, for: exercise))
-        let workoutsInRange = Set(setsInRange.compactMap { $0.workout }).filter {
-            guard let d = $0.date else { return false }
-            return d >= s && d <= e
-        }
-        let workoutCount = max(workoutsInRange.count, 1)
-        return totalVolume / Double(workoutCount)
-    }
-
-    private func exerciseVolumeHeadlineKey(isMore: Bool) -> String {
-        switch chartGranularity {
-        case .month: return isMore ? "avgMoreExerciseVolumeThisMonthThanLastMonth" : "avgLessExerciseVolumeThisMonthThanLastMonth"
-        case .year: return isMore ? "avgMoreExerciseVolumeThisYearThanLastYear" : "avgLessExerciseVolumeThisYearThanLastYear"
-        }
-    }
 }
 
 private struct PreviewWrapperView: View {

--- a/LOGIT/Features/Exercise/ExerciseDetail/ExerciseWeightScreen.swift
+++ b/LOGIT/Features/Exercise/ExerciseDetail/ExerciseWeightScreen.swift
@@ -213,9 +213,6 @@ struct ExerciseWeightScreen: View {
                 .padding(.trailing, 5)
                 }
                 
-                // MARK: - Highlights Section
-                highlightsSection(allDailyMaxSets: allDailyMaxSets)
-
                 // MARK: - About Section
                 AboutSection(
                     metricTitle: NSLocalizedString("weight", comment: ""),
@@ -392,59 +389,6 @@ struct ExerciseWeightScreen: View {
         }
     }
 
-    // MARK: - Highlights
-
-    @ViewBuilder
-    private func highlightsSection(allDailyMaxSets: [WorkoutSet]) -> some View {
-        let ranges = periodRanges()
-        let currentMax = maxWeight(in: ranges.current, sets: allDailyMaxSets)
-        let previousMax = maxWeight(in: ranges.previous, sets: allDailyMaxSets)
-        let headlineKey = weightHeadlineKey(isHigher: currentMax >= previousMax)
-        let unit = WeightUnit.used.rawValue
-
-        HighlightView(
-            headline: NSLocalizedString(headlineKey, comment: ""),
-            currentValue: currentMax > 0 ? formatWeightForDisplay(currentMax) : "––",
-            previousValue: previousMax > 0 ? formatWeightForDisplay(previousMax) : "––",
-            unit: unit,
-            currentNumericValue: Double(convertWeightForDisplaying(currentMax)),
-            previousNumericValue: Double(convertWeightForDisplaying(previousMax)),
-            granularity: chartGranularity == .month ? .month : .year,
-            accentColor: exerciseMuscleGroupColor
-        )
-        .padding(.horizontal)
-    }
-
-    private func periodRanges() -> (current: (start: Date, end: Date), previous: (start: Date, end: Date)) {
-        switch chartGranularity {
-        case .month:
-            let current = (Date.now.startOfMonth, Date.now.endOfMonth)
-            let lastStart = Calendar.current.date(byAdding: .month, value: -1, to: .now.startOfMonth)!
-            let previous = (lastStart, lastStart.endOfMonth)
-            return (current, previous)
-        case .year:
-            let current = (Date.now.startOfYear, Date.now.endOfYear)
-            let lastStart = Calendar.current.date(byAdding: .year, value: -1, to: .now.startOfYear)!
-            let previous = (lastStart, lastStart.endOfYear)
-            return (current, previous)
-        }
-    }
-
-    private func maxWeight(in range: (start: Date, end: Date), sets: [WorkoutSet]) -> Int {
-        let s = range.start, e = range.end
-        let setsInRange = sets.filter {
-            guard let d = $0.workout?.date else { return false }
-            return d >= s && d <= e
-        }
-        return setsInRange.map { $0.maximum(.weight, for: exercise) }.max() ?? 0
-    }
-
-    private func weightHeadlineKey(isHigher: Bool) -> String {
-        switch chartGranularity {
-        case .month: return isHigher ? "higherMaxWeightThisMonthThanLastMonth" : "lowerMaxWeightThisMonthThanLastMonth"
-        case .year: return isHigher ? "higherMaxWeightThisYearThanLastYear" : "lowerMaxWeightThisYearThanLastYear"
-        }
-    }
 }
 
 private struct PreviewWrapperView: View {

--- a/LOGIT/Features/Home/OverallSetsScreen.swift
+++ b/LOGIT/Features/Home/OverallSetsScreen.swift
@@ -143,8 +143,6 @@ struct OverallSetsScreen: View {
                 }
                 .padding(.horizontal)
                 
-                // MARK: - Highlights Section
-                highlightsSection
             }
             .padding(.top)
             .padding(.bottom, SCROLLVIEW_BOTTOM_PADDING)
@@ -331,76 +329,6 @@ struct OverallSetsScreen: View {
         return sortedKeys.map { ($0, groupedDict[$0] ?? []) }
     }
 
-    // MARK: - Highlights (helpers kept intentionally minimal)
-
-    private var unitLabel: String { "\(NSLocalizedString("sets", comment: ""))/\(NSLocalizedString("workout", comment: ""))" }
-
-    private func periodRanges() -> (current: (start: Date, end: Date), previous: (start: Date, end: Date)) {
-        switch chartGranularity {
-        case .week:
-            let current = (Date.now.startOfWeek, Date.now.endOfWeek)
-            let lastStart = Calendar.current.date(byAdding: .weekOfYear, value: -1, to: .now.startOfWeek)!
-            let previous = (lastStart, lastStart.endOfWeek)
-            return (current, previous)
-        case .month:
-            let current = (Date.now.startOfMonth, Date.now.endOfMonth)
-            let lastStart = Calendar.current.date(byAdding: .month, value: -1, to: .now.startOfMonth)!
-            let previous = (lastStart, lastStart.endOfMonth)
-            return (current, previous)
-        case .year:
-            let current = (Date.now.startOfYear, Date.now.endOfYear)
-            let lastStart = Calendar.current.date(byAdding: .year, value: -1, to: .now.startOfYear)!
-            let previous = (lastStart, lastStart.endOfYear)
-            return (current, previous)
-        }
-    }
-
-    private func averagePerWorkout(in range: (start: Date, end: Date)) -> Double {
-        let s = range.start, e = range.end
-        let sets = workouts.flatMap { $0.sets }.reduce(into: 0) { acc, set in
-            if let d = set.workout?.date, d >= s && d <= e { acc += 1 }
-        }
-        let sessions = workouts.reduce(into: 0) { acc, w in
-            if let d = w.date, d >= s && d <= e { acc += 1 }
-        }
-        return Double(sets) / max(Double(sessions), 1)
-    }
-
-    private func headlineKey(isMore: Bool) -> String {
-        switch chartGranularity {
-        case .week: return isMore ? "avgMoreSetsPerWorkoutThisWeekThanLastWeek" : "avgFewerSetsPerWorkoutThisWeekThanLastWeek"
-        case .month: return isMore ? "avgMoreSetsPerWorkoutThisMonthThanLastMonth" : "avgFewerSetsPerWorkoutThisMonthThanLastMonth"
-        case .year: return isMore ? "avgMoreSetsPerWorkoutThisYearThanLastYear" : "avgFewerSetsPerWorkoutThisYearThanLastYear"
-        }
-    }
-
-    // MARK: - Highlights
-
-    @ViewBuilder
-    private var highlightsSection: some View {
-        let ranges = periodRanges()
-        let currentAvg = averagePerWorkout(in: ranges.current)
-        let previousAvg = averagePerWorkout(in: ranges.previous)
-        let headlineKey = headlineKey(isMore: currentAvg >= previousAvg)
-        let granularity: HighlightView.Granularity = {
-            switch chartGranularity {
-            case .week: return .week
-            case .month: return .month
-            case .year: return .year
-            }
-        }()
-
-        HighlightView(
-            headline: NSLocalizedString(headlineKey, comment: ""),
-            currentValue: HighlightView.formatNumber(currentAvg),
-            previousValue: HighlightView.formatNumber(previousAvg),
-            unit: unitLabel,
-            currentNumericValue: currentAvg,
-            previousNumericValue: previousAvg,
-            granularity: granularity
-        )
-        .padding(.horizontal)
-    }
 }
 
 // #Preview {

--- a/LOGIT/Features/Home/VolumeScreen.swift
+++ b/LOGIT/Features/Home/VolumeScreen.swift
@@ -160,8 +160,6 @@ struct VolumeScreen: View {
                 
                 MuscleGroupSelector(selectedMuscleGroup: $selectedMuscleGroup)
                 
-                // MARK: - Highlights Section
-                highlightsSection
             }
             .padding(.top)
             .padding(.bottom, SCROLLVIEW_BOTTOM_PADDING)
@@ -311,71 +309,6 @@ struct VolumeScreen: View {
         }
     }
 
-    // MARK: - Highlights
-
-    @ViewBuilder
-    private var highlightsSection: some View {
-        let ranges = periodRanges()
-        let currentAvg = averageVolumePerWorkout(in: ranges.current, muscleGroup: selectedMuscleGroup)
-        let previousAvg = averageVolumePerWorkout(in: ranges.previous, muscleGroup: selectedMuscleGroup)
-        let headlineKey = volumeHeadlineKey(isMore: currentAvg >= previousAvg)
-        let unit = "\(WeightUnit.used.rawValue)/\(NSLocalizedString("workout", comment: ""))"
-
-        HighlightView(
-            headline: NSLocalizedString(headlineKey, comment: ""),
-            currentValue: HighlightView.formatNumber(currentAvg),
-            previousValue: HighlightView.formatNumber(previousAvg),
-            unit: unit,
-            currentNumericValue: currentAvg,
-            previousNumericValue: previousAvg,
-            granularity: chartGranularity == .month ? .month : .year,
-            accentColor: selectedMuscleGroup?.color ?? .accentColor
-        )
-        .padding(.horizontal)
-    }
-
-    private func periodRanges() -> (current: (start: Date, end: Date), previous: (start: Date, end: Date)) {
-        switch chartGranularity {
-        case .month:
-            let current = (Date.now.startOfMonth, Date.now.endOfMonth)
-            let lastStart = Calendar.current.date(byAdding: .month, value: -1, to: .now.startOfMonth)!
-            let previous = (lastStart, lastStart.endOfMonth)
-            return (current, previous)
-        case .year:
-            let current = (Date.now.startOfYear, Date.now.endOfYear)
-            let lastStart = Calendar.current.date(byAdding: .year, value: -1, to: .now.startOfYear)!
-            let previous = (lastStart, lastStart.endOfYear)
-            return (current, previous)
-        }
-    }
-
-    private func averageVolumePerWorkout(in range: (start: Date, end: Date), muscleGroup: MuscleGroup? = nil) -> Double {
-        let s = range.start, e = range.end
-        let setsInRange = workoutSets.filter {
-            guard let d = $0.workout?.date else { return false }
-            return d >= s && d <= e
-        }
-        let totalVolume: Double
-        if let mg = muscleGroup {
-            totalVolume = convertWeightForDisplayingDecimal(getVolume(of: setsInRange, for: mg))
-        } else {
-            totalVolume = convertWeightForDisplayingDecimal(getVolume(of: setsInRange))
-        }
-        // Count unique workouts in range
-        let workoutsInRange = Set(setsInRange.compactMap { $0.workout }).filter {
-            guard let d = $0.date else { return false }
-            return d >= s && d <= e
-        }
-        let workoutCount = max(workoutsInRange.count, 1)
-        return totalVolume / Double(workoutCount)
-    }
-
-    private func volumeHeadlineKey(isMore: Bool) -> String {
-        switch chartGranularity {
-        case .month: return isMore ? "avgMoreVolumePerWorkoutThisMonthThanLastMonth" : "avgLessVolumePerWorkoutThisMonthThanLastMonth"
-        case .year: return isMore ? "avgMoreVolumePerWorkoutThisYearThanLastYear" : "avgLessVolumePerWorkoutThisYearThanLastYear"
-        }
-    }
 }
 
 private struct PreviewWrapperView: View {

--- a/LOGIT/Features/Measurement/MeasurementDetailScreen.swift
+++ b/LOGIT/Features/Measurement/MeasurementDetailScreen.swift
@@ -32,7 +32,6 @@ struct MeasurementDetailScreen: View {
         ScrollView {
             VStack(spacing: SECTION_SPACING) {
                 chartSection
-                highlightsSection
                 entriesListSection
             }
             .padding(.horizontal)
@@ -242,60 +241,6 @@ struct MeasurementDetailScreen: View {
             }
             .frame(height: 300)
             .padding(.trailing, 5)
-        }
-    }
-
-    // MARK: - Highlights Section
-
-    @ViewBuilder
-    private var highlightsSection: some View {
-        let ranges = periodRanges()
-        let currentAvg = averageValue(in: ranges.current)
-        let previousAvg = averageValue(in: ranges.previous)
-        let headlineKey = measurementHeadlineKey(isHigher: currentAvg >= previousAvg)
-        let unit = measurementType.unit
-
-        HighlightView(
-            headline: NSLocalizedString(headlineKey, comment: ""),
-            currentValue: currentAvg > 0 ? formatDecimal(currentAvg) : "––",
-            previousValue: previousAvg > 0 ? formatDecimal(previousAvg) : "––",
-            unit: unit,
-            currentNumericValue: currentAvg,
-            previousNumericValue: previousAvg,
-            granularity: chartGranularity == .month ? .month : .year
-        )
-    }
-
-    private func periodRanges() -> (current: (start: Date, end: Date), previous: (start: Date, end: Date)) {
-        switch chartGranularity {
-        case .month:
-            let current = (Date.now.startOfMonth, Date.now.endOfMonth)
-            let lastStart = Calendar.current.date(byAdding: .month, value: -1, to: .now.startOfMonth)!
-            let previous = (lastStart, lastStart.endOfMonth)
-            return (current, previous)
-        case .year:
-            let current = (Date.now.startOfYear, Date.now.endOfYear)
-            let lastStart = Calendar.current.date(byAdding: .year, value: -1, to: .now.startOfYear)!
-            let previous = (lastStart, lastStart.endOfYear)
-            return (current, previous)
-        }
-    }
-
-    private func averageValue(in range: (start: Date, end: Date)) -> Double {
-        let s = range.start, e = range.end
-        let entriesInRange = entries.filter {
-            guard let d = $0.date else { return false }
-            return d >= s && d <= e
-        }
-        guard !entriesInRange.isEmpty else { return 0 }
-        let total = entriesInRange.reduce(0.0) { $0 + $1.decimalValue }
-        return total / Double(entriesInRange.count)
-    }
-
-    private func measurementHeadlineKey(isHigher: Bool) -> String {
-        switch chartGranularity {
-        case .month: return isHigher ? "measurementHigherThisMonthThanLastMonth" : "measurementLowerThisMonthThanLastMonth"
-        case .year: return isHigher ? "measurementHigherThisYearThanLastYear" : "measurementLowerThisYearThanLastYear"
         }
     }
 

--- a/LOGIT/Features/Workout/WorkoutStatScreen.swift
+++ b/LOGIT/Features/Workout/WorkoutStatScreen.swift
@@ -17,9 +17,9 @@ import SwiftUI
 /// frame (the reference — neutral, and it moves as you scroll) on one side, this workout's own value
 /// (the bold white constant) on the other, and a pill between them reading this workout against that
 /// average. Scroll the chart and the average + pill retarget while this workout stays the anchor —
-/// we're in its detail, after all. The muscle color lives on the accents: the current chart bar, the
-/// highlights' current bar, and the pill. Otherwise the exercise chart screens' anatomy (picker,
-/// header, scrollable chart with tap-to-inspect, highlights, about). One screen serves all four
+/// we're in its detail, after all. The muscle color lives on the accents: the current chart bar and
+/// the pill. Otherwise the exercise chart screens' anatomy (picker, header, scrollable chart with
+/// tap-to-inspect, about). One screen serves all four
 /// stats — `WorkoutStatMetric` supplies values, formatting, and texts.
 struct WorkoutStatScreen: View {
     private enum ChartGranularity {
@@ -94,8 +94,6 @@ struct WorkoutStatScreen: View {
                     header(visibleAverage: visibleAverage)
                     chart(points: points, snappedPoint: snappedPoint)
                 }
-
-                highlightsSection(workouts: workouts)
 
                 AboutSection(metricTitle: metric.title, text: metric.aboutText)
                     .padding(.horizontal)
@@ -364,32 +362,6 @@ struct WorkoutStatScreen: View {
             .map { metric.rawValue(of: $0) }
         guard !values.isEmpty else { return nil }
         return Double(values.reduce(0, +)) / Double(values.count)
-    }
-
-    // MARK: - Highlights
-
-    @ViewBuilder
-    private func highlightsSection(workouts: [Workout]) -> some View {
-        let granularity: HighlightView.Granularity = chartGranularity == .month ? .month : .year
-        let ranges = granularity.periodRanges()
-        let currentAverage = averageRaw(in: workouts, from: ranges.current.start, to: ranges.current.end) ?? 0
-        let previousAverage = averageRaw(in: workouts, from: ranges.previous.start, to: ranges.previous.end) ?? 0
-
-        HighlightView(
-            headline: metric.highlightHeadline(
-                isMore: currentAverage >= previousAverage,
-                isYearGranularity: chartGranularity == .year
-            ),
-            currentValue: currentAverage > 0 ? metric.highlightValue(rawAverage: currentAverage) : "––",
-            previousValue: previousAverage > 0 ? metric.highlightValue(rawAverage: previousAverage) : "––",
-            unit: metric.highlightUnit,
-            currentNumericValue: currentAverage,
-            previousNumericValue: previousAverage,
-            granularity: granularity,
-            accentColor: dominantMuscleGroupColor,
-            accentGradient: workout.muscleGroups.gradient()
-        )
-        .padding(.horizontal)
     }
 
     // MARK: - Chart Window

--- a/LOGIT/SharedUI/Views/AboutSection.swift
+++ b/LOGIT/SharedUI/Views/AboutSection.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 /// Health-app-style explanation shown at the bottom of metric detail screens:
 /// an "About <Metric>" header followed by a short secondary description sitting
-/// in a tile, matching the `HighlightView` section directly above it.
+/// in a tile at the bottom of the screen.
 struct AboutSection: View {
     let metricTitle: String
     let text: String


### PR DESCRIPTION
## What
Removes the period-over-period **Highlights** section (`HighlightView` — current-vs-previous bars + headline) from all 10 chart detail screens: the six exercise metric screens (volume, sets, set volume, e1RM, weight, repetitions) plus Volume, Overall Sets, Workout Stat, and Measurement.

## Why
Each of these screens already shows a recent-vs-prior comparison via the `MetricComparisonView` scoreboard (exercise/workout screens) or a header `TrendIndicatorView` pill (Volume/Overall Sets), so the highlights tile was redundant now that progress indicators are everywhere. On the exercise screens it was the weakest: it restated the top scoreboard but computed on a different basis (per-week / trailing-window for the scoreboard vs per-workout / calendar-month for the highlight), so the two could point in opposite directions on one screen.

## Notes
- `HighlightView` and `ComparisonBar` are intentionally **kept** (not deleted): `HighlightView.formatNumber` is still used by the sets scoreboard and the workout-stat tiles. The now-dead `WorkoutStatMetric.highlight*` helpers and unused localized headline keys are left in place for now.
- Pure removal: 575 deletions, 5 insertions (the insertions are doc-comment rewraps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)