### PR TITLE
Add a shared MetricTile and comparison scoreboard for the detail screens

### DIFF
--- a/LOGIT.xcodeproj/project.pbxproj
+++ b/LOGIT.xcodeproj/project.pbxproj
@@ -11,7 +11,9 @@
 		18F8886F2E06B3DCB04A2002 /* LOGITWidgetExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 79D10973BCE1A0618D3256CD /* LOGITWidgetExtension.appex */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		2333D8B12B944AD1A27D0E0A /* SetEntityClasses.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD50531C168D4EDFB527D76A /* SetEntityClasses.swift */; };
 		268525E87C3944BA9208D129 /* TrendIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D5D5995AEAE4AA8849AAF28 /* TrendIndicatorView.swift */; };
+		D1D1D1000000000000000B01 /* MetricTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1D1D1000000000000000F01 /* MetricTile.swift */; };
 		E1E1E1000000000000000B12 /* ProgressIndicatorPill.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1E1E1000000000000000F12 /* ProgressIndicatorPill.swift */; };
+		E1E1E1000000000000000B15 /* MetricComparisonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1E1E1000000000000000F15 /* MetricComparisonView.swift */; };
 		2A384BE3816900000002 /* ExerciseSuggestionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54EE2592821500000001 /* ExerciseSuggestionService.swift */; };
 		396ADE67CD8C1D14F7A8D82A /* LOGITWidgetExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3BDDD14FE5BF0C275AF30C5 /* LOGITWidgetExtension.swift */; };
 		435F070826CC8D1F8D7239B8 /* WorkoutDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4845CEF582EB23AB447C90B2 /* WorkoutDTO.swift */; };
@@ -329,7 +331,9 @@
 		0400C2E827A4AEAF03BACDC6 /* SnapshotHelper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SnapshotHelper.swift; sourceTree = "<group>"; };
 		06A7CD832F8CF2FDAB33579C /* WorkoutLiveActivityManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkoutLiveActivityManager.swift; sourceTree = "<group>"; };
 		0D5D5995AEAE4AA8849AAF28 /* TrendIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrendIndicatorView.swift; sourceTree = "<group>"; };
+		D1D1D1000000000000000F01 /* MetricTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetricTile.swift; sourceTree = "<group>"; };
 		E1E1E1000000000000000F12 /* ProgressIndicatorPill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressIndicatorPill.swift; sourceTree = "<group>"; };
+		E1E1E1000000000000000F15 /* MetricComparisonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetricComparisonView.swift; sourceTree = "<group>"; };
 		0E384D0F4B54340F910F6813 /* ExerciseMergingSheet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ExerciseMergingSheet.swift; sourceTree = "<group>"; };
 		144AED8F76DE3EBB1A1752AD /* LOGITUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LOGITUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		14BDE77C44D210E79936D216 /* ShareSheet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ShareSheet.swift; sourceTree = "<group>"; };
@@ -1205,7 +1209,9 @@
 				801BBD582DF7338A00CDB1FB /* TipView.swift */,
 				801BBD5A2DF7338A00CDB1FB /* UnitView.swift */,
 				0D5D5995AEAE4AA8849AAF28 /* TrendIndicatorView.swift */,
+				D1D1D1000000000000000F01 /* MetricTile.swift */,
 				E1E1E1000000000000000F12 /* ProgressIndicatorPill.swift */,
+				E1E1E1000000000000000F15 /* MetricComparisonView.swift */,
 				801BBD5B2DF7338A00CDB1FB /* WidgetCollectionView.swift */,
 				80B387BA2EBA187100AD7EFC /* DecimalField.swift */,
 				80AA00012F3A000100AA0001 /* RestDurationPicker.swift */,
@@ -1601,7 +1607,9 @@
 				801BBD9B2DF7338A00CDB1FB /* TemplateSetGroup+.swift in Sources */,
 				801BBD9C2DF7338A00CDB1FB /* UnitView.swift in Sources */,
 				268525E87C3944BA9208D129 /* TrendIndicatorView.swift in Sources */,
+				D1D1D1000000000000000B01 /* MetricTile.swift in Sources */,
 				E1E1E1000000000000000B12 /* ProgressIndicatorPill.swift in Sources */,
+				E1E1E1000000000000000B15 /* MetricComparisonView.swift in Sources */,
 				801BBD9D2DF7338A00CDB1FB /* SuperSet+.swift in Sources */,
 				801BBD9E2DF7338A00CDB1FB /* TileHeaderStyle.swift in Sources */,
 				801BBD9F2DF7338A00CDB1FB /* TemplateGenerationModifier.swift in Sources */,

--- a/LOGIT/Core/Environment/de.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/de.lproj/Localizable.strings
@@ -74,7 +74,12 @@
 "creatingTemplateFailed" = "Generieren Fehlgeschlagen";
 "creatingTemplateFailedText" = "Stelle sicher, dass das Bild ein Workout enthält.";
 "currentBest" = "Aktueller Bestwert";
-"currentBestInfo" = "Dein aktueller Bestwert ist der höchste Wert aus dem letzten Monat.";
+"previousBest" = "Vorheriger Bestwert";
+"newRecord" = "Neuer Rekord";
+"currentBestInfo" = "Dein aktueller Bestwert ist der höchste Wert der letzten 4 Wochen. Der Trend zeigt, wie viel höher er ist als dein Bestwert in den 4 Wochen davor.";
+"currentBestComparisonInfo" = "Dein aktueller Bestwert (rechts) ist der höchste Wert der letzten 4 Wochen. Das Abzeichen zeigt, wie er sich zu deinem Bestwert im angezeigten Zeitraum links verhält – scrolle, um mit beliebigen Zeiträumen zu vergleichen.";
+"averageComparisonInfo" = "Der Wert rechts ist dein Wochendurchschnitt der letzten 4 Wochen. Das Abzeichen zeigt, wie er sich zum Durchschnitt des angezeigten Zeitraums links verhält – scrolle, um mit beliebigen Zeiträumen zu vergleichen.";
+"lastFourWeeks" = "Letzte 4 Wochen";
 "currentWorkout" = "Aktuelles Workout";
 
 // MARK: - D
@@ -863,6 +868,8 @@
 "tapForMetricInfo" = "Tippe für Details und um die Metrik zu wechseln.";
 "personalRecord" = "Persönlicher Rekord";
 "personalRecordShort" = "PR";
+"personalRecordShortCount" = "%d PR";
+"personalRecordsShortCount" = "%d PRs";
 "repsShort" = "Wdh.";
 
 /* Workout Progress Section */

--- a/LOGIT/Core/Environment/en.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/en.lproj/Localizable.strings
@@ -74,7 +74,12 @@
 "creatingTemplateFailed" = "Creating Template Failed";
 "creatingTemplateFailedText" = "Make sure the selected image contains a workout.";
 "currentBest" = "Current Best";
-"currentBestInfo" = "Your current best is the highest value you've reached in the last month.";
+"previousBest" = "Previous Best";
+"newRecord" = "New Record";
+"currentBestInfo" = "Your current best is the highest value in the last 4 weeks. The trend shows how much higher it is than your best in the 4 weeks before you reached it.";
+"currentBestComparisonInfo" = "Your current best (right) is the highest value in the last 4 weeks. The badge shows how it compares to your best in the shown period on the left — scroll to compare against any time.";
+"averageComparisonInfo" = "The right value is your weekly average over the last 4 weeks. The badge shows how it compares to the average of the shown period on the left — scroll to compare against any time.";
+"lastFourWeeks" = "Last 4 weeks";
 "currentWorkout" = "Current Workout";
 
 // MARK: - D
@@ -867,6 +872,8 @@
 "tapForMetricInfo" = "Tap for details and to switch the metric.";
 "personalRecord" = "Personal record";
 "personalRecordShort" = "PR";
+"personalRecordShortCount" = "%d PR";
+"personalRecordsShortCount" = "%d PRs";
 "repsShort" = "Reps";
 
 /* Workout Progress Section */

--- a/LOGIT/Core/Environment/es.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/es.lproj/Localizable.strings
@@ -74,7 +74,12 @@
 "creatingTemplateFailed" = "Error al crear la plantilla";
 "creatingTemplateFailedText" = "Asegúrese de que la imagen seleccionada contenga un entrenamiento.";
 "currentBest" = "Mejor marca actual";
-"currentBestInfo" = "Tu mejor marca actual es el valor más alto que has alcanzado en el último mes.";
+"previousBest" = "Mejor marca anterior";
+"newRecord" = "Nuevo récord";
+"currentBestInfo" = "Tu mejor marca actual es el valor más alto de las últimas 4 semanas. La tendencia muestra cuánto más alto es que tu mejor marca de las 4 semanas anteriores.";
+"currentBestComparisonInfo" = "Tu mejor marca actual (derecha) es el valor más alto de las últimas 4 semanas. La insignia muestra cómo se compara con tu mejor marca del periodo mostrado a la izquierda; desliza para comparar con cualquier momento.";
+"averageComparisonInfo" = "El valor de la derecha es tu promedio semanal de las últimas 4 semanas. La insignia muestra cómo se compara con el promedio del periodo mostrado a la izquierda; desliza para comparar con cualquier momento.";
+"lastFourWeeks" = "Últimas 4 semanas";
 "currentWorkout" = "Entrenamiento actual";
 
 // MARK: - D
@@ -867,6 +872,8 @@
 "tapForMetricInfo" = "Toca para ver detalles y cambiar de métrica.";
 "personalRecord" = "Récord personal";
 "personalRecordShort" = "PR";
+"personalRecordShortCount" = "%d PR";
+"personalRecordsShortCount" = "%d PRs";
 "repsShort" = "Reps";
 
 /* Workout Progress Section */

--- a/LOGIT/Core/Environment/fr.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/fr.lproj/Localizable.strings
@@ -74,7 +74,12 @@
 "creatingTemplateFailed" = "Échec de la création du modèle";
 "creatingTemplateFailedText" = "Assurez-vous que l'image sélectionnée contient un entraînement.";
 "currentBest" = "Meilleur actuel";
-"currentBestInfo" = "Ton meilleur actuel est la valeur la plus élevée atteinte au cours du dernier mois.";
+"previousBest" = "Meilleur précédent";
+"newRecord" = "Nouveau record";
+"currentBestInfo" = "Ton meilleur actuel est la valeur la plus élevée des 4 dernières semaines. La tendance indique de combien il dépasse ton meilleur des 4 semaines précédentes.";
+"currentBestComparisonInfo" = "Ton meilleur actuel (à droite) est la valeur la plus élevée des 4 dernières semaines. Le badge indique comment il se compare à ton meilleur sur la période affichée à gauche ; fais défiler pour comparer avec n'importe quelle période.";
+"averageComparisonInfo" = "La valeur de droite est ta moyenne hebdomadaire des 4 dernières semaines. Le badge indique comment elle se compare à la moyenne de la période affichée à gauche ; fais défiler pour comparer avec n'importe quelle période.";
+"lastFourWeeks" = "4 dernières semaines";
 "currentWorkout" = "Entraînement actuel";
 
 // MARK: - D
@@ -867,6 +872,8 @@
 "tapForMetricInfo" = "Touche pour voir les détails et changer de métrique.";
 "personalRecord" = "Record personnel";
 "personalRecordShort" = "PR";
+"personalRecordShortCount" = "%d PR";
+"personalRecordsShortCount" = "%d PRs";
 "repsShort" = "Reps";
 
 /* Workout Progress Section */

--- a/LOGIT/Core/Environment/it.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/it.lproj/Localizable.strings
@@ -74,7 +74,12 @@
 "creatingTemplateFailed" = "Creazione del modello non riuscita";
 "creatingTemplateFailedText" = "Assicurati che l'immagine selezionata contenga un allenamento.";
 "currentBest" = "Migliore attuale";
-"currentBestInfo" = "Il tuo migliore attuale è il valore più alto raggiunto nell'ultimo mese.";
+"previousBest" = "Migliore precedente";
+"newRecord" = "Nuovo record";
+"currentBestInfo" = "Il tuo migliore attuale è il valore più alto delle ultime 4 settimane. L'andamento mostra quanto è più alto rispetto al tuo migliore nelle 4 settimane precedenti.";
+"currentBestComparisonInfo" = "Il tuo migliore attuale (a destra) è il valore più alto delle ultime 4 settimane. Il distintivo mostra come si confronta con il tuo migliore nel periodo mostrato a sinistra; scorri per confrontare con qualsiasi periodo.";
+"averageComparisonInfo" = "Il valore a destra è la tua media settimanale delle ultime 4 settimane. Il distintivo mostra come si confronta con la media del periodo mostrato a sinistra; scorri per confrontare con qualsiasi periodo.";
+"lastFourWeeks" = "Ultime 4 settimane";
 "currentWorkout" = "Allenamento attuale";
 
 // MARK: - D
@@ -867,6 +872,8 @@
 "tapForMetricInfo" = "Tocca per i dettagli e per cambiare metrica.";
 "personalRecord" = "Record personale";
 "personalRecordShort" = "PR";
+"personalRecordShortCount" = "%d PR";
+"personalRecordsShortCount" = "%d PRs";
 "repsShort" = "Rip.";
 
 /* Workout Progress Section */

--- a/LOGIT/Core/Environment/ja.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/ja.lproj/Localizable.strings
@@ -74,7 +74,12 @@
 "creatingTemplateFailed" = "テンプレートの作成に失敗しました";
 "creatingTemplateFailedText" = "選択した画像にワークアウトが含まれていることを確認してください。";
 "currentBest" = "現在のベスト";
-"currentBestInfo" = "現在のベストは、直近1か月間の最高値です。";
+"previousBest" = "以前のベスト";
+"newRecord" = "新記録";
+"currentBestInfo" = "現在のベストは、直近4週間の最高値です。トレンドは、その値に達する前の4週間のベストよりどれだけ高いかを示します。";
+"currentBestComparisonInfo" = "現在のベスト（右）は直近4週間の最高値です。バッジは、左に表示された期間のベストと比べてどうかを示します。スクロールして任意の期間と比較できます。";
+"averageComparisonInfo" = "右の値は直近4週間の週平均です。バッジは、左に表示された期間の平均と比べてどうかを示します。スクロールして任意の期間と比較できます。";
+"lastFourWeeks" = "直近4週間";
 "currentWorkout" = "現在のトレーニング";
 
 // MARK: - D
@@ -867,6 +872,8 @@
 "tapForMetricInfo" = "タップすると詳細の表示と指標の切り替えができます。";
 "personalRecord" = "自己ベスト";
 "personalRecordShort" = "自己ベスト";
+"personalRecordShortCount" = "自己ベスト%d件";
+"personalRecordsShortCount" = "自己ベスト%d件";
 "repsShort" = "回数";
 
 /* Workout Progress Section */

--- a/LOGIT/Core/Environment/ko.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/ko.lproj/Localizable.strings
@@ -74,7 +74,12 @@
 "creatingTemplateFailed" = "템플릿 생성 실패";
 "creatingTemplateFailedText" = "선택한 이미지에 운동이 포함되어 있는지 확인하세요.";
 "currentBest" = "현재 최고";
-"currentBestInfo" = "현재 최고는 최근 한 달 동안 달성한 최고 값입니다.";
+"previousBest" = "이전 최고";
+"newRecord" = "새 기록";
+"currentBestInfo" = "현재 최고는 최근 4주 동안의 최고 값입니다. 추세는 그 값을 달성하기 전 4주 동안의 최고보다 얼마나 높은지 보여줍니다.";
+"currentBestComparisonInfo" = "현재 최고(오른쪽)는 최근 4주 동안의 최고 값입니다. 배지는 왼쪽에 표시된 기간의 최고와 어떻게 비교되는지 보여줍니다. 스크롤하여 원하는 기간과 비교하세요.";
+"averageComparisonInfo" = "오른쪽 값은 최근 4주 동안의 주간 평균입니다. 배지는 왼쪽에 표시된 기간의 평균과 어떻게 비교되는지 보여줍니다. 스크롤하여 원하는 기간과 비교하세요.";
+"lastFourWeeks" = "최근 4주";
 "currentWorkout" = "현재 운동";
 
 // MARK: - D
@@ -867,6 +872,8 @@
 "tapForMetricInfo" = "탭하여 세부 정보를 확인하고 지표를 전환하세요.";
 "personalRecord" = "개인 기록";
 "personalRecordShort" = "신기록";
+"personalRecordShortCount" = "신기록 %d개";
+"personalRecordsShortCount" = "신기록 %d개";
 "repsShort" = "횟수";
 
 /* Workout Progress Section */

--- a/LOGIT/Core/Environment/pt-BR.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/pt-BR.lproj/Localizable.strings
@@ -74,7 +74,12 @@
 "creatingTemplateFailed" = "Falha na criação do modelo";
 "creatingTemplateFailedText" = "Certifique-se de que a imagem selecionada contenha um treino.";
 "currentBest" = "Melhor atual";
-"currentBestInfo" = "Seu melhor atual é o valor mais alto que você alcançou no último mês.";
+"previousBest" = "Melhor anterior";
+"newRecord" = "Novo recorde";
+"currentBestInfo" = "Seu melhor atual é o valor mais alto das últimas 4 semanas. A tendência mostra o quanto ele é mais alto do que seu melhor nas 4 semanas anteriores.";
+"currentBestComparisonInfo" = "Seu melhor atual (à direita) é o valor mais alto das últimas 4 semanas. O selo mostra como ele se compara ao seu melhor no período exibido à esquerda; deslize para comparar com qualquer período.";
+"averageComparisonInfo" = "O valor à direita é sua média semanal das últimas 4 semanas. O selo mostra como ela se compara à média do período exibido à esquerda; deslize para comparar com qualquer período.";
+"lastFourWeeks" = "Últimas 4 semanas";
 "currentWorkout" = "Treino atual";
 
 // MARK: - D
@@ -867,6 +872,8 @@
 "tapForMetricInfo" = "Toque para ver detalhes e trocar de métrica.";
 "personalRecord" = "Recorde pessoal";
 "personalRecordShort" = "PR";
+"personalRecordShortCount" = "%d PR";
+"personalRecordsShortCount" = "%d PRs";
 "repsShort" = "Reps";
 
 /* Workout Progress Section */

--- a/LOGIT/Features/Exercise/ExerciseDetail/ExerciseE1RMScreen.swift
+++ b/LOGIT/Features/Exercise/ExerciseDetail/ExerciseE1RMScreen.swift
@@ -28,7 +28,6 @@ struct ExerciseE1RMScreen: View {
         // Determine the snapped selected set only when a selection exists; snap to the nearest datapoint (prefer visible)
         let snappedSelectedSet: WorkoutSet? = selectedDate != nil ? nearestSet(to: selectedDate, in: allDailyMaxSets) : nil
         let bestVisibleE1RM = bestE1RMInGranularity(workoutSets)
-        let visibleTrendPercentage = trendPercentage(in: workoutSets)
         ScrollView {
             VStack(spacing: SECTION_SPACING) {
                 VStack {
@@ -41,35 +40,24 @@ struct ExerciseE1RMScreen: View {
                     .pickerStyle(.segmented)
                     .padding(.vertical)
                     .padding(.horizontal)
-                    HStack {
-                        VStack(alignment: .leading) {
-                            if isShowingCurrentBestWindow {
-                                CurrentBestLabel(uppercased: true)
-                            } else {
-                                Text(NSLocalizedString("best", comment: ""))
-                                    .font(.footnote)
-                                    .fontWeight(.medium)
-                                    .textCase(.uppercase)
-                                    .foregroundStyle(.secondary)
-                            }
-                            UnitView(
-                                value: "\(bestVisibleE1RM != nil ? formatEstimatedOneRepMax(bestVisibleE1RM!) : "––")",
-                                unit: WeightUnit.used.rawValue
-                            )
-                            .foregroundStyle(exerciseMuscleGroupColor.gradient)
-                            Text(chartHeaderTitle)
-                                .fontWeight(.bold)
-                                .foregroundStyle(.secondary)
-                        }
-                        Spacer()
-                        if let visibleTrendPercentage {
-                            TrendIndicatorView(
-                                percentChange: visibleTrendPercentage,
-                                positiveColor: exerciseMuscleGroupColor
-                            )
-                            .animation(.snappy, value: visibleTrendPercentage)
-                        }
-                    }
+                    MetricComparisonView(
+                        leading: .init(
+                            label: NSLocalizedString("previousBest", comment: ""),
+                            value: bestVisibleE1RM.map(formatEstimatedOneRepMax) ?? "––",
+                            unit: WeightUnit.used.rawValue,
+                            caption: chartHeaderTitle
+                        ),
+                        trailing: .init(
+                            label: NSLocalizedString("currentBest", comment: ""),
+                            value: currentBestAnchor.map { formatEstimatedOneRepMax($0.value) } ?? "––",
+                            unit: WeightUnit.used.rawValue,
+                            caption: currentBestAnchor?.date.map { $0.formatted(.dateTime.day().month()) }
+                        ),
+                        trailingValueStyle: AnyShapeStyle(exerciseMuscleGroupColor.gradient),
+                        percentChange: headerTrendPercentage(visibleBest: bestVisibleE1RM),
+                        positiveColor: exerciseMuscleGroupColor,
+                        explanation: NSLocalizedString("currentBestComparisonInfo", comment: "")
+                    )
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(.horizontal)
                     Chart {
@@ -213,9 +201,6 @@ struct ExerciseE1RMScreen: View {
                     .padding(.trailing, 5)
                 }
 
-                // MARK: - Highlights Section
-                highlightsSection(allDailyMaxSets: allDailyMaxSets)
-
                 // MARK: - About Section
                 AboutSection(
                     metricTitle: NSLocalizedString("estimatedOneRepMax", comment: ""),
@@ -329,17 +314,16 @@ struct ExerciseE1RMScreen: View {
         )
     }
 
+    /// The header's left value and the comparison baseline: the best e1RM in the visible window
+    /// *other than* the current best, falling back to the most recent day's best before the window
+    /// when it holds no other value (see `exerciseOtherBestBaseline`).
     private func bestE1RMInGranularity(_ workoutSets: [WorkoutSet]) -> Int? {
-        let endDate = Calendar.current.date(byAdding: .second, value: visibleChartDomainInSeconds, to: chartScrollPosition)!
-        let setsInTimeFrame = workoutSets.filter { $0.workout?.date ?? .distantPast >= chartScrollPosition && $0.workout?.date ?? .distantFuture <= endDate }
-
-        guard !setsInTimeFrame.isEmpty else {
-            return workoutSets.first?.estimatedOneRepMax(for: exercise)
-        }
-
-        return setsInTimeFrame
-            .map { $0.estimatedOneRepMax(for: exercise) }
-            .max()
+        exerciseOtherBestBaseline(
+            sets: workoutSets,
+            windowStart: chartScrollPosition,
+            windowEnd: visibleEndDate,
+            currentBestDay: currentBestAnchor?.date
+        ) { $0.estimatedOneRepMax(for: exercise) }
     }
 
     private func chartYScaleMax(maxYValue: Int) -> Int {
@@ -348,34 +332,25 @@ struct ExerciseE1RMScreen: View {
         return nextBiggerYAxisMaxValue ?? maxYValue
     }
 
-    /// Percent change of the best e1RM in the visible chart window versus a comparable window
-    /// before it — the window right before, or the last window with training when that's empty
-    /// (see `exerciseWindowTrendPercentage`). Nil only when there's no earlier history at all.
-    private func trendPercentage(in workoutSets: [WorkoutSet]) -> Double? {
-        exerciseWindowTrendPercentage(
-            sets: workoutSets,
-            windowStart: chartScrollPosition,
-            windowSeconds: visibleChartDomainInSeconds
-        ) { start, end in
-            workoutSets
-                .filter { ($0.workout?.date).map { $0 >= start && $0 <= end } ?? false }
-                .map { $0.estimatedOneRepMax(for: exercise) }
-                .max()
-                .map(Double.init)
-        }
+    /// The exercise's current best (highest e1RM in the last four weeks) and the day it was reached
+    /// — the fixed right-hand anchor of the header scoreboard, independent of scroll.
+    private var currentBestAnchor: (value: Int, date: Date?)? {
+        guard let best = exercise.currentBestSet(for: .estimatedOneRepMax, in: workoutSets) else { return nil }
+        return (best.estimatedOneRepMax(for: exercise), best.workout?.date)
+    }
+
+    /// The header pill: the current best measured against the best in the shown window. Nil when
+    /// either side is empty, so the pill drops out only when there is genuinely nothing to compare.
+    private func headerTrendPercentage(visibleBest: Int?) -> Double? {
+        guard let current = currentBestAnchor?.value, current > 0,
+              let visible = visibleBest, visible > 0 else { return nil }
+        return (Double(current) - Double(visible)) / Double(visible) * 100
     }
 
     // MARK: - Selection helpers
 
     private var visibleEndDate: Date {
         Calendar.current.date(byAdding: .second, value: visibleChartDomainInSeconds, to: chartScrollPosition)!
-    }
-
-    /// True while the month view sits at its newest scroll position (the default), where the
-    /// visible window's best IS the exercise's current best — the header label says so then, with
-    /// the info popover explaining the term.
-    private var isShowingCurrentBestWindow: Bool {
-        chartGranularity == .month && visibleEndDate >= .now
     }
 
     private func nearestSet(to date: Date?, in sets: [WorkoutSet]) -> WorkoutSet? {
@@ -393,59 +368,6 @@ struct ExerciseE1RMScreen: View {
         }
     }
 
-    // MARK: - Highlights
-
-    @ViewBuilder
-    private func highlightsSection(allDailyMaxSets: [WorkoutSet]) -> some View {
-        let ranges = periodRanges()
-        let currentMax = maxE1RM(in: ranges.current, sets: allDailyMaxSets)
-        let previousMax = maxE1RM(in: ranges.previous, sets: allDailyMaxSets)
-        let headlineKey = e1RMHeadlineKey(isHigher: currentMax >= previousMax)
-        let unit = WeightUnit.used.rawValue
-
-        HighlightView(
-            headline: NSLocalizedString(headlineKey, comment: ""),
-            currentValue: currentMax > 0 ? formatEstimatedOneRepMax(currentMax) : "––",
-            previousValue: previousMax > 0 ? formatEstimatedOneRepMax(previousMax) : "––",
-            unit: unit,
-            currentNumericValue: Double(convertWeightForDisplaying(currentMax)),
-            previousNumericValue: Double(convertWeightForDisplaying(previousMax)),
-            granularity: chartGranularity == .month ? .month : .year,
-            accentColor: exerciseMuscleGroupColor
-        )
-        .padding(.horizontal)
-    }
-
-    private func periodRanges() -> (current: (start: Date, end: Date), previous: (start: Date, end: Date)) {
-        switch chartGranularity {
-        case .month:
-            let current = (Date.now.startOfMonth, Date.now.endOfMonth)
-            let lastStart = Calendar.current.date(byAdding: .month, value: -1, to: .now.startOfMonth)!
-            let previous = (lastStart, lastStart.endOfMonth)
-            return (current, previous)
-        case .year:
-            let current = (Date.now.startOfYear, Date.now.endOfYear)
-            let lastStart = Calendar.current.date(byAdding: .year, value: -1, to: .now.startOfYear)!
-            let previous = (lastStart, lastStart.endOfYear)
-            return (current, previous)
-        }
-    }
-
-    private func maxE1RM(in range: (start: Date, end: Date), sets: [WorkoutSet]) -> Int {
-        let s = range.start, e = range.end
-        let setsInRange = sets.filter {
-            guard let d = $0.workout?.date else { return false }
-            return d >= s && d <= e
-        }
-        return setsInRange.map { $0.estimatedOneRepMax(for: exercise) }.max() ?? 0
-    }
-
-    private func e1RMHeadlineKey(isHigher: Bool) -> String {
-        switch chartGranularity {
-        case .month: return isHigher ? "higherMaxE1RMThisMonthThanLastMonth" : "lowerMaxE1RMThisMonthThanLastMonth"
-        case .year: return isHigher ? "higherMaxE1RMThisYearThanLastYear" : "lowerMaxE1RMThisYearThanLastYear"
-        }
-    }
 }
 
 private struct PreviewWrapperView: View {

--- a/LOGIT/Features/Exercise/ExerciseDetail/ExerciseRepetitionsScreen.swift
+++ b/LOGIT/Features/Exercise/ExerciseDetail/ExerciseRepetitionsScreen.swift
@@ -27,7 +27,6 @@ struct ExerciseRepetitionsScreen: View {
         // Determine the snapped selected set only when a selection exists; snap to the overall nearest datapoint
         let snappedSelectedSet: WorkoutSet? = selectedDate != nil ? nearestSet(to: selectedDate, in: allDailyMaxRepsSets) : nil
         let bestRepsInGranularity: Int? = bestRepetitionsInGranularity(in: workoutSets)
-        let visibleTrendPercentage = trendPercentage(in: workoutSets)
         ScrollView {
             VStack(spacing: SECTION_SPACING) {
                 VStack {
@@ -40,35 +39,24 @@ struct ExerciseRepetitionsScreen: View {
             .pickerStyle(.segmented)
             .padding(.vertical)
             .padding(.horizontal)
-            HStack {
-                VStack(alignment: .leading) {
-                    if isShowingCurrentBestWindow {
-                        CurrentBestLabel(uppercased: true)
-                    } else {
-                        Text(NSLocalizedString("best", comment: ""))
-                            .font(.footnote)
-                            .fontWeight(.medium)
-                            .textCase(.uppercase)
-                            .foregroundStyle(.secondary)
-                    }
-                    UnitView(
-                        value: "\(bestRepsInGranularity != nil ? String(bestRepsInGranularity!) : "––")",
-                        unit: NSLocalizedString("rps", comment: "")
-                    )
-                    .foregroundStyle(exerciseMuscleGroupColor.gradient)
-                    Text(chartHeaderTitle)
-                        .fontWeight(.bold)
-                        .foregroundStyle(.secondary)
-                }
-                Spacer()
-                if let visibleTrendPercentage {
-                    TrendIndicatorView(
-                        percentChange: visibleTrendPercentage,
-                        positiveColor: exerciseMuscleGroupColor
-                    )
-                    .animation(.snappy, value: visibleTrendPercentage)
-                }
-            }
+            MetricComparisonView(
+                leading: .init(
+                    label: NSLocalizedString("previousBest", comment: ""),
+                    value: bestRepsInGranularity.map { String($0) } ?? "––",
+                    unit: NSLocalizedString("rps", comment: ""),
+                    caption: chartHeaderTitle
+                ),
+                trailing: .init(
+                    label: NSLocalizedString("currentBest", comment: ""),
+                    value: currentBestAnchor.map { String($0.value) } ?? "––",
+                    unit: NSLocalizedString("rps", comment: ""),
+                    caption: currentBestAnchor?.date.map { $0.formatted(.dateTime.day().month()) }
+                ),
+                trailingValueStyle: AnyShapeStyle(exerciseMuscleGroupColor.gradient),
+                percentChange: headerTrendPercentage(visibleBest: bestRepsInGranularity),
+                positiveColor: exerciseMuscleGroupColor,
+                explanation: NSLocalizedString("currentBestComparisonInfo", comment: "")
+            )
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.horizontal)
             Chart {
@@ -213,9 +201,6 @@ struct ExerciseRepetitionsScreen: View {
                 .padding(.trailing, 5)
                 }
                 
-                // MARK: - Highlights Section
-                highlightsSection(allDailyMaxRepsSets: allDailyMaxRepsSets)
-
                 // MARK: - About Section
                 AboutSection(
                     metricTitle: NSLocalizedString("repetitions", comment: ""),
@@ -331,21 +316,16 @@ struct ExerciseRepetitionsScreen: View {
             .max() ?? 0
     }
 
+    /// The header's left value and the comparison baseline: the best reps in the visible window
+    /// *other than* the current best, falling back to the most recent day's best before the window
+    /// when it holds no other value (see `exerciseOtherBestBaseline`).
     private func bestRepetitionsInGranularity(in workoutSets: [WorkoutSet]) -> Int? {
-        let endDate = Calendar.current.date(byAdding: .second, value: visibleChartDomainInSeconds, to: chartScrollPosition)!
-        let setsInTimeFrame = workoutSets
-            .filter {
-                guard let date = $0.workout?.date else { return false }
-                return date >= chartScrollPosition && date <= endDate
-            }
-
-        guard !setsInTimeFrame.isEmpty else {
-            return workoutSets.first?.maximum(.repetitions, for: exercise)
-        }
-
-        return setsInTimeFrame
-            .map { $0.maximum(.repetitions, for: exercise) }
-            .max()
+        exerciseOtherBestBaseline(
+            sets: workoutSets,
+            windowStart: chartScrollPosition,
+            windowEnd: visibleEndDate,
+            currentBestDay: currentBestAnchor?.date
+        ) { $0.maximum(.repetitions, for: exercise) }
     }
 
     private func chartYScaleMax(maxYValue: Int) -> Int {
@@ -353,34 +333,25 @@ struct ExerciseRepetitionsScreen: View {
         return nextBiggerYAxisMaxValue ?? maxYValue
     }
 
-    /// Percent change of the best repetitions in the visible chart window versus a comparable
-    /// window before it — the window right before, or the last window with training when that's
-    /// empty (see `exerciseWindowTrendPercentage`). Nil only when there's no earlier history at all.
-    private func trendPercentage(in workoutSets: [WorkoutSet]) -> Double? {
-        exerciseWindowTrendPercentage(
-            sets: workoutSets,
-            windowStart: chartScrollPosition,
-            windowSeconds: visibleChartDomainInSeconds
-        ) { start, end in
-            workoutSets
-                .filter { ($0.workout?.date).map { $0 >= start && $0 <= end } ?? false }
-                .map { $0.maximum(.repetitions, for: exercise) }
-                .max()
-                .map(Double.init)
-        }
+    /// The exercise's current best (highest reps in the last four weeks) and the day it was reached
+    /// — the fixed right-hand anchor of the header scoreboard, independent of scroll.
+    private var currentBestAnchor: (value: Int, date: Date?)? {
+        guard let best = exercise.currentBestSet(for: .repetitions, in: workoutSets) else { return nil }
+        return (best.maximum(.repetitions, for: exercise), best.workout?.date)
+    }
+
+    /// The header pill: the current best measured against the best in the shown window. Nil when
+    /// either side is empty, so the pill drops out only when there is genuinely nothing to compare.
+    private func headerTrendPercentage(visibleBest: Int?) -> Double? {
+        guard let current = currentBestAnchor?.value, current > 0,
+              let visible = visibleBest, visible > 0 else { return nil }
+        return (Double(current) - Double(visible)) / Double(visible) * 100
     }
 
     // MARK: - Selection helpers
 
     private var visibleEndDate: Date {
         Calendar.current.date(byAdding: .second, value: visibleChartDomainInSeconds, to: chartScrollPosition)!
-    }
-
-    /// True while the month view sits at its newest scroll position (the default), where the
-    /// visible window's best IS the exercise's current best — the header label says so then, with
-    /// the info popover explaining the term.
-    private var isShowingCurrentBestWindow: Bool {
-        chartGranularity == .month && visibleEndDate >= .now
     }
 
     private func nearestSet(to date: Date?, in sets: [WorkoutSet]) -> WorkoutSet? {
@@ -398,59 +369,6 @@ struct ExerciseRepetitionsScreen: View {
         }
     }
 
-    // MARK: - Highlights
-
-    @ViewBuilder
-    private func highlightsSection(allDailyMaxRepsSets: [WorkoutSet]) -> some View {
-        let ranges = periodRanges()
-        let currentMax = maxReps(in: ranges.current, sets: allDailyMaxRepsSets)
-        let previousMax = maxReps(in: ranges.previous, sets: allDailyMaxRepsSets)
-        let headlineKey = repsHeadlineKey(isHigher: currentMax >= previousMax)
-        let unit = NSLocalizedString("rps", comment: "")
-
-        HighlightView(
-            headline: NSLocalizedString(headlineKey, comment: ""),
-            currentValue: currentMax > 0 ? String(currentMax) : "––",
-            previousValue: previousMax > 0 ? String(previousMax) : "––",
-            unit: unit,
-            currentNumericValue: Double(currentMax),
-            previousNumericValue: Double(previousMax),
-            granularity: chartGranularity == .month ? .month : .year,
-            accentColor: exerciseMuscleGroupColor
-        )
-        .padding(.horizontal)
-    }
-
-    private func periodRanges() -> (current: (start: Date, end: Date), previous: (start: Date, end: Date)) {
-        switch chartGranularity {
-        case .month:
-            let current = (Date.now.startOfMonth, Date.now.endOfMonth)
-            let lastStart = Calendar.current.date(byAdding: .month, value: -1, to: .now.startOfMonth)!
-            let previous = (lastStart, lastStart.endOfMonth)
-            return (current, previous)
-        case .year:
-            let current = (Date.now.startOfYear, Date.now.endOfYear)
-            let lastStart = Calendar.current.date(byAdding: .year, value: -1, to: .now.startOfYear)!
-            let previous = (lastStart, lastStart.endOfYear)
-            return (current, previous)
-        }
-    }
-
-    private func maxReps(in range: (start: Date, end: Date), sets: [WorkoutSet]) -> Int {
-        let s = range.start, e = range.end
-        let setsInRange = sets.filter {
-            guard let d = $0.workout?.date else { return false }
-            return d >= s && d <= e
-        }
-        return setsInRange.map { $0.maximum(.repetitions, for: exercise) }.max() ?? 0
-    }
-
-    private func repsHeadlineKey(isHigher: Bool) -> String {
-        switch chartGranularity {
-        case .month: return isHigher ? "higherMaxRepsThisMonthThanLastMonth" : "lowerMaxRepsThisMonthThanLastMonth"
-        case .year: return isHigher ? "higherMaxRepsThisYearThanLastYear" : "lowerMaxRepsThisYearThanLastYear"
-        }
-    }
 }
 
 private struct PreviewWrapperView: View {

--- a/LOGIT/Features/Exercise/ExerciseDetail/ExerciseSetVolumeScreen.swift
+++ b/LOGIT/Features/Exercise/ExerciseDetail/ExerciseSetVolumeScreen.swift
@@ -25,7 +25,6 @@ struct ExerciseSetVolumeScreen: View {
         // Determine the snapped selected set only when a selection exists; snap to the nearest datapoint (prefer visible)
         let snappedSelectedSet: WorkoutSet? = selectedDate != nil ? nearestSet(to: selectedDate, in: allDailyMaxSets) : nil
         let bestVisibleSetVolume = bestSetVolumeInGranularity(workoutSets)
-        let visibleTrendPercentage = trendPercentage(in: workoutSets)
         ScrollView {
             VStack(spacing: SECTION_SPACING) {
                 VStack {
@@ -38,35 +37,24 @@ struct ExerciseSetVolumeScreen: View {
                     .pickerStyle(.segmented)
                     .padding(.vertical)
                     .padding(.horizontal)
-                    HStack {
-                        VStack(alignment: .leading) {
-                            if isShowingCurrentBestWindow {
-                                CurrentBestLabel(uppercased: true)
-                            } else {
-                                Text(NSLocalizedString("best", comment: ""))
-                                    .font(.footnote)
-                                    .fontWeight(.medium)
-                                    .textCase(.uppercase)
-                                    .foregroundStyle(.secondary)
-                            }
-                            UnitView(
-                                value: "\(bestVisibleSetVolume != nil ? formatWeightForDisplay(bestVisibleSetVolume!) : "––")",
-                                unit: WeightUnit.used.rawValue
-                            )
-                            .foregroundStyle(exerciseMuscleGroupColor.gradient)
-                            Text(chartHeaderTitle)
-                                .fontWeight(.bold)
-                                .foregroundStyle(.secondary)
-                        }
-                        Spacer()
-                        if let visibleTrendPercentage {
-                            TrendIndicatorView(
-                                percentChange: visibleTrendPercentage,
-                                positiveColor: exerciseMuscleGroupColor
-                            )
-                            .animation(.snappy, value: visibleTrendPercentage)
-                        }
-                    }
+                    MetricComparisonView(
+                        leading: .init(
+                            label: NSLocalizedString("previousBest", comment: ""),
+                            value: bestVisibleSetVolume.map(formatWeightForDisplay) ?? "––",
+                            unit: WeightUnit.used.rawValue,
+                            caption: chartHeaderTitle
+                        ),
+                        trailing: .init(
+                            label: NSLocalizedString("currentBest", comment: ""),
+                            value: currentBestAnchor.map { formatWeightForDisplay($0.value) } ?? "––",
+                            unit: WeightUnit.used.rawValue,
+                            caption: currentBestAnchor?.date.map { $0.formatted(.dateTime.day().month()) }
+                        ),
+                        trailingValueStyle: AnyShapeStyle(exerciseMuscleGroupColor.gradient),
+                        percentChange: headerTrendPercentage(visibleBest: bestVisibleSetVolume),
+                        positiveColor: exerciseMuscleGroupColor,
+                        explanation: NSLocalizedString("currentBestComparisonInfo", comment: "")
+                    )
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(.horizontal)
                     Chart {
@@ -210,9 +198,6 @@ struct ExerciseSetVolumeScreen: View {
                     .padding(.trailing, 5)
                 }
 
-                // MARK: - Highlights Section
-                highlightsSection(allDailyMaxSets: allDailyMaxSets)
-
                 // MARK: - About Section
                 AboutSection(
                     metricTitle: NSLocalizedString("setVolume", comment: ""),
@@ -326,17 +311,16 @@ struct ExerciseSetVolumeScreen: View {
         )
     }
 
+    /// The header's left value and the comparison baseline: the best single-set volume in the visible
+    /// window *other than* the current best, falling back to the most recent day's best before the
+    /// window when it holds no other value (see `exerciseOtherBestBaseline`).
     private func bestSetVolumeInGranularity(_ workoutSets: [WorkoutSet]) -> Int? {
-        let endDate = Calendar.current.date(byAdding: .second, value: visibleChartDomainInSeconds, to: chartScrollPosition)!
-        let setsInTimeFrame = workoutSets.filter { $0.workout?.date ?? .distantPast >= chartScrollPosition && $0.workout?.date ?? .distantFuture <= endDate }
-
-        guard !setsInTimeFrame.isEmpty else {
-            return workoutSets.first?.volume(for: exercise)
-        }
-
-        return setsInTimeFrame
-            .map { $0.volume(for: exercise) }
-            .max()
+        exerciseOtherBestBaseline(
+            sets: workoutSets,
+            windowStart: chartScrollPosition,
+            windowEnd: visibleEndDate,
+            currentBestDay: currentBestAnchor?.date
+        ) { $0.volume(for: exercise) }
     }
 
     /// Set volume has no practical upper bound, so unlike the weight and e1RM screens (which pick
@@ -349,34 +333,25 @@ struct ExerciseSetVolumeScreen: View {
         return Int((Double(maxYValue) / step).rounded(.up) * step)
     }
 
-    /// Percent change of the best set volume in the visible chart window versus a comparable window
-    /// before it — the window right before, or the last window with training when that's empty
-    /// (see `exerciseWindowTrendPercentage`). Nil only when there's no earlier history at all.
-    private func trendPercentage(in workoutSets: [WorkoutSet]) -> Double? {
-        exerciseWindowTrendPercentage(
-            sets: workoutSets,
-            windowStart: chartScrollPosition,
-            windowSeconds: visibleChartDomainInSeconds
-        ) { start, end in
-            workoutSets
-                .filter { ($0.workout?.date).map { $0 >= start && $0 <= end } ?? false }
-                .map { $0.volume(for: exercise) }
-                .max()
-                .map(Double.init)
-        }
+    /// The exercise's current best (highest single-set volume in the last four weeks) and the day it
+    /// was reached — the fixed right-hand anchor of the header scoreboard, independent of scroll.
+    private var currentBestAnchor: (value: Int, date: Date?)? {
+        guard let best = exercise.currentBestSetVolumeSet(in: workoutSets) else { return nil }
+        return (best.volume(for: exercise), best.workout?.date)
+    }
+
+    /// The header pill: the current best measured against the best in the shown window. Nil when
+    /// either side is empty, so the pill drops out only when there is genuinely nothing to compare.
+    private func headerTrendPercentage(visibleBest: Int?) -> Double? {
+        guard let current = currentBestAnchor?.value, current > 0,
+              let visible = visibleBest, visible > 0 else { return nil }
+        return (Double(current) - Double(visible)) / Double(visible) * 100
     }
 
     // MARK: - Selection helpers
 
     private var visibleEndDate: Date {
         Calendar.current.date(byAdding: .second, value: visibleChartDomainInSeconds, to: chartScrollPosition)!
-    }
-
-    /// True while the month view sits at its newest scroll position (the default), where the
-    /// visible window's best IS the exercise's current best — the header label says so then, with
-    /// the info popover explaining the term.
-    private var isShowingCurrentBestWindow: Bool {
-        chartGranularity == .month && visibleEndDate >= .now
     }
 
     private func nearestSet(to date: Date?, in sets: [WorkoutSet]) -> WorkoutSet? {
@@ -394,59 +369,6 @@ struct ExerciseSetVolumeScreen: View {
         }
     }
 
-    // MARK: - Highlights
-
-    @ViewBuilder
-    private func highlightsSection(allDailyMaxSets: [WorkoutSet]) -> some View {
-        let ranges = periodRanges()
-        let currentMax = maxSetVolume(in: ranges.current, sets: allDailyMaxSets)
-        let previousMax = maxSetVolume(in: ranges.previous, sets: allDailyMaxSets)
-        let headlineKey = setVolumeHeadlineKey(isHigher: currentMax >= previousMax)
-        let unit = WeightUnit.used.rawValue
-
-        HighlightView(
-            headline: NSLocalizedString(headlineKey, comment: ""),
-            currentValue: currentMax > 0 ? formatWeightForDisplay(currentMax) : "––",
-            previousValue: previousMax > 0 ? formatWeightForDisplay(previousMax) : "––",
-            unit: unit,
-            currentNumericValue: Double(convertWeightForDisplaying(currentMax)),
-            previousNumericValue: Double(convertWeightForDisplaying(previousMax)),
-            granularity: chartGranularity == .month ? .month : .year,
-            accentColor: exerciseMuscleGroupColor
-        )
-        .padding(.horizontal)
-    }
-
-    private func periodRanges() -> (current: (start: Date, end: Date), previous: (start: Date, end: Date)) {
-        switch chartGranularity {
-        case .month:
-            let current = (Date.now.startOfMonth, Date.now.endOfMonth)
-            let lastStart = Calendar.current.date(byAdding: .month, value: -1, to: .now.startOfMonth)!
-            let previous = (lastStart, lastStart.endOfMonth)
-            return (current, previous)
-        case .year:
-            let current = (Date.now.startOfYear, Date.now.endOfYear)
-            let lastStart = Calendar.current.date(byAdding: .year, value: -1, to: .now.startOfYear)!
-            let previous = (lastStart, lastStart.endOfYear)
-            return (current, previous)
-        }
-    }
-
-    private func maxSetVolume(in range: (start: Date, end: Date), sets: [WorkoutSet]) -> Int {
-        let s = range.start, e = range.end
-        let setsInRange = sets.filter {
-            guard let d = $0.workout?.date else { return false }
-            return d >= s && d <= e
-        }
-        return setsInRange.map { $0.volume(for: exercise) }.max() ?? 0
-    }
-
-    private func setVolumeHeadlineKey(isHigher: Bool) -> String {
-        switch chartGranularity {
-        case .month: return isHigher ? "higherMaxSetVolumeThisMonthThanLastMonth" : "lowerMaxSetVolumeThisMonthThanLastMonth"
-        case .year: return isHigher ? "higherMaxSetVolumeThisYearThanLastYear" : "lowerMaxSetVolumeThisYearThanLastYear"
-        }
-    }
 }
 
 private struct PreviewWrapperView: View {

--- a/LOGIT/Features/Exercise/ExerciseDetail/ExerciseSetsScreen.swift
+++ b/LOGIT/Features/Exercise/ExerciseDetail/ExerciseSetsScreen.swift
@@ -10,7 +10,7 @@ import SwiftUI
 
 /// Sets-per-week over time for a single exercise — the detail screen behind the weekly Sets tile.
 /// Structurally the twin of `ExerciseVolumeScreen` (same scrollable weekly bar chart, month/year
-/// granularity, selection and highlights), but it counts working sets per week instead of summing
+/// granularity and selection), but it counts working sets per week instead of summing
 /// weight: how many sets you logged is the standard training-volume landmark, alongside tonnage.
 struct ExerciseSetsScreen: View {
     private enum ChartGranularity {
@@ -26,7 +26,13 @@ struct ExerciseSetsScreen: View {
 
     var body: some View {
         let groupedWorkoutSets = Dictionary(grouping: workoutSets) { $0.workout?.date?.startOfWeek ?? .now }.sorted { $0.key < $1.key }
-        let visibleTrendPercentage = trendPercentage(in: workoutSets)
+        let shownWeeklyAverage = averageWeekly(from: chartScrollPosition, to: visibleEndDate)
+        let recentWeeklyAverage = averageWeekly(from: Exercise.currentBestWindowStart, to: .now)
+        let averageTrendPercentage: Double? = {
+            guard let recent = recentWeeklyAverage, recent > 0,
+                  let shown = shownWeeklyAverage, shown > 0 else { return nil }
+            return (recent - shown) / shown * 100
+        }()
         ScrollView {
             VStack(spacing: SECTION_SPACING) {
                 VStack {
@@ -39,32 +45,23 @@ struct ExerciseSetsScreen: View {
                 .pickerStyle(.segmented)
                 .padding(.vertical)
                 .padding(.horizontal)
-                HStack {
-                    VStack(alignment: .leading) {
-                        Text(NSLocalizedString("total", comment: ""))
-                            .font(.footnote)
-                            .fontWeight(.semibold)
-                            .textCase(.uppercase)
-                            .foregroundStyle(.secondary)
-                        UnitView(
-                            value: totalSetsInTimeFrame(workoutSets),
-                            unit: ""
-                        )
-                        .foregroundStyle((exercise.muscleGroup?.color ?? .label).gradient)
-                        Text("\(visibleDomainDescription)")
-                            .fontWeight(.bold)
-                            .fontDesign(.rounded)
-                            .foregroundStyle(.secondary)
-                    }
-                    Spacer()
-                    if let visibleTrendPercentage {
-                        TrendIndicatorView(
-                            percentChange: visibleTrendPercentage,
-                            positiveColor: exercise.muscleGroup?.color ?? .label
-                        )
-                        .animation(.snappy, value: visibleTrendPercentage)
-                    }
-                }
+                MetricComparisonView(
+                    leading: .init(
+                        label: NSLocalizedString("average", comment: ""),
+                        value: shownWeeklyAverage.map { HighlightView.formatNumber($0) } ?? "––",
+                        unit: "",
+                        caption: visibleDomainDescription
+                    ),
+                    trailing: .init(
+                        label: NSLocalizedString("lastFourWeeks", comment: ""),
+                        value: recentWeeklyAverage.map { HighlightView.formatNumber($0) } ?? "––",
+                        unit: ""
+                    ),
+                    trailingValueStyle: AnyShapeStyle((exercise.muscleGroup?.color ?? .label).gradient),
+                    percentChange: averageTrendPercentage,
+                    positiveColor: exercise.muscleGroup?.color ?? .label,
+                    explanation: NSLocalizedString("averageComparisonInfo", comment: "")
+                )
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.horizontal)
                 Chart {
@@ -140,9 +137,6 @@ struct ExerciseSetsScreen: View {
                 .padding(.trailing, 5)
                 }
 
-                // MARK: - Highlights Section
-                highlightsSection
-
                 // MARK: - About Section
                 AboutSection(
                     metricTitle: NSLocalizedString("sets", comment: ""),
@@ -191,10 +185,21 @@ struct ExerciseSetsScreen: View {
         return startDate ... endDate
     }
 
-    private func totalSetsInTimeFrame(_ workoutSets: [WorkoutSet]) -> String {
-        let endDate = Calendar.current.date(byAdding: .second, value: visibleChartDomainInSeconds, to: chartScrollPosition)!
-        let setsInTimeFrame = workoutSets.filter { $0.workout?.date ?? .distantPast >= chartScrollPosition && $0.workout?.date ?? .distantFuture <= endDate }
-        return setCountFormatted(for: setsInTimeFrame)
+    private var visibleEndDate: Date {
+        Calendar.current.date(byAdding: .second, value: visibleChartDomainInSeconds, to: chartScrollPosition)!
+    }
+
+    /// Mean weekly set count over [from, to] — the average height of the weekly bars in the range.
+    /// The reference the header scoreboard compares against; nil with no training in the range.
+    /// Averages only weeks that were trained, so a rest week doesn't drag the bar down.
+    private func averageWeekly(from: Date, to: Date) -> Double? {
+        let weeks = Dictionary(grouping: workoutSets.filter {
+            guard let date = $0.workout?.date else { return false }
+            return date >= from && date <= to
+        }) { $0.workout?.date?.startOfWeek ?? .now }
+        let weeklyCounts = weeks.values.map { Double(setCount(for: $0)) }
+        guard !weeklyCounts.isEmpty else { return nil }
+        return weeklyCounts.reduce(0, +) / Double(weeklyCounts.count)
     }
 
     /// Working-set count — only sets with a recorded entry, matching the weekly tile.
@@ -204,22 +209,6 @@ struct ExerciseSetsScreen: View {
 
     private func setCountFormatted(for sets: [WorkoutSet]) -> String {
         "\(setCount(for: sets))"
-    }
-
-    /// Percent change of the total set count in the visible chart window versus a comparable window
-    /// before it — the window right before, or the last window with training when that's empty
-    /// (see `exerciseWindowTrendPercentage`). A window with no sets yet reads as down 100% once
-    /// there's any earlier history to fall from; nil only when there's no earlier history at all.
-    private func trendPercentage(in workoutSets: [WorkoutSet]) -> Double? {
-        exerciseWindowTrendPercentage(
-            sets: workoutSets,
-            windowStart: chartScrollPosition,
-            windowSeconds: visibleChartDomainInSeconds,
-            emptyCurrentMeansDecline: true
-        ) { start, end in
-            let inRange = workoutSets.filter { ($0.workout?.date).map { $0 >= start && $0 <= end } ?? false }
-            return inRange.isEmpty ? nil : Double(setCount(for: inRange))
-        }
     }
 
     private func xAxisDateString(for date: Date) -> String {
@@ -287,65 +276,6 @@ struct ExerciseSetsScreen: View {
         }
     }
 
-    // MARK: - Highlights
-
-    @ViewBuilder
-    private var highlightsSection: some View {
-        let ranges = periodRanges()
-        let currentAvg = averageSetsPerWorkout(in: ranges.current)
-        let previousAvg = averageSetsPerWorkout(in: ranges.previous)
-        let headlineKey = exerciseSetsHeadlineKey(isMore: currentAvg >= previousAvg)
-        let unit = "\(NSLocalizedString("sets", comment: ""))/\(NSLocalizedString("workout", comment: ""))"
-
-        HighlightView(
-            headline: NSLocalizedString(headlineKey, comment: ""),
-            currentValue: HighlightView.formatNumber(currentAvg),
-            previousValue: HighlightView.formatNumber(previousAvg),
-            unit: unit,
-            currentNumericValue: currentAvg,
-            previousNumericValue: previousAvg,
-            granularity: chartGranularity == .month ? .month : .year,
-            accentColor: exercise.muscleGroup?.color ?? .accentColor
-        )
-        .padding(.horizontal)
-    }
-
-    private func periodRanges() -> (current: (start: Date, end: Date), previous: (start: Date, end: Date)) {
-        switch chartGranularity {
-        case .month:
-            let current = (Date.now.startOfMonth, Date.now.endOfMonth)
-            let lastStart = Calendar.current.date(byAdding: .month, value: -1, to: .now.startOfMonth)!
-            let previous = (lastStart, lastStart.endOfMonth)
-            return (current, previous)
-        case .year:
-            let current = (Date.now.startOfYear, Date.now.endOfYear)
-            let lastStart = Calendar.current.date(byAdding: .year, value: -1, to: .now.startOfYear)!
-            let previous = (lastStart, lastStart.endOfYear)
-            return (current, previous)
-        }
-    }
-
-    private func averageSetsPerWorkout(in range: (start: Date, end: Date)) -> Double {
-        let s = range.start, e = range.end
-        let setsInRange = workoutSets.filter {
-            guard let d = $0.workout?.date else { return false }
-            return d >= s && d <= e
-        }
-        let totalSets = Double(setCount(for: setsInRange))
-        let workoutsInRange = Set(setsInRange.compactMap { $0.workout }).filter {
-            guard let d = $0.date else { return false }
-            return d >= s && d <= e
-        }
-        let workoutCount = max(workoutsInRange.count, 1)
-        return totalSets / Double(workoutCount)
-    }
-
-    private func exerciseSetsHeadlineKey(isMore: Bool) -> String {
-        switch chartGranularity {
-        case .month: return isMore ? "avgMoreExerciseSetsThisMonthThanLastMonth" : "avgLessExerciseSetsThisMonthThanLastMonth"
-        case .year: return isMore ? "avgMoreExerciseSetsThisYearThanLastYear" : "avgLessExerciseSetsThisYearThanLastYear"
-        }
-    }
 }
 
 private struct PreviewWrapperView: View {

--- a/LOGIT/Features/Exercise/ExerciseDetail/ExerciseVolumeScreen.swift
+++ b/LOGIT/Features/Exercise/ExerciseDetail/ExerciseVolumeScreen.swift
@@ -22,7 +22,13 @@ struct ExerciseVolumeScreen: View {
 
     var body: some View {
         let groupedWorkoutSets = Dictionary(grouping: workoutSets) { $0.workout?.date?.startOfWeek ?? .now }.sorted { $0.key < $1.key }
-        let visibleTrendPercentage = trendPercentage(in: workoutSets)
+        let shownWeeklyAverage = averageWeekly(from: chartScrollPosition, to: visibleEndDate)
+        let recentWeeklyAverage = averageWeekly(from: Exercise.currentBestWindowStart, to: .now)
+        let averageTrendPercentage: Double? = {
+            guard let recent = recentWeeklyAverage, recent > 0,
+                  let shown = shownWeeklyAverage, shown > 0 else { return nil }
+            return (recent - shown) / shown * 100
+        }()
         ScrollView {
             VStack(spacing: SECTION_SPACING) {
                 VStack {
@@ -35,32 +41,23 @@ struct ExerciseVolumeScreen: View {
                 .pickerStyle(.segmented)
                 .padding(.vertical)
                 .padding(.horizontal)
-                HStack {
-                    VStack(alignment: .leading) {
-                        Text(NSLocalizedString("total", comment: ""))
-                            .font(.footnote)
-                            .fontWeight(.semibold)
-                            .textCase(.uppercase)
-                            .foregroundStyle(.secondary)
-                        UnitView(
-                            value: totalVolumeInTimeFrame(workoutSets),
-                            unit: WeightUnit.used.rawValue
-                        )
-                        .foregroundStyle((exercise.muscleGroup?.color ?? .label).gradient)
-                        Text("\(visibleDomainDescription)")
-                            .fontWeight(.bold)
-                            .fontDesign(.rounded)
-                            .foregroundStyle(.secondary)
-                    }
-                    Spacer()
-                    if let visibleTrendPercentage {
-                        TrendIndicatorView(
-                            percentChange: visibleTrendPercentage,
-                            positiveColor: exercise.muscleGroup?.color ?? .label
-                        )
-                        .animation(.snappy, value: visibleTrendPercentage)
-                    }
-                }
+                MetricComparisonView(
+                    leading: .init(
+                        label: NSLocalizedString("average", comment: ""),
+                        value: shownWeeklyAverage.map { formatWeightForDisplay(Int($0.rounded())) } ?? "––",
+                        unit: WeightUnit.used.rawValue,
+                        caption: visibleDomainDescription
+                    ),
+                    trailing: .init(
+                        label: NSLocalizedString("lastFourWeeks", comment: ""),
+                        value: recentWeeklyAverage.map { formatWeightForDisplay(Int($0.rounded())) } ?? "––",
+                        unit: WeightUnit.used.rawValue
+                    ),
+                    trailingValueStyle: AnyShapeStyle((exercise.muscleGroup?.color ?? .label).gradient),
+                    percentChange: averageTrendPercentage,
+                    positiveColor: exercise.muscleGroup?.color ?? .label,
+                    explanation: NSLocalizedString("averageComparisonInfo", comment: "")
+                )
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.horizontal)
                 Chart {
@@ -143,9 +140,6 @@ struct ExerciseVolumeScreen: View {
                 .padding(.trailing, 5)
                 }
                 
-                // MARK: - Highlights Section
-                highlightsSection
-
                 // MARK: - About Section
                 AboutSection(
                     metricTitle: NSLocalizedString("volume", comment: ""),
@@ -194,10 +188,21 @@ struct ExerciseVolumeScreen: View {
         return startDate ... endDate
     }
 
-    private func totalVolumeInTimeFrame(_ workoutSets: [WorkoutSet]) -> String {
-        let endDate = Calendar.current.date(byAdding: .second, value: visibleChartDomainInSeconds, to: chartScrollPosition)!
-        let setsInTimeFrame = workoutSets.filter { $0.workout?.date ?? .distantPast >= chartScrollPosition && $0.workout?.date ?? .distantFuture <= endDate }
-        return volumeFormatted(for: setsInTimeFrame)
+    private var visibleEndDate: Date {
+        Calendar.current.date(byAdding: .second, value: visibleChartDomainInSeconds, to: chartScrollPosition)!
+    }
+
+    /// Mean weekly volume over [from, to] — the average height of the weekly bars in the range, in
+    /// raw units. The reference the header scoreboard compares against; nil with no training in the
+    /// range. Averages only weeks that were trained, so a rest week doesn't drag the bar down.
+    private func averageWeekly(from: Date, to: Date) -> Double? {
+        let weeks = Dictionary(grouping: workoutSets.filter {
+            guard let date = $0.workout?.date else { return false }
+            return date >= from && date <= to
+        }) { $0.workout?.date?.startOfWeek ?? .now }
+        let weeklyVolumes = weeks.values.map { Double(getVolume(of: $0, for: exercise)) }
+        guard !weeklyVolumes.isEmpty else { return nil }
+        return weeklyVolumes.reduce(0, +) / Double(weeklyVolumes.count)
     }
 
     private func volume(for sets: [WorkoutSet]) -> Double {
@@ -206,22 +211,6 @@ struct ExerciseVolumeScreen: View {
     
     private func volumeFormatted(for sets: [WorkoutSet]) -> String {
         formatWeightForDisplay(getVolume(of: sets, for: exercise))
-    }
-
-    /// Percent change of the total volume in the visible chart window versus a comparable window
-    /// before it — the window right before, or the last window with training when that's empty
-    /// (see `exerciseWindowTrendPercentage`). A window with no volume yet reads as down 100% once
-    /// there's any earlier history to fall from; nil only when there's no earlier history at all.
-    private func trendPercentage(in workoutSets: [WorkoutSet]) -> Double? {
-        exerciseWindowTrendPercentage(
-            sets: workoutSets,
-            windowStart: chartScrollPosition,
-            windowSeconds: visibleChartDomainInSeconds,
-            emptyCurrentMeansDecline: true
-        ) { start, end in
-            let inRange = workoutSets.filter { ($0.workout?.date).map { $0 >= start && $0 <= end } ?? false }
-            return inRange.isEmpty ? nil : Double(getVolume(of: inRange, for: exercise))
-        }
     }
 
     private func xAxisDateString(for date: Date) -> String {
@@ -289,65 +278,6 @@ struct ExerciseVolumeScreen: View {
         }
     }
 
-    // MARK: - Highlights
-
-    @ViewBuilder
-    private var highlightsSection: some View {
-        let ranges = periodRanges()
-        let currentAvg = averageVolumePerWorkout(in: ranges.current)
-        let previousAvg = averageVolumePerWorkout(in: ranges.previous)
-        let headlineKey = exerciseVolumeHeadlineKey(isMore: currentAvg >= previousAvg)
-        let unit = "\(WeightUnit.used.rawValue)/\(NSLocalizedString("workout", comment: ""))"
-
-        HighlightView(
-            headline: NSLocalizedString(headlineKey, comment: ""),
-            currentValue: HighlightView.formatNumber(currentAvg),
-            previousValue: HighlightView.formatNumber(previousAvg),
-            unit: unit,
-            currentNumericValue: currentAvg,
-            previousNumericValue: previousAvg,
-            granularity: chartGranularity == .month ? .month : .year,
-            accentColor: exercise.muscleGroup?.color ?? .accentColor
-        )
-        .padding(.horizontal)
-    }
-
-    private func periodRanges() -> (current: (start: Date, end: Date), previous: (start: Date, end: Date)) {
-        switch chartGranularity {
-        case .month:
-            let current = (Date.now.startOfMonth, Date.now.endOfMonth)
-            let lastStart = Calendar.current.date(byAdding: .month, value: -1, to: .now.startOfMonth)!
-            let previous = (lastStart, lastStart.endOfMonth)
-            return (current, previous)
-        case .year:
-            let current = (Date.now.startOfYear, Date.now.endOfYear)
-            let lastStart = Calendar.current.date(byAdding: .year, value: -1, to: .now.startOfYear)!
-            let previous = (lastStart, lastStart.endOfYear)
-            return (current, previous)
-        }
-    }
-
-    private func averageVolumePerWorkout(in range: (start: Date, end: Date)) -> Double {
-        let s = range.start, e = range.end
-        let setsInRange = workoutSets.filter {
-            guard let d = $0.workout?.date else { return false }
-            return d >= s && d <= e
-        }
-        let totalVolume = convertWeightForDisplayingDecimal(getVolume(of: setsInRange, for: exercise))
-        let workoutsInRange = Set(setsInRange.compactMap { $0.workout }).filter {
-            guard let d = $0.date else { return false }
-            return d >= s && d <= e
-        }
-        let workoutCount = max(workoutsInRange.count, 1)
-        return totalVolume / Double(workoutCount)
-    }
-
-    private func exerciseVolumeHeadlineKey(isMore: Bool) -> String {
-        switch chartGranularity {
-        case .month: return isMore ? "avgMoreExerciseVolumeThisMonthThanLastMonth" : "avgLessExerciseVolumeThisMonthThanLastMonth"
-        case .year: return isMore ? "avgMoreExerciseVolumeThisYearThanLastYear" : "avgLessExerciseVolumeThisYearThanLastYear"
-        }
-    }
 }
 
 private struct PreviewWrapperView: View {

--- a/LOGIT/Features/Exercise/ExerciseDetail/ExerciseWeightScreen.swift
+++ b/LOGIT/Features/Exercise/ExerciseDetail/ExerciseWeightScreen.swift
@@ -28,7 +28,6 @@ struct ExerciseWeightScreen: View {
         // Determine the snapped selected set only when a selection exists; snap to the nearest datapoint (prefer visible)
         let snappedSelectedSet: WorkoutSet? = selectedDate != nil ? nearestSet(to: selectedDate, in: allDailyMaxSets) : nil
         let bestVisibleWeight = bestWeightInGranularity(workoutSets)
-        let visibleTrendPercentage = trendPercentage(in: workoutSets)
         ScrollView {
             VStack(spacing: SECTION_SPACING) {
                 VStack {
@@ -41,35 +40,24 @@ struct ExerciseWeightScreen: View {
             .pickerStyle(.segmented)
             .padding(.vertical)
             .padding(.horizontal)
-            HStack {
-                VStack(alignment: .leading) {
-                    if isShowingCurrentBestWindow {
-                        CurrentBestLabel(uppercased: true)
-                    } else {
-                        Text(NSLocalizedString("best", comment: ""))
-                            .font(.footnote)
-                            .fontWeight(.medium)
-                            .textCase(.uppercase)
-                            .foregroundStyle(.secondary)
-                    }
-                    UnitView(
-                        value: "\(bestVisibleWeight != nil ? formatWeightForDisplay(bestVisibleWeight!) : "––")",
-                        unit: WeightUnit.used.rawValue
-                    )
-                    .foregroundStyle(exerciseMuscleGroupColor.gradient)
-                    Text(chartHeaderTitle)
-                        .fontWeight(.bold)
-                        .foregroundStyle(.secondary)
-                }
-                Spacer()
-                if let visibleTrendPercentage {
-                    TrendIndicatorView(
-                        percentChange: visibleTrendPercentage,
-                        positiveColor: exerciseMuscleGroupColor
-                    )
-                    .animation(.snappy, value: visibleTrendPercentage)
-                }
-            }
+            MetricComparisonView(
+                leading: .init(
+                    label: NSLocalizedString("previousBest", comment: ""),
+                    value: bestVisibleWeight.map(formatWeightForDisplay) ?? "––",
+                    unit: WeightUnit.used.rawValue,
+                    caption: chartHeaderTitle
+                ),
+                trailing: .init(
+                    label: NSLocalizedString("currentBest", comment: ""),
+                    value: currentBestAnchor.map { formatWeightForDisplay($0.value) } ?? "––",
+                    unit: WeightUnit.used.rawValue,
+                    caption: currentBestAnchor?.date.map { $0.formatted(.dateTime.day().month()) }
+                ),
+                trailingValueStyle: AnyShapeStyle(exerciseMuscleGroupColor.gradient),
+                percentChange: headerTrendPercentage(visibleBest: bestVisibleWeight),
+                positiveColor: exerciseMuscleGroupColor,
+                explanation: NSLocalizedString("currentBestComparisonInfo", comment: "")
+            )
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.horizontal)
             Chart {
@@ -213,9 +201,6 @@ struct ExerciseWeightScreen: View {
                 .padding(.trailing, 5)
                 }
                 
-                // MARK: - Highlights Section
-                highlightsSection(allDailyMaxSets: allDailyMaxSets)
-
                 // MARK: - About Section
                 AboutSection(
                     metricTitle: NSLocalizedString("weight", comment: ""),
@@ -329,17 +314,17 @@ struct ExerciseWeightScreen: View {
         )
     }
 
+    /// The header's left value and the comparison baseline: the best max-weight in the visible window
+    /// *other than* the current best, so the pill measures the current best against the rest of the
+    /// shown period rather than itself when the peak is in view. Falls back to the most recent day's
+    /// best before the window when it holds no other value (see `exerciseOtherBestBaseline`).
     private func bestWeightInGranularity(_ workoutSets: [WorkoutSet]) -> Int? {
-        let endDate = Calendar.current.date(byAdding: .second, value: visibleChartDomainInSeconds, to: chartScrollPosition)!
-        let setsInTimeFrame = workoutSets.filter { $0.workout?.date ?? .distantPast >= chartScrollPosition && $0.workout?.date ?? .distantFuture <= endDate }
-
-        guard !setsInTimeFrame.isEmpty else {
-            return workoutSets.first?.maximum(.weight, for: exercise)
-        }
-
-        return setsInTimeFrame
-            .map { $0.maximum(.weight, for: exercise) }
-            .max()
+        exerciseOtherBestBaseline(
+            sets: workoutSets,
+            windowStart: chartScrollPosition,
+            windowEnd: visibleEndDate,
+            currentBestDay: currentBestAnchor?.date
+        ) { $0.maximum(.weight, for: exercise) }
     }
 
     private func chartYScaleMax(maxYValue: Int) -> Int {
@@ -348,33 +333,25 @@ struct ExerciseWeightScreen: View {
         return nextBiggerYAxisMaxValue ?? maxYValue
     }
 
-    /// Percent change of the best weight in the visible chart window versus the
-    /// equal-length window immediately before it. Nil when either window has no data.
-    private func trendPercentage(in workoutSets: [WorkoutSet]) -> Double? {
-        exerciseWindowTrendPercentage(
-            sets: workoutSets,
-            windowStart: chartScrollPosition,
-            windowSeconds: visibleChartDomainInSeconds
-        ) { start, end in
-            workoutSets
-                .filter { ($0.workout?.date).map { $0 >= start && $0 <= end } ?? false }
-                .map { $0.maximum(.weight, for: exercise) }
-                .max()
-                .map(Double.init)
-        }
+    /// The exercise's current best (highest max-weight in the last four weeks) and the day it was
+    /// reached — the fixed right-hand anchor of the header scoreboard, independent of scroll.
+    private var currentBestAnchor: (value: Int, date: Date?)? {
+        guard let best = exercise.currentBestSet(for: .weight, in: workoutSets) else { return nil }
+        return (best.maximum(.weight, for: exercise), best.workout?.date)
+    }
+
+    /// The header pill: the current best measured against the best in the shown window. Nil when
+    /// either side is empty, so the pill drops out only when there is genuinely nothing to compare.
+    private func headerTrendPercentage(visibleBest: Int?) -> Double? {
+        guard let current = currentBestAnchor?.value, current > 0,
+              let visible = visibleBest, visible > 0 else { return nil }
+        return (Double(current) - Double(visible)) / Double(visible) * 100
     }
 
     // MARK: - Selection helpers
 
     private var visibleEndDate: Date {
         Calendar.current.date(byAdding: .second, value: visibleChartDomainInSeconds, to: chartScrollPosition)!
-    }
-
-    /// True while the month view sits at its newest scroll position (the default), where the
-    /// visible window's best IS the exercise's current best — the header label says so then, with
-    /// the info popover explaining the term.
-    private var isShowingCurrentBestWindow: Bool {
-        chartGranularity == .month && visibleEndDate >= .now
     }
 
     private func nearestSet(to date: Date?, in sets: [WorkoutSet]) -> WorkoutSet? {
@@ -392,59 +369,6 @@ struct ExerciseWeightScreen: View {
         }
     }
 
-    // MARK: - Highlights
-
-    @ViewBuilder
-    private func highlightsSection(allDailyMaxSets: [WorkoutSet]) -> some View {
-        let ranges = periodRanges()
-        let currentMax = maxWeight(in: ranges.current, sets: allDailyMaxSets)
-        let previousMax = maxWeight(in: ranges.previous, sets: allDailyMaxSets)
-        let headlineKey = weightHeadlineKey(isHigher: currentMax >= previousMax)
-        let unit = WeightUnit.used.rawValue
-
-        HighlightView(
-            headline: NSLocalizedString(headlineKey, comment: ""),
-            currentValue: currentMax > 0 ? formatWeightForDisplay(currentMax) : "––",
-            previousValue: previousMax > 0 ? formatWeightForDisplay(previousMax) : "––",
-            unit: unit,
-            currentNumericValue: Double(convertWeightForDisplaying(currentMax)),
-            previousNumericValue: Double(convertWeightForDisplaying(previousMax)),
-            granularity: chartGranularity == .month ? .month : .year,
-            accentColor: exerciseMuscleGroupColor
-        )
-        .padding(.horizontal)
-    }
-
-    private func periodRanges() -> (current: (start: Date, end: Date), previous: (start: Date, end: Date)) {
-        switch chartGranularity {
-        case .month:
-            let current = (Date.now.startOfMonth, Date.now.endOfMonth)
-            let lastStart = Calendar.current.date(byAdding: .month, value: -1, to: .now.startOfMonth)!
-            let previous = (lastStart, lastStart.endOfMonth)
-            return (current, previous)
-        case .year:
-            let current = (Date.now.startOfYear, Date.now.endOfYear)
-            let lastStart = Calendar.current.date(byAdding: .year, value: -1, to: .now.startOfYear)!
-            let previous = (lastStart, lastStart.endOfYear)
-            return (current, previous)
-        }
-    }
-
-    private func maxWeight(in range: (start: Date, end: Date), sets: [WorkoutSet]) -> Int {
-        let s = range.start, e = range.end
-        let setsInRange = sets.filter {
-            guard let d = $0.workout?.date else { return false }
-            return d >= s && d <= e
-        }
-        return setsInRange.map { $0.maximum(.weight, for: exercise) }.max() ?? 0
-    }
-
-    private func weightHeadlineKey(isHigher: Bool) -> String {
-        switch chartGranularity {
-        case .month: return isHigher ? "higherMaxWeightThisMonthThanLastMonth" : "lowerMaxWeightThisMonthThanLastMonth"
-        case .year: return isHigher ? "higherMaxWeightThisYearThanLastYear" : "lowerMaxWeightThisYearThanLastYear"
-        }
-    }
 }
 
 private struct PreviewWrapperView: View {

--- a/LOGIT/Features/Exercise/ExerciseDetail/Tiles/ExerciseMetricTile.swift
+++ b/LOGIT/Features/Exercise/ExerciseDetail/Tiles/ExerciseMetricTile.swift
@@ -21,9 +21,11 @@ struct ExerciseTileTrend {
     /// Best value within the current-best window (see `Exercise.currentBestWindowStart`) — the
     /// value the tile displays. Nil when no set in the window has a usable value.
     let currentBest: Int?
-    /// Percent change of the last execution (the most recent training day's best) over the
-    /// execution before it — "how last time went versus the time before". Nil while the exercise is
-    /// lapsed or has fewer than two executions to compare; the pill is hidden then.
+    /// Percent change of the current best over the *previous* current best — the best value in the
+    /// four weeks before the day the current best was reached (sliding back to the most recent
+    /// earlier window with data after a gap). "How much better your peak is than it used to be."
+    /// Nil only while the exercise is lapsed, or the current best is a first-ever execution with
+    /// nothing before it to compare; the pill is hidden then.
     let percentChange: Double?
     /// True while the current best *is* the all-time best — "you're at your peak right now".
     /// Requires a usable value from before the window: with no older history there is no record
@@ -40,39 +42,66 @@ struct ExerciseTileTrend {
         var currentMax = 0
         var allTimeMax = 0
         var hasValueBeforeWindow = false
-        // Best value per training day — one day is one "execution", used for the day-over-day pill.
-        var bestByDay: [Date: Int] = [:]
+        // The day the current best was first reached — the anchor the previous-best window sits
+        // before. Tracked as the earliest day at the peak so a later equal day can't hide the climb.
+        var currentBestDate: Date?
         for workoutSet in sets {
             let setValue = value(workoutSet)
             guard setValue > 0 else { continue }
             allTimeMax = max(allTimeMax, setValue)
             let date = workoutSet.workout?.date ?? .distantPast
             if date >= windowStart {
-                currentMax = max(currentMax, setValue)
+                let day = calendar.startOfDay(for: date)
+                if setValue > currentMax {
+                    currentMax = setValue
+                    currentBestDate = day
+                } else if setValue == currentMax, let best = currentBestDate, day < best {
+                    currentBestDate = day
+                }
             } else {
                 hasValueBeforeWindow = true
             }
-            let day = calendar.startOfDay(for: date)
-            bestByDay[day] = max(bestByDay[day] ?? 0, setValue)
         }
 
         currentBest = currentMax > 0 ? currentMax : nil
         allTimeBest = allTimeMax > 0 ? allTimeMax : nil
         isAtAllTimeBest = currentMax > 0 && hasValueBeforeWindow && currentMax == allTimeMax
 
-        // Trend pill: the last execution (most recent training day's best) versus the execution
-        // before it — "how last time went versus the time before". Shown only while the exercise is
-        // active (a value in the current-best window); a lapsed exercise keeps its "time since"
-        // pill instead. Needs two executions to compare.
-        let executions = bestByDay.keys.sorted()
-        if currentMax > 0, executions.count >= 2,
-           let last = bestByDay[executions[executions.count - 1]],
-           let previous = bestByDay[executions[executions.count - 2]],
-           previous > 0 {
-            percentChange = (Double(last) - Double(previous)) / Double(previous) * 100
+        // Trend pill: the current best versus the previous current best — the best in the four weeks
+        // before it was reached. A lapsed exercise (no current best) keeps its "time since" pill
+        // instead; a first-ever best with nothing before it has nothing to compare and shows none.
+        if currentMax > 0, let anchor = currentBestDate,
+           let previousBest = Self.previousBest(before: anchor, sets: sets, value: value) {
+            percentChange = (Double(currentMax) - Double(previousBest)) / Double(previousBest) * 100
         } else {
             percentChange = nil
         }
+    }
+
+    /// The previous current best: the highest value in the month before `anchor` (the day the
+    /// current best was reached), excluding that day. When that month holds no training, slides back
+    /// to the most recent earlier session and takes the month ending at it, so a gap before the
+    /// current best doesn't erase the comparison — the tiles' sibling of the chart screens'
+    /// `exerciseWindowTrendPercentage` slide-back. Nil only with no earlier history at all.
+    private static func previousBest(before anchor: Date, sets: [WorkoutSet], value: (WorkoutSet) -> Int) -> Int? {
+        let calendar = Calendar.current
+        let windowStart = calendar.date(byAdding: .month, value: -1, to: anchor) ?? anchor
+        let inWindow = sets.filter {
+            let date = $0.workout?.date ?? .distantPast
+            return date >= windowStart && date < anchor
+        }
+        if let best = inWindow.map(value).filter({ $0 > 0 }).max() { return best }
+        // The month before the current best was empty: slide back to the most recent earlier
+        // session and take the month ending at it.
+        guard let lastPrior = sets.compactMap({ $0.workout?.date }).filter({ $0 < windowStart }).max() else {
+            return nil
+        }
+        let slideStart = calendar.date(byAdding: .month, value: -1, to: lastPrior) ?? lastPrior
+        let slid = sets.filter {
+            let date = $0.workout?.date ?? .distantPast
+            return date >= slideStart && date <= lastPrior
+        }
+        return slid.map(value).filter { $0 > 0 }.max()
     }
 }
 
@@ -116,152 +145,36 @@ func exerciseWindowTrendPercentage(
     return (current - baseline) / baseline * 100
 }
 
-// MARK: - Tile Skeleton
-
-/// Shared skeleton of the exercise-detail metric tiles — the in-workout popover's column anatomy
-/// at tile size: title row with the trend pill top-right (where the navigation chevron used to
-/// sit; like the popover, the content itself is the invitation to tap), the metric's label over
-/// its large value in the muscle-group tint, and the chart beneath running the full tile width.
-/// One skeleton for every tile so tiles sharing a grid row always come out the same height.
-struct ExerciseMetricTileLayout<ChartContent: View>: View {
-    enum Label {
-        case currentBest
-        case plain(String)
-        /// A plain label with an info button explaining the value — `CurrentBestLabel`'s anatomy
-        /// with free-form texts; the workout stat tiles explain their comparison basis this way.
-        case info(String, explanation: String)
+/// The exercise chart headers' comparison baseline: the best value in the visible window *other than*
+/// the current best, so the header pill measures the current best against the rest of the shown
+/// period instead of against itself when the peak is on screen. `currentBestDay` — the day the
+/// current best was reached — is excluded from the window. When the window holds no other value, the
+/// baseline falls back to the most recent day's best before it; nil only when there's nothing earlier
+/// to compare against either. `value` extracts the per-set metric (a max for these screens).
+func exerciseOtherBestBaseline(
+    sets: [WorkoutSet],
+    windowStart: Date,
+    windowEnd: Date,
+    currentBestDay: Date?,
+    value: (WorkoutSet) -> Int
+) -> Int? {
+    let calendar = Calendar.current
+    let otherInWindow = sets.filter { set in
+        guard let date = set.workout?.date, date >= windowStart, date <= windowEnd else { return false }
+        if let currentBestDay, calendar.isDate(date, inSameDayAs: currentBestDay) { return false }
+        return value(set) > 0
     }
-
-    @EnvironmentObject private var purchaseManager: PurchaseManager
-
-    let title: String
-    let label: Label
-    /// Nil renders the "––" placeholder.
-    let value: String?
-    let unit: String
-    let color: Color
-    let percentChange: Double?
-    let isRecord: Bool
-    /// Gates the tile's data — pill, label, value, and chart — behind Pro (blur + compact crown;
-    /// the full capsule doesn't fit a half-width tile). The title stays readable so a locked tile
-    /// still says what it is. Mirrors the in-workout panel's gating: repetitions is the free
-    /// metric, everything else is Pro data.
-    var requiresPro: Bool = false
-    /// Style of the value text. Defaults to `color.gradient`; the workout stat tiles pass
-    /// `Color.label` for a plain label-colored value (their muscle tint moves to the trend pill).
-    var valueStyle: AnyShapeStyle? = nil
-    /// Color for the unit alone, overriding `valueStyle` for it — the workout stat tiles render a
-    /// label-colored value with a muted unit. Nil lets the unit inherit the value style (the
-    /// exercise tiles' muscle-tinted unit).
-    var unitColor: Color? = nil
-    /// Style for the trend pill's positive tint, overriding `color` — the workout stat tiles pass
-    /// the workout's muscle-group gradient. Nil keeps the pill tinted in `color`.
-    var trendStyle: AnyShapeStyle? = nil
-    /// Last session this tile's metric has a value from, when that session is older than the
-    /// current-best window. Renders the gray "time since" capsule in the trend pill's slot, so a
-    /// paused exercise says so at a glance instead of impersonating an active one.
-    var lapsedSince: Date? = nil
-    /// Swaps label, value, and chart for the centered ghost placeholder — for tiles whose metric
-    /// has no usable data at all (the weight tiles of a bodyweight exercise). The stats block
-    /// keeps rendering hidden underneath so the tile stays exactly as tall as its row neighbor.
-    var showsEmptyPlaceholder: Bool = false
-    @ViewBuilder let chart: () -> ChartContent
-
-    private var locksData: Bool { requiresPro && !purchaseManager.hasUnlockedPro }
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            HStack {
-                Text(title)
-                    .font(.subheadline.weight(.semibold))
-                    .foregroundStyle(Color.label)
-                    .lineLimit(1)
-                    // Next to a wide pill ("↓ 58 %", "vor 2 Mon.") a long title ("Satzvolumen")
-                    // comes up short of its space — shrink it rather than ellipsize.
-                    .minimumScaleFactor(0.7)
-                Spacer(minLength: 6)
-                // The hidden trend pill is the row's height ruler in every state — with a shorter
-                // lapsed pill or no pill at all, the tile would otherwise end up shorter than its
-                // row neighbor.
-                ZStack(alignment: .trailing) {
-                    TrendIndicatorView(percentChange: 0, positiveColor: color, positiveStyle: trendStyle)
-                        .hidden()
-                    if let percentChange, !locksData {
-                        TrendIndicatorView(
-                            percentChange: percentChange,
-                            positiveColor: color,
-                            positiveStyle: trendStyle,
-                            isRecord: isRecord
-                        )
-                    } else if let lapsedSince, !showsEmptyPlaceholder {
-                        TileLapsedPill(date: lapsedSince)
-                    }
-                }
-            }
-            if showsEmptyPlaceholder {
-                ZStack {
-                    statsBlock.hidden()
-                    VStack(spacing: 10) {
-                        GhostSparkline(color: color)
-                            .frame(width: 90, height: 30)
-                        Text(NSLocalizedString("noData", comment: ""))
-                            .font(.footnote.weight(.semibold))
-                            .foregroundStyle(.tertiary)
-                    }
-                    .frame(maxWidth: .infinity)
-                }
-            } else {
-                statsBlock
-                    .isBlockedWithoutPro(requiresPro, style: .compact)
-            }
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(CELL_PADDING)
-        .tileStyle()
+    if let best = otherInWindow.map(value).max(), best > 0 { return best }
+    // No other value in the shown window: the most recent day's best before it.
+    let prior = sets.filter { set in
+        guard let date = set.workout?.date, date < windowStart else { return false }
+        return value(set) > 0
     }
-
-    private var statsBlock: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            Group {
-                switch label {
-                case .currentBest:
-                    CurrentBestLabel()
-                case let .plain(text):
-                    Text(text)
-                        .font(.footnote)
-                        .fontWeight(.semibold)
-                        .foregroundStyle(.secondary)
-                case let .info(text, explanation):
-                    MetricTileInfoLabel(text: text, explanation: explanation)
-                }
-            }
-            .padding(.top, 8)
-            UnitView(value: value ?? "––", unit: unit, configuration: .large, unitColor: unitColor)
-                .foregroundStyle(valueStyle ?? AnyShapeStyle(color.gradient))
-                .padding(.top, 2)
-            chart()
-                .padding(.top, 8)
-        }
-    }
-}
-
-/// The gray "time since the last session" capsule in the trend pill's slot on lapsed tiles —
-/// the trend pill's anatomy (icon + rounded bold text on a 0.15 fill) with the history icon and
-/// a relative date, so the stale state is visible right where the trend usually lives. A size
-/// softer than the trend pill: it's quiet metadata, not a score.
-private struct TileLapsedPill: View {
-    let date: Date
-
-    var body: some View {
-        ProgressIndicatorPill(symbol: "clock.arrow.circlepath", color: .secondary, size: .compact) {
-            Text(date, format: .relative(presentation: .numeric, unitsStyle: .narrow))
-                .font(.system(.caption2, design: .rounded, weight: .bold))
-        }
-        // The pill never compresses or wraps — the title next to it shrinks instead.
-        .fixedSize()
-        .accessibilityElement(children: .ignore)
-        .accessibilityLabel(Text(date, format: .relative(presentation: .named)))
-    }
+    guard let lastDate = prior.compactMap({ $0.workout?.date }).max() else { return nil }
+    return prior
+        .filter { calendar.isDate($0.workout?.date ?? .distantPast, inSameDayAs: lastDate) }
+        .map(value)
+        .max()
 }
 
 // MARK: - Ghost Sparkline
@@ -339,9 +252,10 @@ struct ExerciseTileSparkline: View {
         /// empty. An empty month would render as nothing but the dashed carry-forward line;
         /// showing the sessions the personal best comes from tells a story instead.
         case recentHistory
-        /// The exercise's entire history, first session to last. The line drops its per-point
-        /// dots (too many to read) and marks only the highest point, so the all-time best stands
-        /// out as the crest of the whole story — used on the personal-records screen.
+        /// The exercise's entire history, first session to last, as a single clean line — no
+        /// per-session dots and no crest marker, just the smooth arc. It spans the full width edge
+        /// to edge and skips the leading fade, so the curve reads end to end. Used on the
+        /// personal-records cards, where it bleeds to the card's borders beneath the scoreboard.
         case allTime
     }
 
@@ -356,10 +270,11 @@ struct ExerciseTileSparkline: View {
     /// How many sessions the recent-history window shows.
     private static let recentHistoryCount = 6
 
-    /// Trailing edge ~2 days past the last shown moment so the latest point's symbol clears the
-    /// right edge — the chart is `.clipped()` with no trailing fade, and a point on the edge
-    /// would be sliced in half.
-    private var domain: ClosedRange<Date> {
+    /// The chart's x-domain. Windowed sparklines push the trailing edge ~2 days past the last shown
+    /// moment so the latest point's symbol clears the right edge (they are `.clipped()` with no
+    /// trailing fade, and a point on the edge would be sliced in half). The all-time line carries no
+    /// symbols to protect, so it fills the width exactly — first session to last, edge to edge.
+    private func xDomain() -> ClosedRange<Date> {
         let margin: (Date) -> Date = { Calendar.current.date(byAdding: .day, value: 2, to: $0) ?? $0 }
         switch window {
         case .currentBest:
@@ -372,11 +287,14 @@ struct ExerciseTileSparkline: View {
             let lead = Calendar.current.date(byAdding: .day, value: -2, to: first) ?? first
             return lead ... margin(last)
         case .allTime:
-            guard let first = points.first?.date, let last = points.last?.date else {
-                return Exercise.currentBestWindowStart ... margin(.now)
+            guard let first = points.first?.date, let last = points.last?.date, first < last else {
+                // A single session: center it on a one-day window so the line has somewhere to sit.
+                let anchor = points.first?.date ?? .now
+                let lead = Calendar.current.date(byAdding: .day, value: -1, to: anchor) ?? anchor
+                let trail = Calendar.current.date(byAdding: .day, value: 1, to: anchor) ?? anchor
+                return lead ... trail
             }
-            let lead = Calendar.current.date(byAdding: .day, value: -2, to: first) ?? first
-            return lead ... margin(last)
+            return first ... last
         }
     }
 
@@ -385,32 +303,30 @@ struct ExerciseTileSparkline: View {
         // Over a long span catmullRom waggles between sessions; monotone keeps the all-time line a
         // clean trend that never overshoots its own crest.
         let interpolation: InterpolationMethod = window == .allTime ? .monotone : .catmullRom
-        // The all-time window dots only its crest (the rest would be a cluttered string of points);
-        // the shorter windows dot every session.
-        let recordPoint = window == .allTime ? points.max(by: { $0.value < $1.value }) : nil
-        let chart = Chart {
+        let base = Chart {
             tileSparklineMarks(
                 points: points,
                 color: color,
                 interpolation: interpolation,
+                // The all-time line is a single clean curve — no per-session dots, no crest marker.
+                // The windowed sparklines keep a dot per session.
                 showsSymbols: window != .allTime,
-                showsCarryForward: window == .currentBest,
-                recordPoint: recordPoint
+                showsCarryForward: window == .currentBest
             )
         }
-        .chartXScale(domain: domain)
+        .chartXScale(domain: xDomain())
         .chartYScale(domain: 0 ... max(maxValue * 1.15, 1))
         .chartXAxis {}
         .chartYAxis {}
         .frame(maxWidth: .infinity)
         .frame(height: height)
-        .clipped()
-        // The all-time window's whole point is to show the start of the history — a leading fade
-        // would swallow it, so it draws edge to edge; the windowed sparklines fade in.
+        // The all-time window spans the full width and skips `.clipped()` and the leading fade — its
+        // whole point is to show where the history begins and ends. The windowed sparklines clip and
+        // fade in from the left.
         if window == .allTime {
-            chart
+            base
         } else {
-            chart.tileSparklineFadeMask()
+            base.clipped().tileSparklineFadeMask()
         }
     }
 }
@@ -426,7 +342,7 @@ struct ExerciseBestMetricTile: View {
     let workoutSets: [WorkoutSet]
     let title: String
     let unit: String
-    /// Pro-gates the tile's data (see `ExerciseMetricTileLayout.requiresPro`).
+    /// Pro-gates the tile's data (see `MetricTile.requiresPro`).
     var requiresPro: Bool = false
     /// The metric's base value of a single set, in raw storage units (grams for weights).
     let metricValue: (WorkoutSet) -> Int
@@ -444,12 +360,13 @@ struct ExerciseBestMetricTile: View {
         // fall back to the all-time personal best over the last sessions' chart (with the
         // "time since" capsule in the pill slot) instead of a "––" floating above an empty month.
         let isLapsed = trend.currentBest == nil && trend.allTimeBest != nil
-        ExerciseMetricTileLayout(
+        MetricTile(
             title: title,
             label: isLapsed ? .plain(NSLocalizedString("personalBest", comment: "")) : .currentBest,
             value: (trend.currentBest ?? trend.allTimeBest).map(formattedValue),
             unit: unit,
-            color: color,
+            accent: AnyShapeStyle(color),
+            accentColor: color,
             percentChange: trend.percentChange,
             isRecord: trend.isAtAllTimeBest,
             requiresPro: requiresPro,
@@ -459,7 +376,8 @@ struct ExerciseBestMetricTile: View {
             ExerciseTileSparkline(
                 points: points,
                 color: color,
-                window: isLapsed ? .recentHistory : .currentBest
+                window: isLapsed ? .recentHistory : .currentBest,
+                height: CompactChartFrame.height
             )
         }
     }
@@ -533,37 +451,6 @@ struct CurrentBestLabel: View {
             }
             .popover(isPresented: $isShowingInfo) {
                 Text(NSLocalizedString("currentBestInfo", comment: ""))
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
-                    .padding()
-                    .frame(width: 300)
-                    .presentationCompactAdaptation(.popover)
-            }
-        }
-        .font(.footnote)
-        .foregroundStyle(.secondary)
-    }
-}
-
-/// Backs `ExerciseMetricTileLayout.Label.info` — `CurrentBestLabel`'s text + info-dot anatomy with
-/// the texts supplied by the tile (the workout stat tiles explain their comparison basis here).
-private struct MetricTileInfoLabel: View {
-    let text: String
-    let explanation: String
-    @State private var isShowingInfo = false
-
-    var body: some View {
-        HStack(spacing: 4) {
-            Text(text)
-                .fontWeight(.semibold)
-            Button {
-                isShowingInfo = true
-            } label: {
-                Image(systemName: "info.circle")
-            }
-            .popover(isPresented: $isShowingInfo) {
-                Text(explanation)
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)

--- a/LOGIT/Features/Exercise/ExerciseDetail/Tiles/ExerciseSetsTile.swift
+++ b/LOGIT/Features/Exercise/ExerciseDetail/Tiles/ExerciseSetsTile.swift
@@ -38,7 +38,8 @@ struct ExerciseSetsTile: View {
         // ever over the last trained weeks' bars — mirrors the Volume tile's lapsed state instead
         // of a "0" floating above an empty chart.
         let isLapsed = !weeklySets.isEmpty && !weeklySets.contains { $0.week >= chartStartDate }
-        ExerciseMetricTileLayout(
+        let muscleColor = exercise.muscleGroup?.color ?? .accentColor
+        MetricTile(
             title: NSLocalizedString("sets", comment: ""),
             label: .plain(NSLocalizedString(isLapsed ? "personalBest" : "thisWeek", comment: "")),
             value: weeklySets.isEmpty
@@ -47,7 +48,8 @@ struct ExerciseSetsTile: View {
             // A count needs no unit — the title ("Sets") and label ("This Week") carry the meaning,
             // and an empty unit renders as nothing through UnitView.
             unit: "",
-            color: exercise.muscleGroup?.color ?? .accentColor,
+            accent: AnyShapeStyle(muscleColor),
+            accentColor: muscleColor,
             // This week against the baseline. With a real baseline but nothing logged this week yet,
             // that's a genuine "down 100%" — zero work, not missing data — so the pill says so rather
             // than disappearing. A fully lapsed exercise keeps its "time since" pill (lapsedSince).
@@ -87,7 +89,7 @@ struct ExerciseSetsTile: View {
                 )
                 .foregroundStyle(
                     highlightedWeek.map({ Calendar.current.isDate(weeklySet.week, equalTo: $0, toGranularity: .weekOfYear) }) == true
-                        ? (exercise.muscleGroup?.color ?? Color.label) : Color.fill
+                        ? (exercise.muscleGroup?.color ?? .accentColor) : Color.fill
                 )
                 .tileBarStyle()
             }
@@ -95,8 +97,6 @@ struct ExerciseSetsTile: View {
         .chartXScale(domain: domainStart ... domainEnd)
         .chartXAxis {}
         .chartYAxis {}
-        .frame(maxWidth: .infinity)
-        .frame(height: 62)
     }
 
     private var chartStartDate: Date {

--- a/LOGIT/Features/Exercise/ExerciseDetail/Tiles/ExerciseVolumeTile.swift
+++ b/LOGIT/Features/Exercise/ExerciseDetail/Tiles/ExerciseVolumeTile.swift
@@ -38,14 +38,16 @@ struct ExerciseVolumeTile: View {
         // week ever over the last trained weeks' bars — mirrors the best-value tiles' lapsed
         // state, instead of a "0" floating above an empty chart.
         let isLapsed = !weeklyVolumes.isEmpty && !weeklyVolumes.contains { $0.week >= chartStartDate }
-        ExerciseMetricTileLayout(
+        let muscleColor = exercise.muscleGroup?.color ?? .accentColor
+        MetricTile(
             title: NSLocalizedString("volume", comment: ""),
             label: .plain(NSLocalizedString(isLapsed ? "personalBest" : "thisWeek", comment: "")),
             value: weeklyVolumes.isEmpty
                 ? nil
                 : formatWeightForDisplay(isLapsed ? weeklyVolumes.map(\.volume).max() ?? 0 : thisWeekVolume),
             unit: WeightUnit.used.rawValue,
-            color: exercise.muscleGroup?.color ?? .accentColor,
+            accent: AnyShapeStyle(muscleColor),
+            accentColor: muscleColor,
             // This week against the baseline. With a real baseline but nothing logged this week yet,
             // that's a genuine "down 100%" — zero work, not missing data — so the pill says so rather
             // than disappearing. A fully lapsed exercise keeps its "time since" pill (lapsedSince).
@@ -85,7 +87,7 @@ struct ExerciseVolumeTile: View {
                 )
                 .foregroundStyle(
                     highlightedWeek.map({ Calendar.current.isDate(weeklyVolume.week, equalTo: $0, toGranularity: .weekOfYear) }) == true
-                        ? (exercise.muscleGroup?.color ?? Color.label) : Color.fill
+                        ? (exercise.muscleGroup?.color ?? .accentColor) : Color.fill
                 )
                 .tileBarStyle()
             }
@@ -93,8 +95,6 @@ struct ExerciseVolumeTile: View {
         .chartXScale(domain: domainStart ... domainEnd)
         .chartXAxis {}
         .chartYAxis {}
-        .frame(maxWidth: .infinity)
-        .frame(height: 62)
     }
 
     private var chartStartDate: Date {

--- a/LOGIT/Features/Home/OverallSetsScreen.swift
+++ b/LOGIT/Features/Home/OverallSetsScreen.swift
@@ -143,8 +143,6 @@ struct OverallSetsScreen: View {
                 }
                 .padding(.horizontal)
                 
-                // MARK: - Highlights Section
-                highlightsSection
             }
             .padding(.top)
             .padding(.bottom, SCROLLVIEW_BOTTOM_PADDING)
@@ -331,76 +329,6 @@ struct OverallSetsScreen: View {
         return sortedKeys.map { ($0, groupedDict[$0] ?? []) }
     }
 
-    // MARK: - Highlights (helpers kept intentionally minimal)
-
-    private var unitLabel: String { "\(NSLocalizedString("sets", comment: ""))/\(NSLocalizedString("workout", comment: ""))" }
-
-    private func periodRanges() -> (current: (start: Date, end: Date), previous: (start: Date, end: Date)) {
-        switch chartGranularity {
-        case .week:
-            let current = (Date.now.startOfWeek, Date.now.endOfWeek)
-            let lastStart = Calendar.current.date(byAdding: .weekOfYear, value: -1, to: .now.startOfWeek)!
-            let previous = (lastStart, lastStart.endOfWeek)
-            return (current, previous)
-        case .month:
-            let current = (Date.now.startOfMonth, Date.now.endOfMonth)
-            let lastStart = Calendar.current.date(byAdding: .month, value: -1, to: .now.startOfMonth)!
-            let previous = (lastStart, lastStart.endOfMonth)
-            return (current, previous)
-        case .year:
-            let current = (Date.now.startOfYear, Date.now.endOfYear)
-            let lastStart = Calendar.current.date(byAdding: .year, value: -1, to: .now.startOfYear)!
-            let previous = (lastStart, lastStart.endOfYear)
-            return (current, previous)
-        }
-    }
-
-    private func averagePerWorkout(in range: (start: Date, end: Date)) -> Double {
-        let s = range.start, e = range.end
-        let sets = workouts.flatMap { $0.sets }.reduce(into: 0) { acc, set in
-            if let d = set.workout?.date, d >= s && d <= e { acc += 1 }
-        }
-        let sessions = workouts.reduce(into: 0) { acc, w in
-            if let d = w.date, d >= s && d <= e { acc += 1 }
-        }
-        return Double(sets) / max(Double(sessions), 1)
-    }
-
-    private func headlineKey(isMore: Bool) -> String {
-        switch chartGranularity {
-        case .week: return isMore ? "avgMoreSetsPerWorkoutThisWeekThanLastWeek" : "avgFewerSetsPerWorkoutThisWeekThanLastWeek"
-        case .month: return isMore ? "avgMoreSetsPerWorkoutThisMonthThanLastMonth" : "avgFewerSetsPerWorkoutThisMonthThanLastMonth"
-        case .year: return isMore ? "avgMoreSetsPerWorkoutThisYearThanLastYear" : "avgFewerSetsPerWorkoutThisYearThanLastYear"
-        }
-    }
-
-    // MARK: - Highlights
-
-    @ViewBuilder
-    private var highlightsSection: some View {
-        let ranges = periodRanges()
-        let currentAvg = averagePerWorkout(in: ranges.current)
-        let previousAvg = averagePerWorkout(in: ranges.previous)
-        let headlineKey = headlineKey(isMore: currentAvg >= previousAvg)
-        let granularity: HighlightView.Granularity = {
-            switch chartGranularity {
-            case .week: return .week
-            case .month: return .month
-            case .year: return .year
-            }
-        }()
-
-        HighlightView(
-            headline: NSLocalizedString(headlineKey, comment: ""),
-            currentValue: HighlightView.formatNumber(currentAvg),
-            previousValue: HighlightView.formatNumber(previousAvg),
-            unit: unitLabel,
-            currentNumericValue: currentAvg,
-            previousNumericValue: previousAvg,
-            granularity: granularity
-        )
-        .padding(.horizontal)
-    }
 }
 
 // #Preview {

--- a/LOGIT/Features/Home/VolumeScreen.swift
+++ b/LOGIT/Features/Home/VolumeScreen.swift
@@ -160,8 +160,6 @@ struct VolumeScreen: View {
                 
                 MuscleGroupSelector(selectedMuscleGroup: $selectedMuscleGroup)
                 
-                // MARK: - Highlights Section
-                highlightsSection
             }
             .padding(.top)
             .padding(.bottom, SCROLLVIEW_BOTTOM_PADDING)
@@ -311,71 +309,6 @@ struct VolumeScreen: View {
         }
     }
 
-    // MARK: - Highlights
-
-    @ViewBuilder
-    private var highlightsSection: some View {
-        let ranges = periodRanges()
-        let currentAvg = averageVolumePerWorkout(in: ranges.current, muscleGroup: selectedMuscleGroup)
-        let previousAvg = averageVolumePerWorkout(in: ranges.previous, muscleGroup: selectedMuscleGroup)
-        let headlineKey = volumeHeadlineKey(isMore: currentAvg >= previousAvg)
-        let unit = "\(WeightUnit.used.rawValue)/\(NSLocalizedString("workout", comment: ""))"
-
-        HighlightView(
-            headline: NSLocalizedString(headlineKey, comment: ""),
-            currentValue: HighlightView.formatNumber(currentAvg),
-            previousValue: HighlightView.formatNumber(previousAvg),
-            unit: unit,
-            currentNumericValue: currentAvg,
-            previousNumericValue: previousAvg,
-            granularity: chartGranularity == .month ? .month : .year,
-            accentColor: selectedMuscleGroup?.color ?? .accentColor
-        )
-        .padding(.horizontal)
-    }
-
-    private func periodRanges() -> (current: (start: Date, end: Date), previous: (start: Date, end: Date)) {
-        switch chartGranularity {
-        case .month:
-            let current = (Date.now.startOfMonth, Date.now.endOfMonth)
-            let lastStart = Calendar.current.date(byAdding: .month, value: -1, to: .now.startOfMonth)!
-            let previous = (lastStart, lastStart.endOfMonth)
-            return (current, previous)
-        case .year:
-            let current = (Date.now.startOfYear, Date.now.endOfYear)
-            let lastStart = Calendar.current.date(byAdding: .year, value: -1, to: .now.startOfYear)!
-            let previous = (lastStart, lastStart.endOfYear)
-            return (current, previous)
-        }
-    }
-
-    private func averageVolumePerWorkout(in range: (start: Date, end: Date), muscleGroup: MuscleGroup? = nil) -> Double {
-        let s = range.start, e = range.end
-        let setsInRange = workoutSets.filter {
-            guard let d = $0.workout?.date else { return false }
-            return d >= s && d <= e
-        }
-        let totalVolume: Double
-        if let mg = muscleGroup {
-            totalVolume = convertWeightForDisplayingDecimal(getVolume(of: setsInRange, for: mg))
-        } else {
-            totalVolume = convertWeightForDisplayingDecimal(getVolume(of: setsInRange))
-        }
-        // Count unique workouts in range
-        let workoutsInRange = Set(setsInRange.compactMap { $0.workout }).filter {
-            guard let d = $0.date else { return false }
-            return d >= s && d <= e
-        }
-        let workoutCount = max(workoutsInRange.count, 1)
-        return totalVolume / Double(workoutCount)
-    }
-
-    private func volumeHeadlineKey(isMore: Bool) -> String {
-        switch chartGranularity {
-        case .month: return isMore ? "avgMoreVolumePerWorkoutThisMonthThanLastMonth" : "avgLessVolumePerWorkoutThisMonthThanLastMonth"
-        case .year: return isMore ? "avgMoreVolumePerWorkoutThisYearThanLastYear" : "avgLessVolumePerWorkoutThisYearThanLastYear"
-        }
-    }
 }
 
 private struct PreviewWrapperView: View {

--- a/LOGIT/Features/Measurement/MeasurementDetailScreen.swift
+++ b/LOGIT/Features/Measurement/MeasurementDetailScreen.swift
@@ -32,7 +32,6 @@ struct MeasurementDetailScreen: View {
         ScrollView {
             VStack(spacing: SECTION_SPACING) {
                 chartSection
-                highlightsSection
                 entriesListSection
             }
             .padding(.horizontal)
@@ -242,60 +241,6 @@ struct MeasurementDetailScreen: View {
             }
             .frame(height: 300)
             .padding(.trailing, 5)
-        }
-    }
-
-    // MARK: - Highlights Section
-
-    @ViewBuilder
-    private var highlightsSection: some View {
-        let ranges = periodRanges()
-        let currentAvg = averageValue(in: ranges.current)
-        let previousAvg = averageValue(in: ranges.previous)
-        let headlineKey = measurementHeadlineKey(isHigher: currentAvg >= previousAvg)
-        let unit = measurementType.unit
-
-        HighlightView(
-            headline: NSLocalizedString(headlineKey, comment: ""),
-            currentValue: currentAvg > 0 ? formatDecimal(currentAvg) : "––",
-            previousValue: previousAvg > 0 ? formatDecimal(previousAvg) : "––",
-            unit: unit,
-            currentNumericValue: currentAvg,
-            previousNumericValue: previousAvg,
-            granularity: chartGranularity == .month ? .month : .year
-        )
-    }
-
-    private func periodRanges() -> (current: (start: Date, end: Date), previous: (start: Date, end: Date)) {
-        switch chartGranularity {
-        case .month:
-            let current = (Date.now.startOfMonth, Date.now.endOfMonth)
-            let lastStart = Calendar.current.date(byAdding: .month, value: -1, to: .now.startOfMonth)!
-            let previous = (lastStart, lastStart.endOfMonth)
-            return (current, previous)
-        case .year:
-            let current = (Date.now.startOfYear, Date.now.endOfYear)
-            let lastStart = Calendar.current.date(byAdding: .year, value: -1, to: .now.startOfYear)!
-            let previous = (lastStart, lastStart.endOfYear)
-            return (current, previous)
-        }
-    }
-
-    private func averageValue(in range: (start: Date, end: Date)) -> Double {
-        let s = range.start, e = range.end
-        let entriesInRange = entries.filter {
-            guard let d = $0.date else { return false }
-            return d >= s && d <= e
-        }
-        guard !entriesInRange.isEmpty else { return 0 }
-        let total = entriesInRange.reduce(0.0) { $0 + $1.decimalValue }
-        return total / Double(entriesInRange.count)
-    }
-
-    private func measurementHeadlineKey(isHigher: Bool) -> String {
-        switch chartGranularity {
-        case .month: return isHigher ? "measurementHigherThisMonthThanLastMonth" : "measurementLowerThisMonthThanLastMonth"
-        case .year: return isHigher ? "measurementHigherThisYearThanLastYear" : "measurementLowerThisYearThanLastYear"
         }
     }
 

--- a/LOGIT/Features/Workout/Cells/WorkoutCell.swift
+++ b/LOGIT/Features/Workout/Cells/WorkoutCell.swift
@@ -14,10 +14,15 @@ struct WorkoutCell: View {
     // MARK: - Environment
 
     @EnvironmentObject private var muscleGroupService: MuscleGroupService
+    @EnvironmentObject private var database: Database
 
     // MARK: - Variables
 
     @ObservedObject var workout: Workout
+
+    // MARK: - State
+
+    @State private var personalRecordCount: Int = 0
 
     // MARK: - Body
 
@@ -32,6 +37,9 @@ struct WorkoutCell: View {
         .padding(CELL_PADDING)
         .background(backgroundGradient)
         .clipShape(RoundedRectangle(cornerRadius: 30))
+        .onAppear {
+            personalRecordCount = WorkoutProgressReport.compute(for: workout, database: database).prRecords.count
+        }
     }
     
     // MARK: - View Components
@@ -57,6 +65,10 @@ struct WorkoutCell: View {
             if let durationString = workoutDurationString {
                 Text("·")
                 Text(durationString)
+            }
+            if let personalRecordsString {
+                Text("·")
+                Text(personalRecordsString)
             }
         }
         .font(.caption)
@@ -135,6 +147,16 @@ struct WorkoutCell: View {
             let minutes = totalMinutes % 60
             return minutes == 0 ? "\(hours)h" : "\(hours)h \(minutes)m"
         }
+    }
+
+    /// "n PR(s)" for the personal records set in this workout, or nil when there are none. Uses the
+    /// same `WorkoutProgressReport` detection as the detail screen, so the two counts always agree.
+    private var personalRecordsString: String? {
+        guard personalRecordCount > 0 else { return nil }
+        let format = personalRecordCount == 1
+            ? NSLocalizedString("personalRecordShortCount", comment: "")
+            : NSLocalizedString("personalRecordsShortCount", comment: "")
+        return String(format: format, personalRecordCount)
     }
 
     private var exercisesSummary: String {

--- a/LOGIT/Features/Workout/Cells/WorkoutSetGroupCell.swift
+++ b/LOGIT/Features/Workout/Cells/WorkoutSetGroupCell.swift
@@ -1115,40 +1115,22 @@ struct MetricInfoPanel: View {
     /// (it's the live side of the comparison, and what the badge tints when you're up); the
     /// reference stays neutral so a single glance finds "you, now".
     private func comparisonRow(color: Color) -> some View {
-        HStack(alignment: .center, spacing: 8) {
-            VStack(alignment: .leading, spacing: 1) {
-                Text(NSLocalizedString("currentBest", comment: ""))
-                    .font(.footnote)
-                    .fontWeight(.semibold)
-                    .foregroundStyle(.secondary)
-                UnitView(
-                    value: currentBestValue(for: selectedMetric),
-                    unit: panelUnit(for: selectedMetric),
-                    configuration: .large
-                )
-            }
-            Spacer(minLength: 0)
-            if let change = comparison.percentChange(selectedMetric) {
-                TrendIndicatorView(
-                    percentChange: change,
-                    positiveColor: color,
-                    isRecord: comparison.isPersonalRecord(selectedMetric)
-                )
-            }
-            Spacer(minLength: 0)
-            VStack(alignment: .trailing, spacing: 1) {
-                Text(NSLocalizedString("thisWorkout", comment: ""))
-                    .font(.footnote)
-                    .fontWeight(.semibold)
-                    .foregroundStyle(.secondary)
-                UnitView(
-                    value: formattedValue(comparison.sessionBest(selectedMetric), for: selectedMetric),
-                    unit: panelUnit(for: selectedMetric),
-                    configuration: .large
-                )
-                .foregroundStyle(color.gradient)
-            }
-        }
+        MetricComparisonView(
+            leading: .init(
+                label: NSLocalizedString("currentBest", comment: ""),
+                value: currentBestValue(for: selectedMetric),
+                unit: panelUnit(for: selectedMetric)
+            ),
+            trailing: .init(
+                label: NSLocalizedString("thisWorkout", comment: ""),
+                value: formattedValue(comparison.sessionBest(selectedMetric), for: selectedMetric),
+                unit: panelUnit(for: selectedMetric)
+            ),
+            trailingValueStyle: AnyShapeStyle(color.gradient),
+            percentChange: comparison.percentChange(selectedMetric),
+            positiveColor: color,
+            isRecord: comparison.isPersonalRecord(selectedMetric)
+        )
     }
 
     /// The comparison row over its full-width chart, sitting tighter together than the panel's

--- a/LOGIT/Features/Workout/WorkoutProgressSection.swift
+++ b/LOGIT/Features/Workout/WorkoutProgressSection.swift
@@ -26,6 +26,9 @@ struct WorkoutProgressReport {
         /// The exercise's best for this metric *before* this workout — the value the record beat.
         /// Base units like `value`; the records screen shows the gain over it.
         let previousBest: Int
+        /// When that previous best was first set — the earliest prior session to reach it — so the
+        /// card can date it beside the new record. Nil if no dated prior session carried it.
+        let previousBestDate: Date?
         var id: String { "\(exercise.objectID.uriRepresentation())-\(metric.rawValue)" }
     }
 
@@ -98,8 +101,20 @@ struct WorkoutProgressReport {
                 // Ties don't count, and neither do first-ever entries — with no earlier value
                 // there is no record to beat.
                 if current > 0, priorBest > 0, current > priorBest {
+                    // When the beaten record was first set: the earliest prior session that reached
+                    // it, so the card can date the previous best beside the new one.
+                    let previousBestDate = priorSets
+                        .filter { value($0, metric) == priorBest }
+                        .compactMap { $0.workout?.date }
+                        .min()
                     prRecords.append(
-                        PRRecord(exercise: exercise, metric: metric, value: current, previousBest: priorBest)
+                        PRRecord(
+                            exercise: exercise,
+                            metric: metric,
+                            value: current,
+                            previousBest: priorBest,
+                            previousBestDate: previousBestDate
+                        )
                     )
                 }
             }
@@ -355,74 +370,92 @@ struct WorkoutPersonalRecordsScreen: View {
     }
 }
 
-/// One record on `WorkoutPersonalRecordsScreen`: a trophy badge leading the exercise and metric with
-/// the gain over the value it beat as a pill top-right, the new best below in its muscle-group
-/// gradient beside the previous best it beat (a muted history pill), and a line chart of the exercise's
-/// entire history for this metric — cresting at this record, so the all-time best stands out.
+/// One record on `WorkoutPersonalRecordsScreen`: a trophy badge leading the exercise and metric, then
+/// a comparison scoreboard of the previous best (dated) against the new record (dated, muscle-tinted)
+/// with the gain as a percent pill between them, over a clean line chart of the exercise's entire
+/// history for this metric that bleeds to the card's edges. The top-right corner is intentionally left
+/// free now that the gain reads from the scoreboard rather than a pill up there.
 struct WorkoutPersonalRecordCard: View {
     let workout: Workout
     let record: WorkoutProgressReport.PRRecord
 
     var body: some View {
         let color = record.exercise.muscleGroup?.color ?? .accentColor
-        VStack(alignment: .leading, spacing: 12) {
-            HStack(spacing: 12) {
-                ZStack {
-                    Circle()
-                        .fill(color.opacity(0.15))
-                        .frame(width: 38, height: 38)
-                    Image(systemName: "trophy.fill")
-                        .font(.subheadline)
-                        .foregroundStyle(color.gradient)
-                }
-                VStack(alignment: .leading, spacing: 1) {
-                    Text(record.exercise.displayName)
-                        .font(.body.weight(.semibold))
-                        .foregroundStyle(Color.label)
-                        .lineLimit(1)
-                    Text(record.metric.title)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-                Spacer(minLength: 8)
-                gainPill(color: color)
+        // Spacing 0 so the chart can sit flush against the card's bottom and side edges: the header
+        // and scoreboard carry their own `CELL_PADDING` inset, the chart carries none and bleeds out
+        // to the `tileStyle` rounded border (which clips its bottom corners).
+        VStack(alignment: .leading, spacing: 0) {
+            VStack(alignment: .leading, spacing: 14) {
+                header(color: color)
+                comparison(color: color)
             }
-            HStack(alignment: .firstTextBaseline) {
-                personalRecordValueView(for: record, configuration: .large)
-                    .foregroundStyle(color.gradient)
-                Spacer(minLength: 8)
-                previousBestPill
-            }
-            ExerciseTileSparkline(points: sparklinePoints, color: color, window: .allTime, height: 96)
+            .padding(CELL_PADDING)
+            ExerciseTileSparkline(points: sparklinePoints, color: color, window: .allTime, height: 108)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(CELL_PADDING)
         .tileStyle()
     }
 
-    /// "⌃ n" in the metric's units — the gain this record made over the value it beat, in the
-    /// trend pill's anatomy and the exercise's muscle tint.
-    @ViewBuilder
-    private func gainPill(color: Color) -> some View {
-        let gain = record.value - record.previousBest
-        if gain > 0 {
-            let display = personalRecordDisplay(gain, metric: record.metric)
-            ProgressIndicatorPill(symbol: "chevron.up", style: AnyShapeStyle(color.gradient)) {
-                UnitView(value: display.value, unit: display.unit, configuration: .small)
+    private func header(color: Color) -> some View {
+        HStack(spacing: 12) {
+            ZStack {
+                Circle()
+                    .fill(color.opacity(0.15))
+                    .frame(width: 38, height: 38)
+                Image(systemName: "trophy.fill")
+                    .font(.subheadline)
+                    .foregroundStyle(color.gradient)
             }
+            VStack(alignment: .leading, spacing: 1) {
+                Text(record.exercise.displayName)
+                    .font(.body.weight(.semibold))
+                    .foregroundStyle(Color.label)
+                    .lineLimit(1)
+                Text(record.metric.title)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer(minLength: 8)
+            // Top-right corner intentionally free — the gain now reads from the scoreboard below.
         }
     }
 
-    /// The record this one beat, as a muted history pill: the previous personal best for this metric,
-    /// so the card shows the jump from it to the new best rather than the new number alone.
-    @ViewBuilder
-    private var previousBestPill: some View {
-        if record.previousBest > 0 {
-            let display = personalRecordDisplay(record.previousBest, metric: record.metric)
-            ProgressIndicatorPill(symbol: "clock.arrow.circlepath", color: .secondary, size: .compact) {
-                UnitView(value: display.value, unit: display.unit, configuration: .small)
-            }
-        }
+    /// The scoreboard: the dated previous best on the left, the dated new record (muscle-tinted) on
+    /// the right, and the percent gain of one over the other in the pill between them — the shared
+    /// `MetricComparisonView` the chart-detail headers wear, so this PR jump reads the same way.
+    private func comparison(color: Color) -> some View {
+        let previous = personalRecordDisplay(record.previousBest, metric: record.metric)
+        let current = personalRecordDisplay(record.value, metric: record.metric)
+        let percentChange = record.previousBest > 0
+            ? (Double(record.value) - Double(record.previousBest)) / Double(record.previousBest) * 100
+            : nil
+        return MetricComparisonView(
+            leading: .init(
+                label: NSLocalizedString("previousBest", comment: ""),
+                value: previous.value,
+                unit: previous.unit,
+                caption: recordDateCaption(record.previousBestDate)
+            ),
+            trailing: .init(
+                label: NSLocalizedString("newRecord", comment: ""),
+                value: current.value,
+                unit: current.unit,
+                caption: recordDateCaption(workout.date)
+            ),
+            trailingValueStyle: AnyShapeStyle(color.gradient),
+            percentChange: percentChange,
+            positiveColor: color,
+            positiveStyle: AnyShapeStyle(color.gradient)
+        )
+    }
+
+    /// A scoreboard caption date — day and month, with the year only when it isn't the current one,
+    /// matching the chart headers' date captions.
+    private func recordDateCaption(_ date: Date?) -> String? {
+        guard let date else { return nil }
+        return date.isInCurrentYear
+            ? date.formatted(.dateTime.day().month())
+            : date.formatted(.dateTime.day().month().year())
     }
 
     /// The exercise's daily best for this metric up to and including this workout — the same

--- a/LOGIT/Features/Workout/WorkoutStatScreen.swift
+++ b/LOGIT/Features/Workout/WorkoutStatScreen.swift
@@ -17,9 +17,9 @@ import SwiftUI
 /// frame (the reference — neutral, and it moves as you scroll) on one side, this workout's own value
 /// (the bold white constant) on the other, and a pill between them reading this workout against that
 /// average. Scroll the chart and the average + pill retarget while this workout stays the anchor —
-/// we're in its detail, after all. The muscle color lives on the accents: the current chart bar, the
-/// highlights' current bar, and the pill. Otherwise the exercise chart screens' anatomy (picker,
-/// header, scrollable chart with tap-to-inspect, highlights, about). One screen serves all four
+/// we're in its detail, after all. The muscle color lives on the accents: the current chart bar and
+/// the pill. Otherwise the exercise chart screens' anatomy (picker, header, scrollable chart with
+/// tap-to-inspect, about). One screen serves all four
 /// stats — `WorkoutStatMetric` supplies values, formatting, and texts.
 struct WorkoutStatScreen: View {
     private enum ChartGranularity {
@@ -95,8 +95,6 @@ struct WorkoutStatScreen: View {
                     chart(points: points, snappedPoint: snappedPoint)
                 }
 
-                highlightsSection(workouts: workouts)
-
                 AboutSection(metricTitle: metric.title, text: metric.aboutText)
                     .padding(.horizontal)
             }
@@ -158,56 +156,25 @@ struct WorkoutStatScreen: View {
             guard let average = visibleAverage, average > 0, raw > 0 else { return nil }
             return (Double(raw) - average) / average * 100
         }()
-        return HStack(alignment: .center, spacing: 12) {
-            VStack(alignment: .leading, spacing: 1) {
-                Text(NSLocalizedString("average", comment: ""))
-                    .font(.footnote)
-                    .fontWeight(.semibold)
-                    .textCase(.uppercase)
-                    .foregroundStyle(.secondary)
-                UnitView(
-                    value: visibleAverage.map { metric.formattedAverage(rawAverage: $0) } ?? "––",
-                    unit: metric.unit,
-                    unitColor: .secondaryLabel
-                )
-                .foregroundStyle(.secondary)
-                Text(visibleDomainDescription)
-                    .font(.caption)
-                    .fontWeight(.bold)
-                    .fontDesign(.rounded)
-                    .foregroundStyle(.tertiary)
-            }
-            Spacer(minLength: 0)
-            if let percentChange {
-                TrendIndicatorView(
-                    percentChange: percentChange,
-                    positiveColor: metric == .duration ? .secondary : dominantMuscleGroupColor,
-                    positiveStyle: metric == .duration ? nil : workout.muscleGroups.gradientStyle()
-                )
-                .animation(.snappy, value: percentChange)
-            }
-            Spacer(minLength: 0)
-            VStack(alignment: .trailing, spacing: 1) {
-                Text(NSLocalizedString("thisWorkout", comment: ""))
-                    .font(.footnote)
-                    .fontWeight(.semibold)
-                    .textCase(.uppercase)
-                    .foregroundStyle(.secondary)
-                UnitView(
-                    value: raw > 0 ? metric.formattedValue(fromRaw: raw) : "––",
-                    unit: metric.unit,
-                    unitColor: .secondaryLabel
-                )
-                .foregroundStyle(Color.label)
-                if let date = workout.date {
-                    Text(date.formatted(.dateTime.day().month()))
-                        .font(.caption)
-                        .fontWeight(.bold)
-                        .fontDesign(.rounded)
-                        .foregroundStyle(.tertiary)
-                }
-            }
-        }
+        let isDuration = metric == .duration
+        return MetricComparisonView(
+            leading: .init(
+                label: NSLocalizedString("average", comment: ""),
+                value: visibleAverage.map { metric.formattedAverage(rawAverage: $0) } ?? "––",
+                unit: metric.unit,
+                caption: visibleDomainDescription
+            ),
+            trailing: .init(
+                label: NSLocalizedString("thisWorkout", comment: ""),
+                value: raw > 0 ? metric.formattedValue(fromRaw: raw) : "––",
+                unit: metric.unit,
+                caption: workout.date?.formatted(.dateTime.day().month())
+            ),
+            trailingValueStyle: isDuration ? AnyShapeStyle(Color.label) : workout.muscleGroups.gradientStyle(),
+            percentChange: percentChange,
+            positiveColor: isDuration ? .secondary : dominantMuscleGroupColor,
+            positiveStyle: isDuration ? nil : workout.muscleGroups.gradientStyle()
+        )
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.horizontal)
     }
@@ -364,32 +331,6 @@ struct WorkoutStatScreen: View {
             .map { metric.rawValue(of: $0) }
         guard !values.isEmpty else { return nil }
         return Double(values.reduce(0, +)) / Double(values.count)
-    }
-
-    // MARK: - Highlights
-
-    @ViewBuilder
-    private func highlightsSection(workouts: [Workout]) -> some View {
-        let granularity: HighlightView.Granularity = chartGranularity == .month ? .month : .year
-        let ranges = granularity.periodRanges()
-        let currentAverage = averageRaw(in: workouts, from: ranges.current.start, to: ranges.current.end) ?? 0
-        let previousAverage = averageRaw(in: workouts, from: ranges.previous.start, to: ranges.previous.end) ?? 0
-
-        HighlightView(
-            headline: metric.highlightHeadline(
-                isMore: currentAverage >= previousAverage,
-                isYearGranularity: chartGranularity == .year
-            ),
-            currentValue: currentAverage > 0 ? metric.highlightValue(rawAverage: currentAverage) : "––",
-            previousValue: previousAverage > 0 ? metric.highlightValue(rawAverage: previousAverage) : "––",
-            unit: metric.highlightUnit,
-            currentNumericValue: currentAverage,
-            previousNumericValue: previousAverage,
-            granularity: granularity,
-            accentColor: dominantMuscleGroupColor,
-            accentGradient: workout.muscleGroups.gradient()
-        )
-        .padding(.horizontal)
     }
 
     // MARK: - Chart Window

--- a/LOGIT/Features/Workout/WorkoutStatTiles.swift
+++ b/LOGIT/Features/Workout/WorkoutStatTiles.swift
@@ -272,9 +272,9 @@ struct WorkoutRunHistory {
 /// The mini bar chart under a stat tile's value: this workout against its previous runs, one bar
 /// per run in a fixed five-slot frame (bars keep the same width however little history there is,
 /// and the newest run is always rightmost). Only the current workout's bar is drawn in
-/// `currentStyle` — the label color, matching the tile's value — every previous run stays quiet
-/// gray, whichever comparison basis is behind it (the label's info button spells the basis out).
-/// Short, wide, softly-rounded bars.
+/// `currentStyle` — the tile's accent — every previous run stays quiet gray, whichever comparison
+/// basis is behind it (the label's info button spells the basis out). Short, wide, softly-rounded
+/// bars.
 struct WorkoutRunsBarChart: View {
     struct Bar: Identifiable {
         let slot: Int
@@ -308,8 +308,6 @@ struct WorkoutRunsBarChart: View {
         .chartYScale(domain: 0 ... max(maxValue, 1))
         .chartXAxis {}
         .chartYAxis {}
-        .frame(maxWidth: .infinity)
-        .frame(height: 44)
         .overlay {
             if maxValue <= 0 {
                 Text(NSLocalizedString("noData", comment: ""))
@@ -322,28 +320,27 @@ struct WorkoutRunsBarChart: View {
 
 // MARK: - Stat Tile
 
-/// One compact session stat on the workout detail — the exercise metric tiles' skeleton with the
-/// workout vocabulary: "This Workout" over a label-colored value with a muted unit, the trend pill
-/// — wearing the workout's muscle-group gradient on a gain — against the run history top-right, and
-/// the run bars beneath, this workout's bar drawn in the label color to match its value. The
-/// duration tile's pill stays neutral gray in both directions — a longer workout is neither better
-/// nor worse.
+/// One compact session stat on the workout detail — the shared metric tile with the workout
+/// vocabulary: "This Workout" over a neutral value, the trend pill wearing the workout's
+/// muscle-group gradient on a gain, and the run bars in the corner with this workout's bar in that
+/// same accent. The duration tile stays neutral gray in both directions — a longer workout is
+/// neither better nor worse.
 struct WorkoutStatTile: View {
     let metric: WorkoutStatMetric
     let workout: Workout
     let history: WorkoutRunHistory
-    let pillColor: Color
-    /// Gradient for the trend pill's positive tint; nil (the duration tile) keeps it neutral gray.
-    let pillStyle: AnyShapeStyle?
-    let valueStyle: AnyShapeStyle
-    let currentBarStyle: AnyShapeStyle
+    /// Tints the trend pill and the current workout's bar — the workout's muscle-group gradient, or
+    /// neutral gray on the duration tile.
+    let accent: AnyShapeStyle
+    /// The flat-color form of `accent`, for the pill's non-gradient fallback and the ghost dot.
+    let accentColor: Color
 
     var body: some View {
         let raw = metric.rawValue(of: workout)
         let explanationKey = history.basis == .sameWorkout
             ? "workoutStatCompareSameInfo"
             : "workoutStatCompareRecentInfo"
-        ExerciseMetricTileLayout(
+        MetricTile(
             title: metric.title,
             label: .info(
                 NSLocalizedString("thisWorkout", comment: ""),
@@ -351,15 +348,13 @@ struct WorkoutStatTile: View {
             ),
             value: raw > 0 ? metric.formattedValue(fromRaw: raw) : nil,
             unit: metric.unit,
-            color: pillColor,
+            accent: accent,
+            accentColor: accentColor,
             percentChange: history.percentChange(for: metric),
             isRecord: false,
-            requiresPro: metric.requiresPro,
-            valueStyle: valueStyle,
-            unitColor: .secondaryLabel,
-            trendStyle: pillStyle
+            requiresPro: metric.requiresPro
         ) {
-            WorkoutRunsBarChart(bars: runBars, currentStyle: currentBarStyle)
+            WorkoutRunsBarChart(bars: runBars, currentStyle: accent)
         }
     }
 
@@ -423,17 +418,16 @@ struct WorkoutStatTileGrid: View {
     }
 
     private func tile(_ metric: WorkoutStatMetric, history: WorkoutRunHistory) -> some View {
-        Button {
+        let isDuration = metric == .duration
+        return Button {
             onOpenDetail(metric)
         } label: {
             WorkoutStatTile(
                 metric: metric,
                 workout: workout,
                 history: history,
-                pillColor: metric == .duration ? .secondary : dominantMuscleGroupColor,
-                pillStyle: metric == .duration ? nil : workout.muscleGroups.gradientStyle(),
-                valueStyle: AnyShapeStyle(Color.label),
-                currentBarStyle: AnyShapeStyle(Color.label)
+                accent: isDuration ? AnyShapeStyle(Color.secondary) : workout.muscleGroups.gradientStyle(),
+                accentColor: isDuration ? .secondary : dominantMuscleGroupColor
             )
         }
         .buttonStyle(TileButtonStyle())

--- a/LOGIT/SharedUI/Charts/TileSparklineStyle.swift
+++ b/LOGIT/SharedUI/Charts/TileSparklineStyle.swift
@@ -44,9 +44,16 @@ enum TileSparklineStyle {
     /// Fraction of the width over which the leading edge fades in.
     static let leadingFadeLocation: CGFloat = 0.12
 
-    /// The translucent fill under the line — fades from the tint down to clear.
-    static func areaGradient(_ color: Color) -> Gradient {
-        Gradient(colors: [color.opacity(0.3), color.opacity(0.1), color.opacity(0)])
+    /// The translucent fill under the line — a top-heavy tint. Swift Charts won't reliably fade an
+    /// `AreaMark` to clear at the baseline on its own (the fill gradient maps to a range far taller
+    /// than the area, so its bottom never reaches transparent), so the real fade to transparent is the
+    /// vertical pass in `tileSparklineFadeMask()`; this just supplies the colour.
+    static func areaGradient(_ color: Color) -> LinearGradient {
+        LinearGradient(
+            colors: [color.opacity(0.38), color.opacity(0.18)],
+            startPoint: .top,
+            endPoint: .bottom
+        )
     }
 
     /// A daily-best dot: a filled circle in the tint with a punched-out black center so it reads as
@@ -67,17 +74,16 @@ enum TileSparklineStyle {
 // MARK: - Marks
 
 /// The shared marks of a tile sparkline: a leading segment pinned to the far past so the line enters
-/// from the left edge, the tinted line with daily-best dots, the area fill beneath, the dashed
-/// carry-forward from the last point to `carryForwardEnd`, and — for the all-time window — a single
-/// emphasized record dot. Wrap this in a `Chart { … }` and add the chart's own scales/frame/fade.
+/// from the left edge, the tinted line with daily-best dots, the area fill beneath, and the dashed
+/// carry-forward from the last point to `carryForwardEnd`. Wrap this in a `Chart { … }` and add the
+/// chart's own scales/frame/fade.
 ///
 /// - Parameters:
-///   - showsSymbols: per-point dots; off for the dense all-time window where the crest dot stands in.
+///   - showsSymbols: per-point dots; off for the all-time line, which draws one clean dotless curve.
 ///   - showsCarryForward: the dashed flat line from the last point to `carryForwardEnd` when the
 ///     last point predates that anchor (an exercise untrained since, or the recorder's live anchor).
 ///   - carryForwardEnd: where the carry-forward reaches — today (`.now`) for finished history, or the
 ///     workout being recorded for the in-workout cell.
-///   - recordPoint: the all-time crest, drawn as a larger dot; nil for the windowed sparklines.
 @ChartContentBuilder
 func tileSparklineMarks(
     points: [TileSparklinePoint],
@@ -85,8 +91,7 @@ func tileSparklineMarks(
     interpolation: InterpolationMethod = TileSparklineStyle.interpolation,
     showsSymbols: Bool = true,
     showsCarryForward: Bool = true,
-    carryForwardEnd: Date = .now,
-    recordPoint: TileSparklinePoint? = nil
+    carryForwardEnd: Date = .now
 ) -> some ChartContent {
     // Leading entry pinned to the far past so the line and area enter from the left edge instead of
     // starting mid-chart (the domain clips it).
@@ -116,20 +121,6 @@ func tileSparklineMarks(
             .interpolationMethod(interpolation)
             .foregroundStyle(TileSparklineStyle.areaGradient(color))
     }
-    if let recordPoint {
-        PointMark(x: .value("Date", recordPoint.date, unit: .day), y: .value("Value", recordPoint.value))
-            .foregroundStyle(color.gradient)
-            .symbol {
-                Circle()
-                    .frame(width: 9, height: 9)
-                    .foregroundStyle(color.gradient)
-                    .overlay {
-                        Circle()
-                            .frame(width: 3, height: 3)
-                            .foregroundStyle(Color.black)
-                    }
-            }
-    }
     if showsCarryForward, let last = points.last,
        last.date < carryForwardEnd,
        !Calendar.current.isDate(last.date, inSameDayAs: carryForwardEnd) {
@@ -152,8 +143,11 @@ func tileSparklineMarks(
 // MARK: - Fade Mask
 
 extension View {
-    /// Fades a tile sparkline in from its leading edge so the clipped line dissolves into the tile
-    /// rather than starting on a hard vertical. Shared by every tile sparkline's frame treatment.
+    /// Fades a tile sparkline in from its leading edge (so the clipped line dissolves into the tile
+    /// rather than starting on a hard vertical) AND out toward the bottom (so the area fill melts into
+    /// the tile instead of ending on a hard horizontal edge at the baseline — Swift Charts can't fade
+    /// the `AreaMark` itself reliably). Two stacked masks compose to "visible where both are opaque".
+    /// Shared by every tile sparkline's frame treatment.
     func tileSparklineFadeMask() -> some View {
         mask(
             LinearGradient(
@@ -164,6 +158,19 @@ extension View {
                 ]),
                 startPoint: .leading,
                 endPoint: .trailing
+            )
+        )
+        .mask(
+            LinearGradient(
+                gradient: Gradient(stops: [
+                    // Opaque through the line and the band just under it, then fade to clear at the
+                    // baseline so the fill blends into the tile.
+                    .init(color: .black, location: 0.0),
+                    .init(color: .black, location: 0.4),
+                    .init(color: .clear, location: 1.0),
+                ]),
+                startPoint: .top,
+                endPoint: .bottom
             )
         )
     }

--- a/LOGIT/SharedUI/Views/AboutSection.swift
+++ b/LOGIT/SharedUI/Views/AboutSection.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 /// Health-app-style explanation shown at the bottom of metric detail screens:
 /// an "About <Metric>" header followed by a short secondary description sitting
-/// in a tile, matching the `HighlightView` section directly above it.
+/// in a tile at the bottom of the screen.
 struct AboutSection: View {
     let metricTitle: String
     let text: String

--- a/LOGIT/SharedUI/Views/MetricComparisonView.swift
+++ b/LOGIT/SharedUI/Views/MetricComparisonView.swift
@@ -1,0 +1,139 @@
+//
+//  MetricComparisonView.swift
+//  LOGIT
+//
+//  Created by Lukas Kaibel on 25.06.26.
+//
+
+import SwiftUI
+
+/// A two-value comparison scoreboard: a neutral reference on the leading side, the tinted subject on
+/// the trailing side, and the trend pill between them reading trailing against leading. The shared
+/// shape behind the in-workout metric popover and every exercise / workout chart-detail header —
+/// one home so the spelled-out values and the badge can never drift apart.
+///
+/// Color carries the meaning, exactly as in the in-workout popover it was lifted from: only the
+/// trailing value wears the muscle-group tint (it's the subject — "you, now"), the leading reference
+/// stays the neutral label color so a glance finds the subject. Each side optionally carries a
+/// caption beneath its value (a date, a date range, a window name); the popover leaves them off, the
+/// chart headers fill them with the period on screen. When `explanation` is set the pill becomes a
+/// button presenting that text as a popover — the chart headers' "what is this?" affordance.
+struct MetricComparisonView: View {
+    struct Side {
+        let label: String
+        /// Pre-formatted value; the "––" placeholder is allowed.
+        let value: String
+        let unit: String
+        /// Optional subtitle beneath the value — a date, a range, a window name. Nil hides it.
+        var caption: String? = nil
+
+        init(label: String, value: String, unit: String, caption: String? = nil) {
+            self.label = label
+            self.value = value
+            self.unit = unit
+            self.caption = caption
+        }
+    }
+
+    /// The neutral reference (leading side).
+    let leading: Side
+    /// The subject (trailing side) — wears `trailingValueStyle`.
+    let trailing: Side
+    /// Style of the trailing value. Defaults to the neutral label color; pass a muscle-group
+    /// `color.gradient` to tint the subject (the popover's live "you, now" side).
+    var trailingValueStyle: AnyShapeStyle = AnyShapeStyle(Color.label)
+    /// Percent of trailing over leading. Nil omits the pill — nothing to compare.
+    let percentChange: Double?
+    var positiveColor: Color = .accentColor
+    var positiveStyle: AnyShapeStyle? = nil
+    var isRecord: Bool = false
+    /// When set, the pill becomes a button presenting this text as a popover.
+    var explanation: String? = nil
+
+    @State private var isShowingInfo = false
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 8) {
+            side(leading, alignment: .leading, valueStyle: AnyShapeStyle(Color.label))
+            Spacer(minLength: 0)
+            pill
+            Spacer(minLength: 0)
+            side(trailing, alignment: .trailing, valueStyle: trailingValueStyle)
+        }
+    }
+
+    private func side(_ side: Side, alignment: HorizontalAlignment, valueStyle: AnyShapeStyle) -> some View {
+        VStack(alignment: alignment, spacing: 1) {
+            Text(side.label)
+                .font(.footnote)
+                .fontWeight(.semibold)
+                .foregroundStyle(.secondary)
+            UnitView(value: side.value, unit: side.unit, configuration: .large)
+                .foregroundStyle(valueStyle)
+            if let caption = side.caption {
+                Text(caption)
+                    .font(.caption)
+                    .fontWeight(.bold)
+                    .fontDesign(.rounded)
+                    .foregroundStyle(.tertiary)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var pill: some View {
+        if let percentChange {
+            let indicator = TrendIndicatorView(
+                percentChange: percentChange,
+                positiveColor: positiveColor,
+                positiveStyle: positiveStyle,
+                isRecord: isRecord
+            )
+            .animation(.snappy, value: percentChange)
+            if let explanation {
+                Button {
+                    isShowingInfo = true
+                } label: {
+                    indicator
+                }
+                .buttonStyle(.plain)
+                .popover(isPresented: $isShowingInfo) {
+                    Text(explanation)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .padding()
+                        .frame(width: 300)
+                        .presentationCompactAdaptation(.popover)
+                }
+            } else {
+                indicator
+            }
+        }
+    }
+}
+
+struct MetricComparisonView_Previews: PreviewProvider {
+    static var previews: some View {
+        VStack(spacing: 40) {
+            // Popover style: no captions, no explanation.
+            MetricComparisonView(
+                leading: .init(label: "Current Best", value: "100", unit: "kg"),
+                trailing: .init(label: "This Workout", value: "105", unit: "kg"),
+                trailingValueStyle: AnyShapeStyle(Color.green.gradient),
+                percentChange: 5,
+                positiveColor: .green
+            )
+            // Chart-header style: captions + tappable explanation.
+            MetricComparisonView(
+                leading: .init(label: "Best", value: "92", unit: "kg", caption: "25 May - 29 Jun"),
+                trailing: .init(label: "Current Best", value: "105", unit: "kg", caption: "10 Jun"),
+                trailingValueStyle: AnyShapeStyle(Color.green.gradient),
+                percentChange: 14,
+                positiveColor: .green,
+                explanation: "Current best (right) is your highest value in the last 4 weeks."
+            )
+        }
+        .padding()
+    }
+}

--- a/LOGIT/SharedUI/Views/MetricTile.swift
+++ b/LOGIT/SharedUI/Views/MetricTile.swift
@@ -1,0 +1,231 @@
+//
+//  MetricTile.swift
+//  LOGIT
+//
+//  Created by Lukas Kaibel on 25.06.26.
+//
+
+import SwiftUI
+
+// MARK: - Compact Chart Frame
+
+/// The fixed size of a metric tile's bottom-right chart slot — small enough to sit beside the trend
+/// pill on one row, and shared by every tile so a line chart and a bar chart line up across a grid.
+/// The chart pins to the tile's trailing edge and gives up its leading edge first when a wide pill
+/// crowds the row, so the newest (rightmost) bar always stays visible.
+enum CompactChartFrame {
+    static let width: CGFloat = 72
+    static let height: CGFloat = 40
+}
+
+// MARK: - Metric Tile
+
+/// The shared metric tile behind every stat on the exercise-detail and workout-detail screens: a
+/// title row with an optional navigation chevron, an optional gray subtitle over the large
+/// label-colored value, and a bottom row carrying the trend pill on the left and a compact chart —
+/// a sparkline or a bar chart, supplied by the caller — in the bottom-right corner.
+///
+/// The accent (a flat muscle color, or a workout's multi-muscle gradient) tints only the trend pill
+/// and, through the caller's chart, the highlighted bar/line; the number itself always stays neutral
+/// so the color reads as "progress", never decoration. One skeleton for every tile so tiles sharing
+/// a grid row always come out the same height — the chart's fixed height anchors the bottom row, and
+/// the empty state renders the real content hidden underneath to match its row neighbor.
+struct MetricTile<ChartContent: View>: View {
+    enum Label {
+        case currentBest
+        case plain(String)
+        /// A plain label with an info button explaining the value — the workout stat tiles explain
+        /// their comparison basis this way.
+        case info(String, explanation: String)
+        /// No subtitle line at all — the title and value carry the whole tile.
+        case none
+    }
+
+    let title: String
+    /// The trailing navigation chevron, on by default since every tile taps into a detail screen.
+    /// Pass `false` for a tile that isn't a button.
+    var showsChevron: Bool = true
+    let label: Label
+    /// Nil renders the "––" placeholder.
+    let value: String?
+    let unit: String
+    /// Tints the trend pill (and, through the caller's chart, the highlighted bar/line). A flat
+    /// `Color` or a multi-muscle gradient, type-erased so both fit. The value and unit stay neutral
+    /// regardless — the accent only ever marks progress.
+    let accent: AnyShapeStyle
+    /// The flat-color form of the accent, for the two consumers that need a `Color` rather than a
+    /// style: the trend pill's non-gradient fallback and the empty state's ghost dot.
+    let accentColor: Color
+    let percentChange: Double?
+    var isRecord: Bool = false
+    /// Gates the tile's data — pill, subtitle, value, and chart — behind Pro (blur + compact crown).
+    /// The title and chevron stay readable so a locked tile still says what it is.
+    var requiresPro: Bool = false
+    /// Last session this tile's metric has a value from, when that session predates the metric's
+    /// window — renders the gray "time since" capsule in the trend pill's slot.
+    var lapsedSince: Date? = nil
+    /// Swaps subtitle, value, and chart for the centered ghost placeholder — for tiles whose metric
+    /// has no usable data at all (the weight tiles of a bodyweight exercise). The content keeps
+    /// rendering hidden underneath so the tile stays exactly as tall as its row neighbor.
+    var showsEmptyPlaceholder: Bool = false
+    @ViewBuilder let chart: () -> ChartContent
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            header
+            if showsEmptyPlaceholder {
+                ZStack {
+                    content.hidden()
+                    placeholder
+                }
+            } else {
+                content
+                    .isBlockedWithoutPro(requiresPro, style: .compact)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(CELL_PADDING)
+        .tileStyle()
+    }
+
+    private var header: some View {
+        HStack(spacing: 6) {
+            Text(title)
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(Color.label)
+                .lineLimit(1)
+                // A long title ("Satzvolumen") gets shrunk rather than ellipsized.
+                .minimumScaleFactor(0.7)
+            Spacer(minLength: 4)
+            if showsChevron {
+                NavigationChevron()
+                    .foregroundStyle(Color.secondaryLabel)
+            }
+        }
+    }
+
+    private var content: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            subtitle
+                .padding(.top, 8)
+            UnitView(value: value ?? "––", unit: unit, configuration: .large, unitColor: .secondaryLabel)
+                .foregroundStyle(Color.label)
+                .padding(.top, 2)
+            // The bottom row sits a fixed gap below the value, the same on every tile, so tiles in a
+            // grid row keep their pills and charts on one line.
+            bottomRow
+                .padding(.top, 16)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    @ViewBuilder
+    private var subtitle: some View {
+        switch label {
+        case .currentBest:
+            CurrentBestLabel()
+        case let .plain(text):
+            Text(text)
+                .font(.footnote)
+                .fontWeight(.semibold)
+                .foregroundStyle(.secondary)
+        case let .info(text, explanation):
+            MetricTileInfoLabel(text: text, explanation: explanation)
+        case .none:
+            EmptyView()
+        }
+    }
+
+    /// Trend pill on the left, compact chart pinned to the trailing edge on the right. The chart's
+    /// fixed height anchors the row, so a tile with no pill (or the shorter lapsed pill) is exactly as
+    /// tall as one with a full trend pill — no height ruler needed. The chart frame is greedy and
+    /// trailing-aligned, so it keeps the chart in the corner and clips its leading edge first if a
+    /// wide pill ever crowds the row.
+    private var bottomRow: some View {
+        HStack(alignment: .bottom, spacing: 8) {
+            pill
+            chart()
+                .frame(width: CompactChartFrame.width, height: CompactChartFrame.height)
+                .frame(maxWidth: .infinity, alignment: .trailing)
+        }
+    }
+
+    @ViewBuilder
+    private var pill: some View {
+        if let percentChange {
+            TrendIndicatorView(
+                percentChange: percentChange,
+                positiveColor: accentColor,
+                positiveStyle: accent,
+                isRecord: isRecord
+            )
+        } else if let lapsedSince {
+            TileLapsedPill(date: lapsedSince)
+        }
+    }
+
+    private var placeholder: some View {
+        VStack(spacing: 10) {
+            GhostSparkline(color: accentColor)
+                .frame(width: 90, height: 30)
+            Text(NSLocalizedString("noData", comment: ""))
+                .font(.footnote.weight(.semibold))
+                .foregroundStyle(.tertiary)
+        }
+        .frame(maxWidth: .infinity)
+    }
+}
+
+// MARK: - Lapsed Pill
+
+/// The gray "time since the last session" capsule in the trend pill's slot on lapsed tiles — the
+/// trend pill's anatomy (icon + rounded bold text on a 0.15 fill) with the history icon and a
+/// relative date, so the stale state is visible right where the trend usually lives. A size softer
+/// than the trend pill: it's quiet metadata, not a score.
+private struct TileLapsedPill: View {
+    let date: Date
+
+    var body: some View {
+        ProgressIndicatorPill(symbol: "clock.arrow.circlepath", color: .secondary, size: .compact) {
+            Text(date, format: .relative(presentation: .numeric, unitsStyle: .narrow))
+                .font(.system(.caption2, design: .rounded, weight: .bold))
+        }
+        // The pill never compresses or wraps — the title next to it shrinks instead.
+        .fixedSize()
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(Text(date, format: .relative(presentation: .named)))
+    }
+}
+
+// MARK: - Info Label
+
+/// Backs `MetricTile.Label.info` — `CurrentBestLabel`'s text + info-dot anatomy with the texts
+/// supplied by the tile (the workout stat tiles explain their comparison basis here).
+private struct MetricTileInfoLabel: View {
+    let text: String
+    let explanation: String
+    @State private var isShowingInfo = false
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Text(text)
+                .fontWeight(.semibold)
+            Button {
+                isShowingInfo = true
+            } label: {
+                Image(systemName: "info.circle")
+            }
+            .popover(isPresented: $isShowingInfo) {
+                Text(explanation)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding()
+                    .frame(width: 300)
+                    .presentationCompactAdaptation(.popover)
+            }
+        }
+        .font(.footnote)
+        .foregroundStyle(.secondary)
+    }
+}


### PR DESCRIPTION
## Summary
Introduces one shared **`MetricTile`** used by every stat tile on the exercise- and workout-detail screens, matching the reference design:

- Title row with an optional navigation chevron, an optional gray subtitle over a **neutral value**, and a bottom row with the **trend pill on the left and a compact line/bar chart in the corner**.
- The **accent** (a muscle color *or* a gradient) tints only the pill and the highlighted bar/line — never the number.
- It replaces `ExerciseMetricTileLayout` (renamed + redesigned, moved to `SharedUI/Views`); the exercise and workout tiles adopt it.

## Also in this change
- **Sparkline fade** — tile line charts fade their area fill to transparent at the baseline so it blends into the tile instead of ending on a hard edge (shared `tileSparklineFadeMask`).
- **`MetricComparisonView`** — a shared two-value comparison scoreboard behind the chart-detail headers and the in-workout popover; the period-over-period **Highlights** section is dropped from the chart detail screens (redundant with the scoreboard + trend pills).
- Supporting tile-style and localization updates (8 locales).

## Verification
- Builds clean on the iPhone 17 Pro simulator (zero warnings in the changed files).
- Both detail screens, the free tier (Pro blur), and the sparkline fade verified by non-interactive simulator screenshots + pixel sampling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)