### PR TITLE
Fade the all-time sparkline's area into the card's bottom edge

### DIFF
--- a/LOGIT/Features/Exercise/ExerciseDetail/Tiles/ExerciseMetricTile.swift
+++ b/LOGIT/Features/Exercise/ExerciseDetail/Tiles/ExerciseMetricTile.swift
@@ -321,10 +321,11 @@ struct ExerciseTileSparkline: View {
         .frame(maxWidth: .infinity)
         .frame(height: height)
         // The all-time window spans the full width and skips `.clipped()` and the leading fade — its
-        // whole point is to show where the history begins and ends. The windowed sparklines clip and
-        // fade in from the left.
+        // whole point is to show where the history begins and ends — but it still fades its area out
+        // at the bottom so the full-bleed fill melts into the card border instead of being clipped
+        // while still tinted. The windowed sparklines clip and fade in from the left (and bottom).
         if window == .allTime {
-            base
+            base.tileSparklineBottomFadeMask()
         } else {
             base.clipped().tileSparklineFadeMask()
         }

--- a/LOGIT/SharedUI/Charts/TileSparklineStyle.swift
+++ b/LOGIT/SharedUI/Charts/TileSparklineStyle.swift
@@ -144,10 +144,9 @@ func tileSparklineMarks(
 
 extension View {
     /// Fades a tile sparkline in from its leading edge (so the clipped line dissolves into the tile
-    /// rather than starting on a hard vertical) AND out toward the bottom (so the area fill melts into
-    /// the tile instead of ending on a hard horizontal edge at the baseline — Swift Charts can't fade
-    /// the `AreaMark` itself reliably). Two stacked masks compose to "visible where both are opaque".
-    /// Shared by every tile sparkline's frame treatment.
+    /// rather than starting on a hard vertical) AND out toward the bottom. Two stacked masks compose
+    /// to "visible where both are opaque". Shared by the windowed tile sparklines' frame treatment;
+    /// the all-time line wants only the bottom half and applies `tileSparklineBottomFadeMask()` alone.
     func tileSparklineFadeMask() -> some View {
         mask(
             LinearGradient(
@@ -160,11 +159,18 @@ extension View {
                 endPoint: .trailing
             )
         )
-        .mask(
+        .tileSparklineBottomFadeMask()
+    }
+
+    /// Fades a tile sparkline out toward its BOTTOM edge so the area fill melts into the surface
+    /// instead of ending on a hard horizontal at the baseline (Swift Charts can't fade the `AreaMark`
+    /// itself reliably — left alone it gets clipped while still tinted). The line and the band just
+    /// under it stay opaque; only the lower fill dissolves. Used on its own by the all-time line,
+    /// which bleeds to the card's bottom border and wants this fade but not the leading one.
+    func tileSparklineBottomFadeMask() -> some View {
+        mask(
             LinearGradient(
                 gradient: Gradient(stops: [
-                    // Opaque through the line and the band just under it, then fade to clear at the
-                    // baseline so the fill blends into the tile.
                     .init(color: .black, location: 0.0),
                     .init(color: .black, location: 0.4),
                     .init(color: .clear, location: 1.0),


### PR DESCRIPTION
## What

The personal-records cards' line chart bleeds to the card's bottom border, but its area fill was being **clipped there while still tinted** (~0.17 opacity purple right at the border) instead of dissolving into the card.

Swift Charts can't fade an `AreaMark`'s gradient to transparent on its own, so the windowed tile sparklines already rely on a bottom fade mask — but the all-time line rendered as bare `base` with no mask.

## Fix

- Extract the bottom fade into its own `tileSparklineBottomFadeMask()` modifier.
- Apply it to the `.allTime` branch, which wants the bottom fade but **not** the windowed charts' leading fade.

The line and the band just under it stay opaque; only the lower fill melts away. Verified by pixel-sampling the rebuilt screen — the fill now ramps from the line down to exactly the card background `(28,28,30)` at the bottom border.

🤖 Generated with [Claude Code](https://claude.com/claude-code)