### PR TITLE
Make the template editor a full-screen editor matching the workout recorder

### DIFF
--- a/LOGIT/App/LOGITApp.swift
+++ b/LOGIT/App/LOGITApp.swift
@@ -229,7 +229,7 @@ struct LOGIT: App {
                         }
                     }
                 }
-                .sheet(item: $importedTemplate) { template in
+                .fullScreenCover(item: $importedTemplate) { template in
                     TemplateEditorScreen(
                         template: template,
                         isEditingExistingTemplate: false,

--- a/LOGIT/Features/Template/Cells/TemplateSetGroupCell.swift
+++ b/LOGIT/Features/Template/Cells/TemplateSetGroupCell.swift
@@ -23,6 +23,7 @@ struct TemplateSetGroupCell: View {
 
     let supplementaryText: String?
     var showDetailAsSheet: Bool = false
+    var onTapRestDuration: ((TemplateSet) -> Void)? = nil
 
     // MARK: - State
 
@@ -43,21 +44,28 @@ struct TemplateSetGroupCell: View {
                             canReorder: false,
                             isReordering: .constant(false)
                         ) { templateSet in
-                            TemplateSetCell(
-                                templateSet: templateSet,
-                                focusedIntegerFieldIndex: $focusedIntegerFieldIndex,
-                                onEditRestDuration: nil
-                            )
-                            .contentShape(Rectangle())
-                            .background(
-                                RoundedRectangle(cornerRadius: 15)
-                                    .fill(.shadow(.inner(color: .black.opacity(0.4), radius: 5)))
-                                    .foregroundStyle(Color.tertiaryBackground)
-                            )
-                            .cornerRadius(15)
-                            .onDeleteView(disabled: !canEdit) {
-                                withAnimation(.interactiveSpring()) {
-                                    database.delete(templateSet)
+                            VStack(spacing: CELL_SPACING) {
+                                TemplateSetCell(
+                                    templateSet: templateSet,
+                                    focusedIntegerFieldIndex: $focusedIntegerFieldIndex,
+                                    onEditRestDuration: onTapRestDuration.map { callback in
+                                        { callback(templateSet) }
+                                    }
+                                )
+                                .contentShape(Rectangle())
+                                .background(
+                                    RoundedRectangle(cornerRadius: 15)
+                                        .fill(.shadow(.inner(color: .black.opacity(0.4), radius: 5)))
+                                        .foregroundStyle(Color.tertiaryBackground)
+                                )
+                                .cornerRadius(15)
+                                .onDeleteView(disabled: !canEdit) {
+                                    withAnimation(.interactiveSpring()) {
+                                        database.delete(templateSet)
+                                    }
+                                }
+                                if !isLastSet(templateSet), templateSet.restDurationSeconds > 0 {
+                                    restLabel(for: templateSet)
                                 }
                             }
                         }
@@ -66,6 +74,19 @@ struct TemplateSetGroupCell: View {
                     .animation(.interactiveSpring(), value: setGroup.sets)
                     if canEdit {
                         HStack(spacing: 8) {
+                            Button {
+                                UIImpactFeedbackGenerator(style: .soft).impactOccurred()
+                                withAnimation(.interactiveSpring()) {
+                                    database.duplicateLastSet(from: setGroup)
+                                }
+                            } label: {
+                                Image(systemName: "plus.square.on.square")
+                                    .foregroundStyle((setGroup.exercise?.muscleGroup?.color ?? .accentColor).gradient)
+                                    .font(.system(.body, design: .rounded, weight: .bold))
+                                    .padding(15)
+                                    .background(Color.accentColor.secondaryTranslucentBackground)
+                                    .clipShape(Capsule())
+                            }
                             Button {
                                 UIImpactFeedbackGenerator(style: .soft).impactOccurred()
                                 withAnimation(.interactiveSpring()) {
@@ -83,19 +104,7 @@ struct TemplateSetGroupCell: View {
                                 .background(Color.accentColor.secondaryTranslucentBackground)
                                 .clipShape(Capsule())
                             }
-                            Button {
-                                UIImpactFeedbackGenerator(style: .soft).impactOccurred()
-                                withAnimation(.interactiveSpring()) {
-                                    database.duplicateLastSet(from: setGroup)
-                                }
-                            } label: {
-                                Image(systemName: "plus.square.on.square")
-                                    .foregroundStyle((setGroup.exercise?.muscleGroup?.color ?? .accentColor).gradient)
-                                    .font(.system(.body, design: .rounded, weight: .bold))
-                                    .padding(15)
-                                    .background(Color.accentColor.secondaryTranslucentBackground)
-                                    .clipShape(Capsule())
-                            }
+                            menu
                         }
                         .padding(.horizontal, CELL_PADDING)
                     }
@@ -155,10 +164,43 @@ struct TemplateSetGroupCell: View {
         }
     .accentColor(setGroup.exercise?.muscleGroup?.color ?? .accentColor)
     .padding(.bottom, canEdit || isReordering ? CELL_PADDING : CELL_PADDING / 2)
-    .tileStyle()
+    .background(
+        RoundedRectangle(cornerRadius: 30)
+            .fill(.shadow(.inner(color: .white.opacity(0.04), radius: 3)))
+            .foregroundStyle(Color.secondaryBackground)
+    )
+    .cornerRadius(30)
     }
 
     // MARK: - Supporting Views
+
+    /// A static, tappable rest indicator shown between two sets (mirrors the recorder's
+    /// `RestTimerBetweenSetsView`, but without the live chronograph since templates don't run a timer).
+    private func restLabel(for templateSet: TemplateSet) -> some View {
+        let label = RestDurationLabel(
+            seconds: templateSet.restDurationSeconds,
+            foregroundColor: .secondary,
+            iconName: "timer",
+            textFont: .caption.weight(.semibold),
+            iconFont: .caption.weight(.semibold)
+        )
+        return Group {
+            if let onTapRestDuration {
+                Button {
+                    onTapRestDuration(templateSet)
+                } label: {
+                    label
+                }
+                .buttonStyle(.plain)
+            } else {
+                label
+            }
+        }
+    }
+
+    private func isLastSet(_ templateSet: TemplateSet) -> Bool {
+        setGroup.sets.last == templateSet
+    }
 
     private var header: some View {
         VStack(spacing: 8) {
@@ -197,7 +239,6 @@ struct TemplateSetGroupCell: View {
                     .font(.system(.footnote, design: .rounded, weight: .bold))
                 }
                 Spacer()
-                if canEdit && !isReordering { menu }
                 if isReordering {
                     Image(systemName: "line.3.horizontal")
                         .fontWeight(.regular)
@@ -285,12 +326,11 @@ struct TemplateSetGroupCell: View {
         } label: {
             Image(systemName: "ellipsis")
                 .foregroundStyle((setGroup.exercise?.muscleGroup?.color ?? .accentColor).gradient)
-                .padding(.horizontal, 3)
-                .padding(.vertical, 10)
-                .background(
-                    Circle()
-                        .fill((setGroup.exercise?.muscleGroup?.color ?? .accentColor).secondaryTranslucentBackground)
-                )
+                .font(.system(.body, design: .rounded, weight: .bold))
+                .frame(width: 20, height: 20)
+                .padding(15)
+                .background(Color.accentColor.secondaryTranslucentBackground)
+                .clipShape(Circle())
         }
     }
 }

--- a/LOGIT/Features/Template/CreateTemplateMenu.swift
+++ b/LOGIT/Features/Template/CreateTemplateMenu.swift
@@ -54,12 +54,11 @@ struct CreateTemplateMenu: View {
             guard let template = newValue else { return }
             database.flagAsTemporary(template)
         }
-        .sheet(item: $newTemplate) { template in
+        .fullScreenCover(item: $newTemplate) { template in
             TemplateEditorScreen(
                 template: template,
                 isEditingExistingTemplate: false
             )
-            .presentationBackground(Color.black)
         }
         .sheet(isPresented: $isShowingUpgradeToProScreen) {
             UpgradeToProScreen()

--- a/LOGIT/Features/Template/TemplateDetailScreen.swift
+++ b/LOGIT/Features/Template/TemplateDetailScreen.swift
@@ -140,9 +140,8 @@ struct TemplateDetailScreen: View {
             actions: {},
             message: { Text(NSLocalizedString("templateExplanation", comment: "")) }
         )
-        .sheet(isPresented: $showingTemplateEditor) {
+        .fullScreenCover(isPresented: $showingTemplateEditor) {
             TemplateEditorScreen(template: template, isEditingExistingTemplate: true)
-                .presentationBackground(Color.black)
         }
     }
 

--- a/LOGIT/Features/Template/TemplateEditorScreen.swift
+++ b/LOGIT/Features/Template/TemplateEditorScreen.swift
@@ -43,6 +43,7 @@ struct TemplateEditorScreen: View {
     @State private var selectedRestDurationSet: TemplateSet?
     @State private var exerciseSelectionPresentationDetent: PresentationDetent = .medium
     @State private var isRenamingTemplate = false
+    @State private var focusedIntegerFieldIndex: IntegerField.Index?
     @FocusState private var isFocusingRenameTemplateField: Bool
 
     // MARK: - Parameters
@@ -111,11 +112,12 @@ struct TemplateEditorScreen: View {
                                 VStack(spacing: 0) {
                                     TemplateSetGroupCell(
                                         setGroup: setGroup,
-                                        focusedIntegerFieldIndex: .constant(nil),
+                                        focusedIntegerFieldIndex: $focusedIntegerFieldIndex,
                                         sheetType: $sheetType,
                                         isReordering: .constant(false),
                                         supplementaryText: nil,
-                                        showDetailAsSheet: true
+                                        showDetailAsSheet: true,
+                                        onTapRestDuration: { selectedRestDurationSet = $0 }
                                     )
                                     .shadow(color: .black.opacity(0.5), radius: 5)
                                     .zIndex(1)
@@ -206,7 +208,8 @@ struct TemplateEditorScreen: View {
                 }
             }
             .interactiveDismissDisabled()
-            .presentationBackground(.thickMaterial)
+            .background(Color.black.ignoresSafeArea())
+            .presentationBackground(.black)
             .navigationBarTitleDisplayMode(.inline)
             .navigationBarHidden(isRenamingTemplate)
             .onAppear {
@@ -261,10 +264,35 @@ struct TemplateEditorScreen: View {
                     ToolbarItemGroup(placement: .keyboard) {
                         HStack {
                             Spacer()
+                            if focusedIntegerFieldIndex != nil, let templateSet = selectedTemplateSet {
+                                Button {
+                                    // Dismiss the keyboard first, then present the rest sheet on the next
+                                    // runloop tick so the keyboard teardown and the sheet presentation
+                                    // don't race. The sheet itself is presented from within the
+                                    // exercise-selection sheet (see `selectedRestDurationSet`), so it
+                                    // stacks on top of it instead of colliding.
+                                    UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+                                    focusedIntegerFieldIndex = nil
+                                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                                        selectedRestDurationSet = templateSet
+                                    }
+                                } label: {
+                                    Image(systemName: "timer")
+                                        .keyboardToolbarButtonStyle()
+                                }
+                            }
                             Button {
-                                UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+                                if focusedIntegerFieldIndex == nil {
+                                    UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+                                } else {
+                                    focusedIntegerFieldIndex = nil
+                                }
                             } label: {
                                 Image(systemName: "keyboard.chevron.compact.down")
+                                    .keyboardToolbarButtonStyle()
+                            }
+                            if focusedIntegerFieldIndex != nil {
+                                Spacer()
                             }
                         }
                     }
@@ -278,6 +306,14 @@ struct TemplateEditorScreen: View {
 
     private var templateName: Binding<String> {
         Binding(get: { template.name ?? "" }, set: { template.name = $0 })
+    }
+
+    /// The template set whose rep/weight field currently holds focus, derived from the keyboard
+    /// field index — mirrors the recorder's `selectedWorkoutSet`. `IntegerField.Index.primary` is
+    /// the set's position in the flat `template.sets` list.
+    private var selectedTemplateSet: TemplateSet? {
+        guard let focusedIndex = focusedIntegerFieldIndex else { return nil }
+        return template.sets.value(at: focusedIndex.primary)
     }
 
     @ViewBuilder

--- a/LOGIT/Features/Template/TemplateListScreen.swift
+++ b/LOGIT/Features/Template/TemplateListScreen.swift
@@ -142,9 +142,8 @@ struct TemplateListScreen: View {
                     }
                 }
             }
-            .popover(isPresented: $showingTemplateCreation) {
+            .fullScreenCover(isPresented: $showingTemplateCreation) {
                 TemplateEditorScreen(template: database.newTemplate(), isEditingExistingTemplate: false)
-                    .presentationBackground(Color.black)
             }
             .navigationDestination(item: $selectedTemplate) { template in
                 TemplateDetailScreen(template: template)

--- a/LOGIT/Features/Workout/WorkoutDetailScreen.swift
+++ b/LOGIT/Features/Workout/WorkoutDetailScreen.swift
@@ -12,7 +12,7 @@ import SwiftUI
 
 struct WorkoutDetailScreen: View {
     enum SheetType: Int, Identifiable {
-        case newTemplateFromWorkout, workoutEditor
+        case workoutEditor
         var id: Int { rawValue }
     }
 
@@ -26,6 +26,7 @@ struct WorkoutDetailScreen: View {
 
     @State private var isShowingDeleteWorkoutAlert: Bool = false
     @State private var sheetType: SheetType? = nil
+    @State private var newTemplateFromWorkout: Template?
     @State private var selectedTemplate: Template?
     @State private var selectedStatMetric: WorkoutStatMetric?
     @State private var headerTextHeight: CGFloat = 64
@@ -126,7 +127,7 @@ struct WorkoutDetailScreen: View {
                         }
                     } else {
                         Button {
-                            sheetType = .newTemplateFromWorkout
+                            newTemplateFromWorkout = database.newTemplate(from: workout)
                         } label: {
                             Label(NSLocalizedString("saveAsTemplate", comment: ""), systemImage: "plus.square.on.square")
                         }
@@ -180,15 +181,15 @@ struct WorkoutDetailScreen: View {
         }
         .sheet(item: $sheetType) { type in
             switch type {
-            case .newTemplateFromWorkout:
-                TemplateEditorScreen(
-                    template: database.newTemplate(from: workout),
-                    isEditingExistingTemplate: false
-                )
-                .presentationBackground(Color.black)
             case .workoutEditor:
                 WorkoutEditorScreen(workout: workout, isAddingNewWorkout: false)
             }
+        }
+        .fullScreenCover(item: $newTemplateFromWorkout) { template in
+            TemplateEditorScreen(
+                template: template,
+                isEditingExistingTemplate: false
+            )
         }
         .navigationDestination(item: $selectedTemplate) { template in
             NavigationStack {

--- a/LOGIT/Features/Workout/WorkoutRecorder/SupportingViews/RestDurationEditorSheet.swift
+++ b/LOGIT/Features/Workout/WorkoutRecorder/SupportingViews/RestDurationEditorSheet.swift
@@ -10,7 +10,12 @@ import SwiftUI
 struct RestDurationEditorSheet: View {
     @Environment(\.dismiss) private var dismiss
 
-    @Binding private var restDurationSeconds: Int
+    /// Local source of truth so the displayed time re-renders immediately on every tap. The sheet
+    /// doesn't observe the underlying set, so a manual `Binding` into it persisted writes but never
+    /// invalidated this view — the number and preset highlight stayed stale. We mirror the value
+    /// here and write it back to the set via `applyRest` whenever it changes.
+    @State private var restDurationSeconds: Int
+    private let applyRest: (Int) -> Void
 
     private let exerciseName: String?
     private let themeColor: Color
@@ -19,19 +24,15 @@ struct RestDurationEditorSheet: View {
     private let quickAdjustments = [-15, -5, 5, 15]
 
     init(workoutSet: WorkoutSet) {
-        _restDurationSeconds = Binding(
-            get: { workoutSet.restDurationSeconds },
-            set: { workoutSet.restDurationSeconds = $0 }
-        )
+        _restDurationSeconds = State(initialValue: workoutSet.restDurationSeconds)
+        applyRest = { workoutSet.restDurationSeconds = $0 }
         exerciseName = workoutSet.exercise?.displayName
         themeColor = workoutSet.exercise?.muscleGroup?.color ?? .accentColor
     }
 
     init(templateSet: TemplateSet) {
-        _restDurationSeconds = Binding(
-            get: { templateSet.restDurationSeconds },
-            set: { templateSet.restDurationSeconds = $0 }
-        )
+        _restDurationSeconds = State(initialValue: templateSet.restDurationSeconds)
+        applyRest = { templateSet.restDurationSeconds = $0 }
         exerciseName = templateSet.exercise?.displayName
         themeColor = templateSet.exercise?.muscleGroup?.color ?? .accentColor
     }
@@ -105,6 +106,12 @@ struct RestDurationEditorSheet: View {
                     Button {
                         UISelectionFeedbackGenerator().selectionChanged()
                         restDurationSeconds = seconds
+                        // Picking a preset is a complete choice — dismiss so the user doesn't
+                        // also have to tap Done. The brief delay lets the selection highlight and
+                        // the value update register before the sheet closes.
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                            dismiss()
+                        }
                     } label: {
                         Text(restTimeString(seconds: seconds))
                             .font(.body.weight(.semibold).monospacedDigit())
@@ -127,8 +134,14 @@ struct RestDurationEditorSheet: View {
             }
 
             Button {
+                UISelectionFeedbackGenerator().selectionChanged()
                 withAnimation(.easeOut(duration: 0.2)) {
                     restDurationSeconds = 0
+                }
+                // Removing the rest is also a complete choice — dismiss once the value has
+                // animated to zero, matching the preset buttons.
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                    dismiss()
                 }
             } label: {
                 Label(NSLocalizedString("remove", comment: ""), systemImage: "xmark.circle.fill")
@@ -142,6 +155,9 @@ struct RestDurationEditorSheet: View {
             .buttonStyle(.plain)
         }
         .padding()
+        .onChange(of: restDurationSeconds) { _, newValue in
+            applyRest(newValue)
+        }
     }
 
     private func adjustRestDuration(by adjustment: Int) {


### PR DESCRIPTION
## What

Updates the template editor to feel like the workout recorder, and adds per-set rest editing from the keyboard.

### Presentation & layout
- Presents `TemplateEditorScreen` as a **full-screen cover** (was a sheet/popover) at every entry point — templates list, create menu, template detail, new-from-workout, and imported-template — on a **solid black** background. The header (Cancel / menu title / Save) is unchanged.
- Reworks `TemplateSetGroupCell` to mirror `WorkoutSetGroupCell`: recessed inner-shadow background and a `[Duplicate, Add Set, ⋯]` action row — **without** the metric badge.

### Per-set rest in templates
- The editor now tracks the focused set field, so the **keyboard toolbar** (restyled to the recorder's padding) can carry a **rest-timer button** that opens `RestDurationEditorSheet` for the focused set. The sheet is presented from inside the persistent exercise-selection sheet so the two don't collide.
- A tappable rest label is shown between sets. Per-set rest already copies into the recorded workout via `startWorkout(from:)` and drives the auto rest timer — no new plumbing needed.

### RestDurationEditorSheet
- Auto-dismisses after picking a preset or removing the rest (±-adjust stays open for tuning).
- Fixes the live time display: the sheet didn't observe the underlying set, so taps persisted the value but never re-rendered. The value is now mirrored in `@State` and written back on change.

## Testing
- Builds clean (zero warnings) in an isolated worktree off `main`.
- Verified in the simulator: full-screen black editor, recorder-style cells (no badge), and the between-set rest label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)