### PR TITLE
Widen the horizontal padding on the exercise detail screen

### DIFF
--- a/LOGIT/Features/Exercise/ExerciseDetail/ExerciseDetailScreen.swift
+++ b/LOGIT/Features/Exercise/ExerciseDetail/ExerciseDetailScreen.swift
@@ -68,10 +68,10 @@ struct ExerciseDetailScreen: View {
             ScrollView {
                 VStack(spacing: SECTION_SPACING) {
                     header
-                        .padding(.horizontal)
+                        .padding(.horizontal, 20)
 
                     metricTiles(workoutSets: workoutSets)
-                        .padding(.horizontal)
+                        .padding(.horizontal, 20)
 
                     VStack(spacing: SECTION_HEADER_SPACING) {
                         HStack {
@@ -111,7 +111,7 @@ struct ExerciseDetailScreen: View {
                         }
                         .padding(.top, 5)
                     }
-                    .padding(.horizontal)
+                    .padding(.horizontal, 20)
                     .padding(.bottom, SCROLLVIEW_BOTTOM_PADDING)
                 }
                 .animation(.easeInOut, value: workoutSetGroups)


### PR DESCRIPTION
Bump the header, metric tiles, and recent-attempts sections of `ExerciseDetailScreen` from the default 16pt horizontal inset to 20pt, so the content sits less tightly against the screen edges. The separate instructions/lookup sheet keeps the default inset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)