### PR TITLE
Shrink the workout detail title to fit instead of truncating it

### DIFF
--- a/LOGIT/Features/Workout/WorkoutDetailScreen.swift
+++ b/LOGIT/Features/Workout/WorkoutDetailScreen.swift
@@ -220,6 +220,7 @@ struct WorkoutDetailScreen: View {
                 Text(workout.name ?? "")
                     .screenHeaderStyle()
                     .lineLimit(2)
+                    .minimumScaleFactor(0.6)
             }
             // The donut matches the height of date + title (like the workout cell's header row),
             // measured so a wrapping title scales it rather than leaving it floating.


### PR DESCRIPTION
## What

The workout name on the **detail screen header** is shown at `.largeTitle` and capped at `.lineLimit(2)`, so longer names were cut off with an ellipsis.

This adds `.minimumScaleFactor(0.6)` so the title scales down to fit within the two lines instead of truncating.

## Why this approach

The muscle-group donut next to the title is sized to the title's measured height (`headerTextHeight`). Simply removing the line limit would let a long name grow the donut — and since a bigger donut steals width from the text, that can feed back into even more wrapping. Keeping the two-line cap and shrinking the glyphs instead keeps the donut's size stable while ensuring the full name is always readable.

## Test

- Builds clean on iPhone 17 Pro (`** BUILD SUCCEEDED **`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)