### PR TITLE
Add a shared set-weighted, spectrum-sorted muscle-group gradient

### DIFF
--- a/LOGIT/Core/Extentions/View+.swift
+++ b/LOGIT/Core/Extentions/View+.swift
@@ -29,3 +29,17 @@ import SwiftUI
 
  }
  */
+
+extension View {
+    /// Fills the view's content with a single `ShapeStyle` resolved across the *whole* view's bounds,
+    /// so a gradient reads as one continuous sweep over a multi-part view — a `UnitView`'s value+unit,
+    /// a pill's icon+label — instead of SwiftUI restarting the gradient inside each child `Text`/
+    /// `Image`. Implemented by masking one full-bounds fill with the content's shape.
+    ///
+    /// For a flat `Color` it matches `.foregroundStyle`. Note it paints the entire content with the
+    /// one style, overriding any per-child color override — use it only where the whole content is
+    /// meant to share the single style.
+    func continuousForegroundStyle<S: ShapeStyle>(_ style: S) -> some View {
+        overlay { Rectangle().fill(style).mask { self } }
+    }
+}

--- a/LOGIT/Features/Workout/WorkoutDetailScreen.swift
+++ b/LOGIT/Features/Workout/WorkoutDetailScreen.swift
@@ -243,7 +243,7 @@ struct WorkoutDetailScreen: View {
         let improved = report.improvedTrendCount
         // Muscle-group gradient once at least one exercise improved, muted gray otherwise.
         let style = improved > 0
-            ? workout.muscleGroups.gradientStyle()
+            ? workout.sets.muscleGroupGradientStyle(startPoint: .bottomLeading, endPoint: .topTrailing)
             : AnyShapeStyle(Color.secondary)
         return ProgressIndicatorPill(symbol: improved > 0 ? "chevron.up" : nil, style: style) {
             Text(String(format: NSLocalizedString("improvedCount", comment: ""), improved))

--- a/LOGIT/Features/Workout/WorkoutProgressSection.swift
+++ b/LOGIT/Features/Workout/WorkoutProgressSection.swift
@@ -339,11 +339,11 @@ struct WorkoutPersonalRecordsScreen: View {
         VStack(spacing: 10) {
             ZStack {
                 Circle()
-                    .fill(workout.muscleGroups.gradient(startPoint: .bottomLeading, endPoint: .topTrailing).opacity(0.15))
+                    .fill(workout.sets.muscleGroupGradient(startPoint: .bottomLeading, endPoint: .topTrailing).opacity(0.15))
                     .frame(width: 64, height: 64)
                 Image(systemName: "trophy.fill")
                     .font(.system(size: 28))
-                    .muscleGroupGradientStyle(for: workout.muscleGroups)
+                    .foregroundStyle(workout.sets.muscleGroupGradientStyle(startPoint: .bottomLeading, endPoint: .topTrailing))
             }
             Text(personalRecordsHeadline(count: report.prRecords.count))
                 .font(.title2.weight(.bold))

--- a/LOGIT/Features/Workout/WorkoutStatScreen.swift
+++ b/LOGIT/Features/Workout/WorkoutStatScreen.swift
@@ -170,10 +170,10 @@ struct WorkoutStatScreen: View {
                 unit: metric.unit,
                 caption: workout.date?.formatted(.dateTime.day().month())
             ),
-            trailingValueStyle: isDuration ? AnyShapeStyle(Color.label) : workout.muscleGroups.gradientStyle(),
+            trailingValueStyle: isDuration ? AnyShapeStyle(Color.label) : workout.sets.muscleGroupGradientStyle(startPoint: .bottomLeading, endPoint: .topTrailing),
             percentChange: percentChange,
             positiveColor: isDuration ? .secondary : dominantMuscleGroupColor,
-            positiveStyle: isDuration ? nil : workout.muscleGroups.gradientStyle()
+            positiveStyle: isDuration ? nil : workout.sets.muscleGroupGradientStyle(startPoint: .bottomLeading, endPoint: .topTrailing)
         )
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.horizontal)
@@ -415,7 +415,7 @@ struct WorkoutStatScreen: View {
     /// ("now showing this"); every other bar stays a quiet gray. `isCurrent` wins when the current
     /// bar is itself the tapped one — its gradient already stands out.
     private func barStyle(for point: StatPoint, snappedPoint: StatPoint?) -> AnyShapeStyle {
-        if point.isCurrent { return workout.muscleGroups.gradientStyle(startPoint: .bottom, endPoint: .top) }
+        if point.isCurrent { return workout.sets.muscleGroupGradientStyle(startPoint: .bottom, endPoint: .top) }
         if snappedPoint?.id == point.id { return AnyShapeStyle(Color.label) }
         return AnyShapeStyle(Color.fill)
     }

--- a/LOGIT/Features/Workout/WorkoutStatTiles.swift
+++ b/LOGIT/Features/Workout/WorkoutStatTiles.swift
@@ -323,15 +323,18 @@ struct WorkoutRunsBarChart: View {
 /// One compact session stat on the workout detail — the shared metric tile with the workout
 /// vocabulary: "This Workout" over a neutral value, the trend pill wearing the workout's
 /// muscle-group gradient on a gain, and the run bars in the corner with this workout's bar in that
-/// same accent. The duration tile stays neutral gray in both directions — a longer workout is
+/// same gradient. The duration tile stays neutral gray in both directions — a longer workout is
 /// neither better nor worse.
 struct WorkoutStatTile: View {
     let metric: WorkoutStatMetric
     let workout: Workout
     let history: WorkoutRunHistory
-    /// Tints the trend pill and the current workout's bar — the workout's muscle-group gradient, or
-    /// neutral gray on the duration tile.
+    /// Tints the trend pill — the workout's muscle-group gradient on a diagonal (text reads
+    /// diagonally), or neutral gray on the duration tile.
     let accent: AnyShapeStyle
+    /// Tints the current workout's run bar — the same muscle-group gradient as `accent` but running
+    /// vertically (bars read bottom-to-top), or neutral gray on the duration tile.
+    let barStyle: AnyShapeStyle
     /// The flat-color form of `accent`, for the pill's non-gradient fallback and the ghost dot.
     let accentColor: Color
 
@@ -354,7 +357,7 @@ struct WorkoutStatTile: View {
             isRecord: false,
             requiresPro: metric.requiresPro
         ) {
-            WorkoutRunsBarChart(bars: runBars, currentStyle: accent)
+            WorkoutRunsBarChart(bars: runBars, currentStyle: barStyle)
         }
     }
 
@@ -419,6 +422,7 @@ struct WorkoutStatTileGrid: View {
 
     private func tile(_ metric: WorkoutStatMetric, history: WorkoutRunHistory) -> some View {
         let isDuration = metric == .duration
+        let sets = workout.sets
         return Button {
             onOpenDetail(metric)
         } label: {
@@ -426,7 +430,8 @@ struct WorkoutStatTileGrid: View {
                 metric: metric,
                 workout: workout,
                 history: history,
-                accent: isDuration ? AnyShapeStyle(Color.secondary) : workout.muscleGroups.gradientStyle(),
+                accent: isDuration ? AnyShapeStyle(Color.secondary) : sets.muscleGroupGradientStyle(startPoint: .bottomLeading, endPoint: .topTrailing),
+                barStyle: isDuration ? AnyShapeStyle(Color.secondary) : sets.muscleGroupGradientStyle(startPoint: .bottom, endPoint: .top),
                 accentColor: isDuration ? .secondary : dominantMuscleGroupColor
             )
         }

--- a/LOGIT/SharedUI/Charts/PieGraph.swift
+++ b/LOGIT/SharedUI/Charts/PieGraph.swift
@@ -84,7 +84,8 @@ struct PieGraph<CenterView: View>: View {
             Text(item.title)
                 .foregroundColor(.primary)
             UnitView(value: "\(percentage(for: item))", unit: "%")
-                .foregroundStyle((item.amount > 0 ? item.color : .placeholder).gradient)
+                // One continuous gradient across value + unit, not one restarting in each.
+                .continuousForegroundStyle((item.amount > 0 ? item.color : .placeholder).gradient)
         }
         .frame(minWidth: 80, alignment: .leading)
     }

--- a/LOGIT/SharedUI/Styles/MuscleGroupGradientStyle.swift
+++ b/LOGIT/SharedUI/Styles/MuscleGroupGradientStyle.swift
@@ -7,46 +7,90 @@
 
 import SwiftUI
 
-struct MuscleGroupGradientModifier: ViewModifier {
-    let muscleGroups: [MuscleGroup]
-
-    func body(content: Content) -> some View {
-        content
-            .foregroundStyle(
-                .linearGradient(
-                    colors: muscleGroups.isEmpty ? [.accentColor] : muscleGroups.map { $0.color },
-                    startPoint: .bottomLeading,
-                    endPoint: .topTrailing
-                )
-            )
-    }
-}
-
-extension View {
-    func muscleGroupGradientStyle(for muscleGroups: [MuscleGroup]) -> some View {
-        modifier(MuscleGroupGradientModifier(muscleGroups: muscleGroups))
-    }
-}
-
 extension Sequence where Element == MuscleGroup {
-    /// The muscle-group gradient as a concrete `LinearGradient` value — the muscle colors in order,
-    /// falling back to the accent color when there are none. For call sites that need a real
-    /// `LinearGradient` rather than a type-erased style (e.g. `ComparisonBar`'s workout-themed fill);
-    /// `gradientStyle()` wraps this for `ShapeStyle` call sites.
-    func gradient(startPoint: UnitPoint = .leading, endPoint: UnitPoint = .trailing) -> LinearGradient {
-        let colors = map(\.color)
-        return LinearGradient(
-            colors: colors.isEmpty ? [.accentColor] : colors,
-            startPoint: startPoint,
-            endPoint: endPoint
-        )
+    /// A gradient that reflects *how often* each muscle group occurs in the sequence — pass one
+    /// element per set and the colours are weighted by set count, so a muscle group trained in
+    /// more sets claims a proportionally wider, more prominent share of the gradient. The distinct
+    /// colours are ordered around the spectrum (by hue) and each is anchored at the midpoint of its
+    /// share, so neighbouring colours blend smoothly into one another instead of clashing. Falls
+    /// back to the accent colour when the sequence is empty.
+    ///
+    /// This is the single source of muscle-group gradients in the app. Call sites that have the
+    /// sets entered should prefer `Sequence<WorkoutSet>.muscleGroupGradient(...)`, which feeds this
+    /// one muscle group per set so the set weighting takes effect.
+    func weightedSpectrumGradient(
+        startPoint: UnitPoint = .leading,
+        endPoint: UnitPoint = .trailing
+    ) -> LinearGradient {
+        // Tally how often each muscle group occurs — with one element per set this is the number
+        // of sets training each muscle group.
+        var counts: [MuscleGroup: Int] = [:]
+        for muscleGroup in self {
+            counts[muscleGroup, default: 0] += 1
+        }
+        guard !counts.isEmpty else {
+            return LinearGradient(colors: [.accentColor], startPoint: startPoint, endPoint: endPoint)
+        }
+        // Order the distinct colours around the spectrum (by hue, breaking ties deterministically)
+        // so adjacent bands transition smoothly rather than jumping between unrelated hues.
+        let ordered = counts.keys.sorted {
+            $0.spectrumHue != $1.spectrumHue ? $0.spectrumHue < $1.spectrumHue : $0.rawValue < $1.rawValue
+        }
+        // Give each colour a share of the 0...1 range proportional to its tally, anchored at the
+        // midpoint of that share — a heavier muscle group sits over, and dominates the blend across,
+        // a wider stretch of the gradient.
+        let total = Double(counts.values.reduce(0, +))
+        var stops: [Gradient.Stop] = []
+        var cumulative = 0.0
+        for muscleGroup in ordered {
+            let share = Double(counts[muscleGroup] ?? 0) / total
+            stops.append(Gradient.Stop(color: muscleGroup.color, location: cumulative + share / 2))
+            cumulative += share
+        }
+        return LinearGradient(stops: stops, startPoint: startPoint, endPoint: endPoint)
     }
 
-    /// The muscle-group gradient as a `ShapeStyle` value — the value-typed counterpart to the
-    /// `muscleGroupGradientStyle` foreground modifier — for tinting a `ProgressIndicatorPill`: the
-    /// muscle colors left to right, falling back to the accent color when there are none. A single
-    /// `Color` can't carry a multi-muscle workout's gradient, so the pills take an `AnyShapeStyle`.
-    func gradientStyle(startPoint: UnitPoint = .leading, endPoint: UnitPoint = .trailing) -> AnyShapeStyle {
-        AnyShapeStyle(gradient(startPoint: startPoint, endPoint: endPoint))
+    /// `weightedSpectrumGradient(...)` as a type-erased `ShapeStyle`, for the `AnyShapeStyle` call
+    /// sites (e.g. tinting a `ProgressIndicatorPill`).
+    func weightedSpectrumGradientStyle(
+        startPoint: UnitPoint = .leading,
+        endPoint: UnitPoint = .trailing
+    ) -> AnyShapeStyle {
+        AnyShapeStyle(weightedSpectrumGradient(startPoint: startPoint, endPoint: endPoint))
+    }
+}
+
+extension Sequence where Element == WorkoutSet {
+    /// The muscle-group gradient for the sets entered, weighted by how many sets train each muscle
+    /// group — a muscle worked across more sets claims a larger, more prominent share — with the
+    /// colours ordered around the spectrum so they transition smoothly into one another. Each set
+    /// contributes its muscle group(s); super sets contribute both. Falls back to the accent colour
+    /// when none of the sets have a muscle group. Built on
+    /// `Sequence<MuscleGroup>.weightedSpectrumGradient(...)`, which does the actual work.
+    func muscleGroupGradient(
+        startPoint: UnitPoint = .leading,
+        endPoint: UnitPoint = .trailing
+    ) -> LinearGradient {
+        flatMap { $0.setGroup?.muscleGroups ?? [] }
+            .weightedSpectrumGradient(startPoint: startPoint, endPoint: endPoint)
+    }
+
+    /// `muscleGroupGradient(...)` as a type-erased `ShapeStyle`, for the `AnyShapeStyle` call sites.
+    func muscleGroupGradientStyle(
+        startPoint: UnitPoint = .leading,
+        endPoint: UnitPoint = .trailing
+    ) -> AnyShapeStyle {
+        AnyShapeStyle(muscleGroupGradient(startPoint: startPoint, endPoint: endPoint))
+    }
+}
+
+private extension MuscleGroup {
+    /// The hue (0...1) of the muscle group's colour, used to order colours around the spectrum so a
+    /// multi-colour gradient transitions smoothly. Derived from `color` itself, so the ordering
+    /// stays correct if the palette is ever retuned.
+    var spectrumHue: Double {
+        var hue: CGFloat = 0
+        UIColor(color).getHue(&hue, saturation: nil, brightness: nil, alpha: nil)
+        return Double(hue)
     }
 }

--- a/LOGIT/SharedUI/Views/MetricComparisonView.swift
+++ b/LOGIT/SharedUI/Views/MetricComparisonView.swift
@@ -69,7 +69,8 @@ struct MetricComparisonView: View {
                 .fontWeight(.semibold)
                 .foregroundStyle(.secondary)
             UnitView(value: side.value, unit: side.unit, configuration: .large)
-                .foregroundStyle(valueStyle)
+                // One continuous gradient across value + unit, not one restarting in each.
+                .continuousForegroundStyle(valueStyle)
             if let caption = side.caption {
                 Text(caption)
                     .font(.caption)

--- a/LOGIT/SharedUI/Views/ProgressIndicatorPill.swift
+++ b/LOGIT/SharedUI/Views/ProgressIndicatorPill.swift
@@ -13,12 +13,15 @@ import SwiftUI
 /// weight, capsule fill and 0.15 tint stay identical everywhere.
 ///
 /// The accent is an `AnyShapeStyle`, so it can be a flat `Color` or a gradient — a single `Color`
-/// can't carry a multi-muscle workout's gradient (see `Sequence.gradientStyle()`). It tints the
+/// can't carry a multi-muscle workout's gradient (see `Sequence.muscleGroupGradientStyle()`). It tints the
 /// symbol, the label's default foreground and the capsule fill at 0.15 opacity. Pass
 /// `Color.secondary` for the muted "decline / no change / metadata" look.
 ///
 /// The label supplies its own fonts, so a one-line percent and the metric badge's two-line
-/// value+name both fit; a per-glyph `foregroundStyle` inside the label wins over the pill's tint.
+/// value+name both fit. A gradient (`style:`) accent fills the symbol and label as one continuous
+/// sweep (see `continuousForegroundStyle`) so the gradient doesn't restart inside each; a flat
+/// (`color:`) accent keeps a plain foreground, so a per-glyph `foregroundStyle` inside the label
+/// still wins over the pill's tint — the two-line badges rely on this.
 struct ProgressIndicatorPill<Label: View>: View {
     /// Padding and spacing presets. `.regular` is the trend / gain / "n improved" pill; `.prominent`
     /// is the in-workout metric badge (a touch wider for its two-line content); `.compact` is quieter
@@ -57,6 +60,10 @@ struct ProgressIndicatorPill<Label: View>: View {
     let style: AnyShapeStyle
     let size: Size
     let label: Label
+    /// Whether the symbol+label share one gradient sweep (the `style:` initializer) rather than each
+    /// resolving it on its own — see `continuousForegroundStyle`. Off for the flat-`color:` badges
+    /// whose two-line labels set their own per-line colors, which a single masked fill would flatten.
+    private let fillsContinuously: Bool
 
     init(
         symbol: String?,
@@ -68,6 +75,7 @@ struct ProgressIndicatorPill<Label: View>: View {
         self.style = style
         self.size = size
         self.label = label()
+        self.fillsContinuously = true
     }
 
     /// Convenience for a flat-color accent — the common case (a single muscle-group color).
@@ -77,26 +85,42 @@ struct ProgressIndicatorPill<Label: View>: View {
         size: Size = .regular,
         @ViewBuilder label: () -> Label
     ) {
-        self.init(symbol: symbol, style: AnyShapeStyle(color), size: size, label: label)
+        self.symbol = symbol
+        self.style = AnyShapeStyle(color)
+        self.size = size
+        self.label = label()
+        self.fillsContinuously = false
     }
 
     var body: some View {
-        HStack(spacing: size.spacing) {
+        tintedContent
+            .padding(.horizontal, size.horizontalPadding)
+            .padding(.vertical, size.verticalPadding)
+            .background(Capsule().fill(style.opacity(0.15)))
+        // The pill always takes its ideal width, so its label never compresses: a percent like
+        // "100 %" can't wrap to two lines or ellipsize. Being rigid, the pill also claims its space
+        // first in any HStack, so a neighbor (a tile title, an exercise name) truncates around it
+        // rather than squeezing it. Vertical stays flexible for the metric badge's two-line label.
+        .fixedSize(horizontal: true, vertical: false)
+    }
+
+    /// Symbol + label, tinted by `style`. A gradient accent (the `style:` initializer) fills the
+    /// symbol and label as one continuous sweep so the gradient doesn't restart inside each; a flat
+    /// `color:` badge keeps a plain foreground so its label's own per-line colors survive.
+    @ViewBuilder
+    private var tintedContent: some View {
+        let content = HStack(spacing: size.spacing) {
             if let symbol {
                 Image(systemName: symbol)
                     .font(.caption2.weight(.bold))
             }
             label
         }
-        .foregroundStyle(style)
-        .padding(.horizontal, size.horizontalPadding)
-        .padding(.vertical, size.verticalPadding)
-        .background(Capsule().fill(style.opacity(0.15)))
-        // The pill always takes its ideal width, so its label never compresses: a percent like
-        // "100 %" can't wrap to two lines or ellipsize. Being rigid, the pill also claims its space
-        // first in any HStack, so a neighbor (a tile title, an exercise name) truncates around it
-        // rather than squeezing it. Vertical stays flexible for the metric badge's two-line label.
-        .fixedSize(horizontal: true, vertical: false)
+        if fillsContinuously {
+            content.continuousForegroundStyle(style)
+        } else {
+            content.foregroundStyle(style)
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
Introduces one shared muscle-group gradient and routes every non-background muscle gradient through it.

- **Weighted by set count** — each muscle group's share of the gradient is proportional to how many sets train it, so a muscle worked in more sets is more prominent.
- **Spectrum-sorted** — the distinct colours are ordered by hue (derived from the colour itself, so it self-corrects if the palette is retuned) so neighbouring colours blend smoothly instead of clashing.
- **One source** — `Sequence<WorkoutSet>.muscleGroupGradient()` / `muscleGroupGradientStyle()` over the core `Sequence<MuscleGroup>.weightedSpectrumGradient()`. The old even/enum-order `gradient()` / `gradientStyle()` helpers and the `muscleGroupGradientStyle(for:)` modifier are removed.

Applied across the workout detail / stat / progress surfaces: trophy header, "improved" pill, stat value + pills, stat tiles, and run bars.

## Direction
Bars wear the gradient vertically (`.bottom`→`.top`); text and pills diagonally (`.bottomLeading`→`.topTrailing`). The stat tile splits its pill (diagonal) and run-bar (vertical) into separate styles, since one `AnyShapeStyle` carries one direction.

## Continuous gradient
Added `View.continuousForegroundStyle(_:)` so a `UnitView`'s value+unit and a pill's icon+label read as one continuous sweep instead of each child restarting the gradient. Applied to `MetricComparisonView`, `PieGraph`, and `ProgressIndicatorPill`'s gradient (`style:`) path — the flat `color:` path stays plain so the two-line in-workout badges keep their per-line colours.

## Out of scope (intentionally untouched)
`ColorfulView` mesh backgrounds, single-muscle `muscleGroup.color.gradient` shimmers, and `CurrentWeekWeeklyTargetTile` (its unit is deliberately a different colour).

## Test plan
- Builds clean (zero warnings) against latest `main` in an isolated worktree.
- `LOGITScreenshots.test04WorkoutDetail` passes; workout-detail render verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)