### PR TITLE
Keep the comparison scoreboard's trend pill centered while scrolling

### DIFF
--- a/LOGIT/SharedUI/Views/MetricComparisonView.swift
+++ b/LOGIT/SharedUI/Views/MetricComparisonView.swift
@@ -54,11 +54,15 @@ struct MetricComparisonView: View {
 
     var body: some View {
         HStack(alignment: .center, spacing: 8) {
+            // Both sides claim an equal, flexible half of the row so the pill always lands in a
+            // fixed center column. Without this the sides size to their content and the spacers
+            // rebalance whenever a value's width changes (e.g. scrolling between data points),
+            // which makes the pill drift off-center.
             side(leading, alignment: .leading, valueStyle: AnyShapeStyle(Color.label))
-            Spacer(minLength: 0)
+                .frame(maxWidth: .infinity, alignment: .leading)
             pill
-            Spacer(minLength: 0)
             side(trailing, alignment: .trailing, valueStyle: trailingValueStyle)
+                .frame(maxWidth: .infinity, alignment: .trailing)
         }
     }
 


### PR DESCRIPTION
## What

In `MetricComparisonView` (the shared two-value comparison scoreboard behind the in-workout metric popover and every exercise/workout chart-detail header), the trend pill in the middle drifted sideways while scrolling between data points.

## Why

The row was laid out as `side · Spacer · pill · Spacer · side`. The two sides sized to their content and the two spacers split the leftover space equally, which puts the pill's center at `rowCenter + (leftWidth − rightWidth) / 2`. So the moment either value changed width — exactly what happens as you scroll through the chart — the pill slid off-center.

## Fix

Each side now claims an equal, flexible half of the row via `.frame(maxWidth: .infinity, alignment:)`, with its content pinned to the outer edge (leading hugs left, trailing hugs right). The pill sits between two always-equal halves, so its center is the row center regardless of how wide either value gets.

Verified: builds clean on the iPhone 17 Pro simulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)