### PR TITLE
Fade long exercise names before the metric badge in the workout cell

### DIFF
--- a/LOGIT/Features/Workout/Cells/WorkoutSetGroupCell.swift
+++ b/LOGIT/Features/Workout/Cells/WorkoutSetGroupCell.swift
@@ -37,6 +37,12 @@ struct WorkoutSetGroupCell: View {
     @State private var primaryExerciseSelectionSheetDetend: PresentationDetent? = .large
     @State private var isSelectingSecondaryExercise = false
     @State private var isEditingNote = false
+    /// Live width of the metric badge (an overlay with no layout footprint), measured so the exercise
+    /// name can reserve room and dissolve before it instead of sliding underneath the capsule.
+    @State private var metricBadgeWidth: CGFloat = 0
+    /// Width of the exercise-name column (the name + muscle-group VStack). Measured so the name's
+    /// width budget can be derived as (column − badge reservation) and handed to `ExerciseHeader`.
+    @State private var nameSlotWidth: CGFloat = 0
     @FocusState private var isNoteFieldFocused: Bool
 
     // MARK: - Body
@@ -244,11 +250,38 @@ struct WorkoutSetGroupCell: View {
                     workout: workout,
                     isEditing: focusedIntegerFieldIndex != nil
                 )
+                // The badge floats here without claiming layout space; feed its width back so the
+                // exercise name can reserve room and fade out before it (see `exerciseNameTrailingInset`).
+                .onGeometryChange(for: CGFloat.self) { proxy in
+                    proxy.size.width
+                } action: { _, newWidth in
+                    metricBadgeWidth = newWidth
+                }
             }
         }
     }
 
     // MARK: - Supporting Views
+
+    /// Trailing space the metric badge occupies, reserved on the exercise name's side so a long name
+    /// fades out *before* the badge instead of sliding under it. The badge is an overlay measuring to
+    /// the cell's true trailing edge while the header is inset by `CELL_PADDING`, so subtract that;
+    /// `+ 8` leaves a small gap between the name's fade and the badge. Zero whenever no badge is shown
+    /// (while reordering, or before there's anything to compare) so the name reclaims the full width.
+    private var exerciseNameTrailingInset: CGFloat {
+        guard !isReordering, setGroup.workout != nil else { return 0 }
+        return max(0, metricBadgeWidth - CELL_PADDING + 8)
+    }
+
+    /// Width budget for the exercise-name label (name + chevron) when a badge is present: the measured
+    /// column width minus the badge reservation. Passed to `ExerciseHeader.nameMaxWidth`, which fades
+    /// the name within it while leaving the chevron opaque. `nil` (no badge yet, or the column not
+    /// measured) leaves the name at its natural width with no fade — there's nothing to dissolve before.
+    private var exerciseNameWidth: CGFloat? {
+        let inset = exerciseNameTrailingInset
+        guard inset > 0, nameSlotWidth > 0 else { return nil }
+        return max(40, nameSlotWidth - inset)
+    }
 
     private var header: some View {
         VStack(spacing: 8) {
@@ -273,7 +306,8 @@ struct WorkoutSetGroupCell: View {
                         isSuperSet: setGroup.setType == .superSet,
                         navigationToDetailEnabled: true,
                         showDetailAsSheet: showDetailAsSheet,
-                        onTapExerciseName: onTapExerciseName
+                        onTapExerciseName: onTapExerciseName,
+                        nameMaxWidth: exerciseNameWidth
                     )
                     HStack {
                         Text(setGroup.exercise?.muscleGroup?.description ?? "")
@@ -290,6 +324,14 @@ struct WorkoutSetGroupCell: View {
                         }
                     }
                     .font(.system(.footnote, design: .rounded, weight: .bold))
+                }
+                // Width of the name column, fed to `exerciseNameWidth` so the name fills exactly to
+                // its fade. The muscle row's trailing `Spacer` holds this at the full available width
+                // regardless of the name's own (narrower) frame, so reading it back can't feed back.
+                .onGeometryChange(for: CGFloat.self) { proxy in
+                    proxy.size.width
+                } action: { _, newWidth in
+                    nameSlotWidth = newWidth
                 }
                 Spacer()
                 if isReordering {

--- a/LOGIT/SharedUI/Views/ExerciseHeader.swift
+++ b/LOGIT/SharedUI/Views/ExerciseHeader.swift
@@ -18,6 +18,11 @@ struct ExerciseHeader: View {
     let navigationToDetailEnabled: Bool
     var showDetailAsSheet: Bool = false
     var onTapExerciseName: ((Exercise) -> Void)? = nil
+    /// When set, the primary name is held to this width and dissolves its trailing edge to
+    /// transparent (instead of truncating with an ellipsis) if it's too long — used by the workout
+    /// recorder so a long name fades out before the metric badge. The chevron is never faded. `nil`
+    /// keeps the name at its natural width.
+    var nameMaxWidth: CGFloat? = nil
 
     // MARK: - State
 
@@ -138,13 +143,67 @@ struct ExerciseHeader: View {
     // MARK: - Helper Views
 
     private func exerciseLabel(_ exercise: Exercise) -> some View {
-        HStack(spacing: 3) {
-            Text(exercise.displayName)
-                .foregroundColor(.label)
+        primaryNameLabel(exercise.displayName)
+            .frame(maxWidth: nameMaxWidth, alignment: .leading)
+    }
+
+    /// The exercise name and its navigation chevron. With `nameMaxWidth` set (the workout recorder),
+    /// an over-long name dissolves to transparent instead of truncating with an ellipsis: `ViewThatFits`
+    /// keeps the plain full name + tight chevron whenever it fits (so a short name is never masked),
+    /// and otherwise masks only the name — leaving the chevron fully opaque — while negative spacing
+    /// slides the chevron back over the masked, already-clear tail so it tucks against the fade as
+    /// snugly as it does after a short name. Without `nameMaxWidth` it's the plain name + chevron,
+    /// exactly as before, so every other caller is unchanged.
+    @ViewBuilder
+    private func primaryNameLabel(_ name: String) -> some View {
+        if nameMaxWidth != nil {
+            ViewThatFits(in: .horizontal) {
+                withChevron(spacing: 3) {
+                    Text(name)
+                        .foregroundColor(.label)
+                        .fixedSize(horizontal: true, vertical: false)
+                }
+                withChevron(spacing: -16) {
+                    Text(name)
+                        .foregroundColor(.label)
+                        .mask(nameFadeMask)
+                }
+            }
+        } else {
+            withChevron(spacing: 3) {
+                Text(name)
+                    .foregroundColor(.label)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func withChevron<Content: View>(
+        spacing: CGFloat,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        HStack(spacing: spacing) {
+            content()
             if navigationToDetailEnabled {
                 NavigationChevron()
                     .foregroundColor(.secondaryLabel)
             }
+        }
+    }
+
+    /// Trailing dissolve for an over-long name: opaque body, a ramp to clear, then a short clear tail.
+    /// The chevron is slid back over that clear tail (see `primaryNameLabel`), which keeps it tucked
+    /// against the fade and also hides any residual truncation "…" behind its opaque glyph.
+    private var nameFadeMask: some View {
+        HStack(spacing: 0) {
+            Rectangle().fill(.black)
+            LinearGradient(
+                gradient: Gradient(colors: [.black, .clear]),
+                startPoint: .leading,
+                endPoint: .trailing
+            )
+            .frame(width: 20)
+            Color.clear.frame(width: 16)
         }
     }
 


### PR DESCRIPTION
## Problem
In `WorkoutSetGroupCell`, a long exercise name expanded to the full cell width *underneath* the translucent metric badge and truncated with an ellipsis hidden behind it.

## Fix
- Measure the badge's width (it's a `.topTrailing` overlay with no layout footprint) and the name-column width, and reserve the badge's space on the name's trailing side.
- Instead of truncating with an ellipsis, the name now **dissolves to transparent** before the badge.
- The navigation chevron stays **fully opaque** and tucks right against the fade (negative spacing slides it over the masked, already-clear tail).
- Short names are untouched — full name + tight chevron. The treatment is opt-in via the new `ExerciseHeader.nameMaxWidth`, so `TemplateSetGroupCell` and every other caller are unchanged.

## Implementation notes
- `ViewThatFits` chooses the plain full name whenever it fits, and only masks the name (never the chevron) when it's too long.
- The fade mask has a clear tail sized to swallow the truncation `…`, so the dissolve is clean letters, not a faded ellipsis.

## Testing
- Built and verified on the iPhone 17 Pro simulator (seeded recorder).
- Long name → name dissolves, chevron tucked tight, no ellipsis, no layout overflow.
- Short name ("Overhead Press") → full name + chevron, no fade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)