### PR TITLE
Bleed the metric-tile chart to the edges

### DIFF
--- a/LOGIT/Features/Exercise/ExerciseDetail/Tiles/ExerciseMetricTile.swift
+++ b/LOGIT/Features/Exercise/ExerciseDetail/Tiles/ExerciseMetricTile.swift
@@ -265,7 +265,13 @@ struct ExerciseTileSparkline: View {
     let color: Color
     var window: Window = .currentBest
     /// Chart height. Taller suits the all-time window, where the full history needs room to read.
+    /// Ignored when `bleeds` is set — the footer fills whatever height the tile hands it.
     var height: CGFloat = 56
+    /// The metric-tile footer treatment: the sparkline fills the slot it's given and runs edge to
+    /// edge — no clip — with the carry-forward dash reaching the right edge and the bottom fade melting
+    /// the fill into the card border, easing IN at its left edge (just right of the trend pill). Off
+    /// for the windowed corner sparklines, which clip and fade in from the left at a fixed height.
+    var bleeds: Bool = false
 
     /// How many sessions the recent-history window shows.
     private static let recentHistoryCount = 6
@@ -278,7 +284,9 @@ struct ExerciseTileSparkline: View {
         let margin: (Date) -> Date = { Calendar.current.date(byAdding: .day, value: 2, to: $0) ?? $0 }
         switch window {
         case .currentBest:
-            return Exercise.currentBestWindowStart ... margin(.now)
+            // Bleeding to the right edge means the carry-forward dash must reach `.now` exactly; the
+            // corner sparkline keeps the +2-day margin so its trailing dot clears the edge.
+            return Exercise.currentBestWindowStart ... (bleeds ? .now : margin(.now))
         case .recentHistory:
             let shown = points.suffix(Self.recentHistoryCount)
             guard let first = shown.first?.date, let last = shown.last?.date else {
@@ -303,7 +311,7 @@ struct ExerciseTileSparkline: View {
         // Over a long span catmullRom waggles between sessions; monotone keeps the all-time line a
         // clean trend that never overshoots its own crest.
         let interpolation: InterpolationMethod = window == .allTime ? .monotone : .catmullRom
-        let base = Chart {
+        let chartView = Chart {
             tileSparklineMarks(
                 points: points,
                 color: color,
@@ -318,16 +326,27 @@ struct ExerciseTileSparkline: View {
         .chartYScale(domain: 0 ... max(maxValue * 1.15, 1))
         .chartXAxis {}
         .chartYAxis {}
-        .frame(maxWidth: .infinity)
-        .frame(height: height)
-        // The all-time window spans the full width and skips `.clipped()` and the leading fade — its
-        // whole point is to show where the history begins and ends — but it still fades its area out
-        // at the bottom so the full-bleed fill melts into the card border instead of being clipped
-        // while still tinted. The windowed sparklines clip and fade in from the left (and bottom).
-        if window == .allTime {
-            base.tileSparklineBottomFadeMask()
+
+        // The bleeding footer (metric tiles) fills the slot the tile hands it and runs edge to edge to
+        // the trailing + bottom edges — no clip — but fades IN from the left so it eases in at its left
+        // edge (just right of the trend pill). The all-time line spans the full width at a fixed height
+        // with only the bottom fade (its point is to show where the history begins and ends). The
+        // windowed corner sparklines clip and fade in from the left.
+        if bleeds {
+            chartView
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .tileSparklineBleedFadeMask()
+        } else if window == .allTime {
+            chartView
+                .frame(maxWidth: .infinity)
+                .frame(height: height)
+                .tileSparklineBottomFadeMask()
         } else {
-            base.clipped().tileSparklineFadeMask()
+            chartView
+                .frame(maxWidth: .infinity)
+                .frame(height: height)
+                .clipped()
+                .tileSparklineFadeMask()
         }
     }
 }
@@ -380,14 +399,14 @@ struct ExerciseBestMetricTile: View {
         ) {
             if isLapsed {
                 // No chart in the last-best state — a single carry-forward dash says nothing. The
-                // empty slot keeps the bottom row's height so the tile matches its grid neighbour.
+                // empty footer keeps the tile's fixed height so it matches its grid neighbours.
                 Color.clear
             } else {
                 ExerciseTileSparkline(
                     points: dailyBestPoints(in: sets),
                     color: color,
                     window: .currentBest,
-                    height: CompactChartFrame.height
+                    bleeds: true
                 )
             }
         }

--- a/LOGIT/Features/Exercise/ExerciseDetail/Tiles/ExerciseSetsTile.swift
+++ b/LOGIT/Features/Exercise/ExerciseDetail/Tiles/ExerciseSetsTile.swift
@@ -62,7 +62,8 @@ struct ExerciseSetsTile: View {
             isRecord: isRecordWeek(count: thisWeekCount, in: weeklySets),
             requiresPro: true,
             lastBestDate: lastBestDate,
-            showsEmptyPlaceholder: weeklySets.isEmpty
+            showsEmptyPlaceholder: weeklySets.isEmpty,
+            chartBleeds: false
         ) {
             // Lapsed → no chart, matching the four best-value tiles (the date carries the story); the
             // empty slot keeps the row height. Otherwise the regular five-week bars.
@@ -85,7 +86,7 @@ struct ExerciseSetsTile: View {
                 BarMark(
                     x: .value("Week", weeklySet.week, unit: .weekOfYear),
                     y: .value("Sets in week", weeklySet.count),
-                    width: TileBarChartStyle.barWidth
+                    width: TileBarChartStyle.footerBarWidth
                 )
                 .foregroundStyle(
                     Calendar.current.isDate(weeklySet.week, equalTo: Date.now.startOfWeek, toGranularity: .weekOfYear)

--- a/LOGIT/Features/Exercise/ExerciseDetail/Tiles/ExerciseVolumeTile.swift
+++ b/LOGIT/Features/Exercise/ExerciseDetail/Tiles/ExerciseVolumeTile.swift
@@ -60,7 +60,8 @@ struct ExerciseVolumeTile: View {
             isRecord: isRecordWeek(volume: thisWeekVolume, in: weeklyVolumes),
             requiresPro: true,
             lastBestDate: lastBestDate,
-            showsEmptyPlaceholder: weeklyVolumes.isEmpty
+            showsEmptyPlaceholder: weeklyVolumes.isEmpty,
+            chartBleeds: false
         ) {
             // Lapsed → no chart, matching the four best-value tiles (the date carries the story); the
             // empty slot keeps the row height. Otherwise the regular five-week bars.
@@ -83,7 +84,7 @@ struct ExerciseVolumeTile: View {
                 BarMark(
                     x: .value("Week", weeklyVolume.week, unit: .weekOfYear),
                     y: .value("Volume in week", convertWeightForDisplayingDecimal(weeklyVolume.volume)),
-                    width: TileBarChartStyle.barWidth
+                    width: TileBarChartStyle.footerBarWidth
                 )
                 .foregroundStyle(
                     Calendar.current.isDate(weeklyVolume.week, equalTo: Date.now.startOfWeek, toGranularity: .weekOfYear)

--- a/LOGIT/Features/Workout/WorkoutStatTiles.swift
+++ b/LOGIT/Features/Workout/WorkoutStatTiles.swift
@@ -297,7 +297,7 @@ struct WorkoutRunsBarChart: View {
                     BarMark(
                         x: .value("Run", String(bar.slot)),
                         y: .value("Value", bar.value),
-                        width: TileBarChartStyle.barWidth
+                        width: TileBarChartStyle.footerBarWidth
                     )
                     .foregroundStyle(bar.isCurrent ? currentStyle : AnyShapeStyle(Color.fill))
                     .tileBarStyle()
@@ -355,7 +355,8 @@ struct WorkoutStatTile: View {
             accentColor: accentColor,
             percentChange: history.percentChange(for: metric),
             isRecord: false,
-            requiresPro: metric.requiresPro
+            requiresPro: metric.requiresPro,
+            chartBleeds: false
         ) {
             WorkoutRunsBarChart(bars: runBars, currentStyle: barStyle)
         }

--- a/LOGIT/SharedUI/Charts/TileBarChartStyle.swift
+++ b/LOGIT/SharedUI/Charts/TileBarChartStyle.swift
@@ -20,8 +20,14 @@ import SwiftUI
 /// detail-screen charts (axes, selection, gradients) are deliberately *not* part of this and keep
 /// their own styling.
 enum TileBarChartStyle {
-    /// Bar width as a fraction of each slot — wide bars with a small gap between them.
+    /// Bar width as a fraction of each slot — wide bars with a small gap between them. The home tiles
+    /// keep this; the metric-tile footer charts use the slim fixed width below.
     static let barWidth: MarkDimension = .ratio(0.8)
+    /// A slim fixed bar for the metric-tile footer charts (exercise Volume/Sets, workout stat tiles).
+    /// Their chart now spans the full tile width (the line tiles bleed edge to edge), and at the 0.8
+    /// ratio the bars turned chunky — a fixed slim width keeps the thin bars they had in the old compact
+    /// corner slot, independent of how wide the footer is.
+    static let footerBarWidth: MarkDimension = .fixed(10)
 
     /// Corner radius of the rounded bar caps.
     static let cornerRadius: CGFloat = 9

--- a/LOGIT/SharedUI/Charts/TileSparklineStyle.swift
+++ b/LOGIT/SharedUI/Charts/TileSparklineStyle.swift
@@ -43,6 +43,10 @@ enum TileSparklineStyle {
     static let carryForwardOpacity: CGFloat = 0.45
     /// Fraction of the width over which the leading edge fades in.
     static let leadingFadeLocation: CGFloat = 0.12
+    /// A longer leading fade for the full-bleed metric-tile line, which carries the trend pill at its
+    /// bottom-left corner: the line eases in over this span so it doesn't start abruptly at its left
+    /// edge (just to the right of the pill).
+    static let bleedLeadingFadeLocation: CGFloat = 0.33
 
     /// The translucent fill under the line — a top-heavy tint. Swift Charts won't reliably fade an
     /// `AreaMark` to clear at the baseline on its own (the fill gradient maps to a range far taller
@@ -179,5 +183,23 @@ extension View {
                 endPoint: .bottom
             )
         )
+    }
+
+    /// The full-bleed metric-tile line's fade: it dissolves IN from the leading edge over a longer span
+    /// than the corner sparklines (so it eases in at its left edge, just right of the trend pill) and
+    /// OUT toward the bottom, with no clip, so the line still runs to the trailing and bottom edges.
+    func tileSparklineBleedFadeMask() -> some View {
+        mask(
+            LinearGradient(
+                gradient: Gradient(stops: [
+                    .init(color: .clear, location: 0.0),
+                    .init(color: .black, location: TileSparklineStyle.bleedLeadingFadeLocation),
+                    .init(color: .black, location: 1.0),
+                ]),
+                startPoint: .leading,
+                endPoint: .trailing
+            )
+        )
+        .tileSparklineBottomFadeMask()
     }
 }

--- a/LOGIT/SharedUI/Views/MetricTile.swift
+++ b/LOGIT/SharedUI/Views/MetricTile.swift
@@ -7,29 +7,19 @@
 
 import SwiftUI
 
-// MARK: - Compact Chart Frame
-
-/// The fixed size of a metric tile's bottom-right chart slot — small enough to sit beside the trend
-/// pill on one row, and shared by every tile so a line chart and a bar chart line up across a grid.
-/// The chart pins to the tile's trailing edge and gives up its leading edge first when a wide pill
-/// crowds the row, so the newest (rightmost) bar always stays visible.
-enum CompactChartFrame {
-    static let width: CGFloat = 72
-    static let height: CGFloat = 40
-}
-
 // MARK: - Metric Tile
 
 /// The shared metric tile behind every stat on the exercise-detail and workout-detail screens: a
-/// title row with an optional navigation chevron, an optional gray subtitle over the large
-/// label-colored value, and a bottom row carrying the trend pill on the left and a compact chart —
-/// a sparkline or a bar chart, supplied by the caller — in the bottom-right corner.
+/// title row with an optional navigation chevron, an optional gray subtitle, and the large label-
+/// colored value; beneath them a full-width chart supplied by the caller — a line sparkline bleeding to
+/// the tile's bottom and side edges, or a bar chart inset just enough (`chartBleeds: false`) that its
+/// rounded bars sit inside the corners — with the trend pill overlaid on the chart's bottom-leading
+/// corner (the line fades in from the left so it doesn't collide with the pill).
 ///
 /// The accent (a flat muscle color, or a workout's multi-muscle gradient) tints only the trend pill
 /// and, through the caller's chart, the highlighted bar/line; the number itself always stays neutral
-/// so the color reads as "progress", never decoration. One skeleton for every tile so tiles sharing
-/// a grid row always come out the same height — the chart's fixed height anchors the bottom row, and
-/// the empty state renders the real content hidden underneath to match its row neighbor.
+/// so the color reads as "progress", never decoration. Every tile is one fixed height so a grid row
+/// stays even — the chart fills the height the value block leaves, never growing the tile.
 struct MetricTile<ChartContent: View>: View {
     enum Label {
         case currentBest
@@ -73,23 +63,43 @@ struct MetricTile<ChartContent: View>: View {
     /// has no usable data at all (the weight tiles of a bodyweight exercise). The content keeps
     /// rendering hidden underneath so the tile stays exactly as tall as its row neighbor.
     var showsEmptyPlaceholder: Bool = false
+    /// Whether the chart bleeds to the tile's bottom and side edges. The default — the line sparklines
+    /// run edge to edge. Bar charts pass `false`: their outermost bars would be sliced by the tile's
+    /// rounded corners, so they take a small inset and sit just inside the corner instead.
+    var chartBleeds: Bool = true
     @ViewBuilder let chart: () -> ChartContent
+
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
+    /// Every tile is pinned to one height so a grid row stays even, and a value too long to share a
+    /// line with the trend pill pushes the pill onto its own line by stealing height from the chart
+    /// rather than growing the tile. Dropped at accessibility sizes, where the tiles stack in one
+    /// column and size to their content.
+    private static var fixedHeight: CGFloat { 172 }
+    /// The chart's height once the tile is no longer fixed-height (accessibility sizes): the footer
+    /// can't fill the leftover space, so it takes a flat height instead of collapsing.
+    private static var accessibilityChartHeight: CGFloat { 64 }
+    /// The small inset a non-bleeding (bar) chart takes so its outermost, rounded bars clear the tile's
+    /// rounded corners instead of being sliced. Smaller than `CELL_PADDING` so the bars still read as
+    /// nearly full-bleed — just pulled off the corners.
+    private static var nonBleedingChartInset: CGFloat { 10 }
+
+    private var usesFixedHeight: Bool { !dynamicTypeSize.isAccessibilitySize }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             header
+                .padding(.horizontal, CELL_PADDING)
+                .padding(.top, CELL_PADDING)
             if showsEmptyPlaceholder {
-                ZStack {
-                    content.hidden()
-                    placeholder
-                }
+                placeholderFooter
             } else {
                 content
                     .isBlockedWithoutPro(requiresPro, style: .compact)
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(CELL_PADDING)
+        .frame(height: usesFixedHeight ? Self.fixedHeight : nil, alignment: .top)
         .tileStyle()
     }
 
@@ -109,19 +119,83 @@ struct MetricTile<ChartContent: View>: View {
         }
     }
 
+    /// The padded subtitle + value/pill block sitting above the full-bleed chart footer. The text
+    /// keeps the tile's `CELL_PADDING` inset; the chart carries none and bleeds to the rounded bottom
+    /// and side edges, the way the personal-record card's all-time line does.
     private var content: some View {
         VStack(alignment: .leading, spacing: 0) {
-            subtitle
-                .padding(.top, 8)
-            UnitView(value: value ?? "––", unit: unit, configuration: .large, unitColor: .secondaryLabel)
-                .foregroundStyle(Color.label)
-                .padding(.top, 2)
-            // The bottom row sits a fixed gap below the value, the same on every tile, so tiles in a
-            // grid row keep their pills and charts on one line.
-            bottomRow
-                .padding(.top, 16)
+            VStack(alignment: .leading, spacing: 0) {
+                subtitle
+                    .padding(.top, 8)
+                valueView
+                    .padding(.top, 2)
+            }
+            .padding(.horizontal, CELL_PADDING)
+            chartFooter
+                .padding(.top, 14)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var valueView: some View {
+        UnitView(value: value ?? "––", unit: unit, configuration: .large, unitColor: .secondaryLabel)
+            .foregroundStyle(Color.label)
+            .lineLimit(1)
+            .minimumScaleFactor(0.7)
+    }
+
+    /// The chart with its trend pill. For a bleeding (line) chart the pill sits at the bottom-leading
+    /// corner and the line fills the space to its RIGHT — it starts past the pill, never under it — and
+    /// still bleeds to the trailing + bottom edges. A bar chart keeps its full width (the slim bars read
+    /// fine behind the pill), the pill overlaid on the bottom-leading corner.
+    @ViewBuilder
+    private var chartFooter: some View {
+        if chartBleeds {
+            HStack(alignment: .bottom, spacing: 8) {
+                if hasPill {
+                    pill
+                        .padding(.leading, CELL_PADDING)
+                        .padding(.bottom, CELL_PADDING)
+                }
+                chartContent
+            }
+        } else {
+            chartContent
+                .overlay(alignment: .bottomLeading) {
+                    pill
+                        .padding(.leading, CELL_PADDING)
+                        .padding(.bottom, CELL_PADDING)
+                }
+        }
+    }
+
+    /// The chart itself: on a fixed-height tile it fills whatever the value block leaves above it; at
+    /// accessibility sizes (no fixed height) it takes a flat height so the footer can't collapse.
+    @ViewBuilder
+    private var chartContent: some View {
+        if usesFixedHeight {
+            chart()
+                .padding(chartFooterInsets)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else {
+            chart()
+                .padding(chartFooterInsets)
+                .frame(maxWidth: .infinity)
+                .frame(height: Self.accessibilityChartHeight)
+        }
+    }
+
+    /// Zero for a bleeding chart (the line sparklines run to the edges), a small leading/trailing/
+    /// bottom inset for a non-bleeding one (the bar charts) so its rounded bars clear the corners.
+    private var chartFooterInsets: EdgeInsets {
+        chartBleeds
+            ? EdgeInsets()
+            : EdgeInsets(
+                top: 0,
+                leading: Self.nonBleedingChartInset,
+                bottom: Self.nonBleedingChartInset,
+                trailing: Self.nonBleedingChartInset
+            )
     }
 
     @ViewBuilder
@@ -141,17 +215,19 @@ struct MetricTile<ChartContent: View>: View {
         }
     }
 
-    /// Trend pill on the left, compact chart pinned to the trailing edge on the right. The chart's
-    /// fixed height anchors the row, so a tile with no pill (or the shorter lapsed pill) is exactly as
-    /// tall as one with a full trend pill — no height ruler needed. The chart frame is greedy and
-    /// trailing-aligned, so it keeps the chart in the corner and clips its leading edge first if a
-    /// wide pill ever crowds the row.
-    private var bottomRow: some View {
-        HStack(alignment: .bottom, spacing: 8) {
-            pill
-            chart()
-                .frame(width: CompactChartFrame.width, height: CompactChartFrame.height)
-                .frame(maxWidth: .infinity, alignment: .trailing)
+    /// The empty-state body: the ghost sparkline + "no data" centered in the space below the header,
+    /// filling the same footer the chart would so an empty tile is exactly as tall as its neighbours.
+    @ViewBuilder
+    private var placeholderFooter: some View {
+        if usesFixedHeight {
+            placeholder
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .padding(CELL_PADDING)
+        } else {
+            placeholder
+                .frame(maxWidth: .infinity)
+                .frame(height: Self.accessibilityChartHeight + 40)
+                .padding(CELL_PADDING)
         }
     }
 
@@ -169,6 +245,11 @@ struct MetricTile<ChartContent: View>: View {
         } else if let lastBestDate {
             TileDatePill(date: lastBestDate)
         }
+    }
+
+    /// Whether any pill applies — drives whether the bleeding line reserves the space to its left.
+    private var hasPill: Bool {
+        percentChange != nil || lapsedSince != nil || lastBestDate != nil
     }
 
     private var placeholder: some View {


### PR DESCRIPTION
## What

Redesigns the shared `MetricTile` (exercise-detail + workout-detail stat tiles) so its chart bleeds full-width along the bottom of the tile instead of sitting in a small 72×40 bottom-right corner — matching the personal-record card's edge-to-edge treatment.

## Details

- **Line tiles** (`chartBleeds: true`, the default): `ExerciseTileSparkline` gains a `bleeds` mode — it fills the footer, runs to the trailing + bottom edges, keeps the carry-forward "held since" dash (the current-best domain now ends at `.now`), and fades in from the left (`tileSparklineBleedFadeMask`). The trend pill sits at the bottom-leading corner and the line **starts to its right**, never under it.
- **Bar tiles** (`chartBleeds: false` — exercise volume/sets, workout stat tiles): slim fixed-width bars (`TileBarChartStyle.footerBarWidth = .fixed(10)`) inset 10pt so their rounded corners clear the tile's 30pt corners; the pill overlays the bottom-leading corner. The home tiles keep the shared `.ratio(0.8)` width.
- **One fixed tile height** keeps a grid row even — the value sits alone and the chart fills the leftover height.

## Testing

Built and verified on the iPhone 17 Pro simulator on both the exercise-detail and workout-detail screens. Zero-warning build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
