### PR TITLE
Fix tile sparkline zig-zag: interpolate monotone, not catmullRom

### DIFF
--- a/LOGIT/Features/Exercise/ExerciseDetail/Tiles/ExerciseMetricTile.swift
+++ b/LOGIT/Features/Exercise/ExerciseDetail/Tiles/ExerciseMetricTile.swift
@@ -308,14 +308,10 @@ struct ExerciseTileSparkline: View {
 
     var body: some View {
         let maxValue = points.map(\.value).max() ?? 1
-        // Over a long span catmullRom waggles between sessions; monotone keeps the all-time line a
-        // clean trend that never overshoots its own crest.
-        let interpolation: InterpolationMethod = window == .allTime ? .monotone : .catmullRom
         let chartView = Chart {
             tileSparklineMarks(
                 points: points,
                 color: color,
-                interpolation: interpolation,
                 // The all-time line is a single clean curve — no per-session dots, no crest marker.
                 // The windowed sparklines keep a dot per session.
                 showsSymbols: window != .allTime,

--- a/LOGIT/SharedUI/Charts/TileSparklineStyle.swift
+++ b/LOGIT/SharedUI/Charts/TileSparklineStyle.swift
@@ -33,8 +33,11 @@ struct TileSparklinePoint: Identifiable {
 enum TileSparklineStyle {
     /// Stroke width of the line (and the carry-forward rule).
     static let lineWidth: CGFloat = 3
-    /// Smoothing of the line — a soft curve through the daily points.
-    static let interpolation: InterpolationMethod = .catmullRom
+    /// Smoothing of the line — a soft curve through the daily points. Monotone cubic, not catmullRom:
+    /// a cardinal spline overshoots, so a value that dips between two close sessions bows the line into
+    /// a zig-zag (a dip-then-spike that isn't in the data). Monotone never overshoots a point, so the
+    /// curve stays a clean trend. Matches the detail chart screens, which all interpolate monotone.
+    static let interpolation: InterpolationMethod = .monotone
     /// Diameter of a daily-best dot.
     static let pointDiameter: CGFloat = 6
     /// Dash pattern of the carry-forward line from the last point to today.


### PR DESCRIPTION
## Problem

The in-tile sparklines (e.g. the **Current Best** metric tiles) showed a zig-zag near the end of the line — a dip-then-spike that isn't in the underlying data. The detail chart screens, plotting the same data, looked clean.

## Cause

The tile sparklines interpolated with **`catmullRom`**, a cardinal spline that *overshoots* each point. When a daily-best value dips slightly between two closely-spaced sessions, the overshoot bows the curve into a false dip-then-spike. The detail screens (`ExerciseWeightScreen` et al.) never had this because they all interpolate with **`.monotone`**, which by construction never overshoots a point. The codebase already knew this — the all-time tile line had been switched to monotone for the same reason.

## Fix

- `TileSparklineStyle.interpolation`: `.catmullRom` → `.monotone` (the shared default for every in-tile sparkline).
- `ExerciseTileSparkline`: dropped the `window == .allTime ? .monotone : .catmullRom` override that was forcing `catmullRom` on the windowed "Current Best" sparkline; it now inherits the monotone default.

Now every in-tile sparkline matches the detail screens and stays a clean trend. Builds clean (zero warnings) on iPhone 17 Pro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)