### PR TITLE
Fix Logger subsystem inconsistency and miscategorized log category

### DIFF
--- a/LOGIT/Core/Utilities/TemplateService.swift
+++ b/LOGIT/Core/Utilities/TemplateService.swift
@@ -11,7 +11,7 @@ import OSLog
 import SwiftUI
 
 class TemplateService: ObservableObject {
-    private static let logger = Logger(subsystem: "com.lukaskbl.LOGIT", category: "TemplateService")
+    private static let logger = Logger(subsystem: ".com.lukaskbl.LOGIT", category: "TemplateService")
 
     enum Error: Swift.Error {
         case emptyResponse, invalidData, invalidImage, jsonParsingError, keysNotMatching,

--- a/LOGIT/Features/Home/TargetPerWeekDetailScreen.swift
+++ b/LOGIT/Features/Home/TargetPerWeekDetailScreen.swift
@@ -14,7 +14,7 @@ struct TargetPerWeekDetailScreen: View {
 
     private static let logger = Logger(
         subsystem: ".com.lukaskbl.LOGIT",
-        category: "MuscleGroupSplitScreen"
+        category: "TargetPerWeekDetailScreen"
     )
 
     // MARK: - AppStorage


### PR DESCRIPTION
Two safe, log-only cleanups surfaced while reviewing the app's runtime logs.

- **Logger subsystem consistency** — `TemplateService` used `subsystem: "com.lukaskbl.LOGIT"` while every other `Logger` in the app uses `".com.lukaskbl.LOGIT"` (matching the bundle id). Aligned it so unified-log filtering by subsystem is consistent.
- **Wrong log category** — `TargetPerWeekDetailScreen`'s logger `category` was copy-pasted as `"MuscleGroupSplitScreen"`, miscategorizing its log output. Corrected to `"TargetPerWeekDetailScreen"`.

No behavioral, data, or UI impact — these only affect how log lines are tagged in Console/`log` filtering. Build verified (iPhone 17 Pro simulator, Debug, 0 warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)