### PR TITLE
Carry the current-best sparkline's area out to the tile's edge

### DIFF
--- a/LOGIT/Features/Exercise/ExerciseDetail/Tiles/ExerciseMetricTile.swift
+++ b/LOGIT/Features/Exercise/ExerciseDetail/Tiles/ExerciseMetricTile.swift
@@ -284,9 +284,9 @@ struct ExerciseTileSparkline: View {
         let margin: (Date) -> Date = { Calendar.current.date(byAdding: .day, value: 2, to: $0) ?? $0 }
         switch window {
         case .currentBest:
-            // Bleeding to the right edge means the carry-forward dash must reach `.now` exactly; the
-            // corner sparkline keeps the +2-day margin so its trailing dot clears the edge.
-            return Exercise.currentBestWindowStart ... (bleeds ? .now : margin(.now))
+            // Keep the +2-day margin so the latest dot clears the right edge instead of being sliced;
+            // the area is carried out to that edge separately (see `carryForwardArea`).
+            return Exercise.currentBestWindowStart ... margin(.now)
         case .recentHistory:
             let shown = points.suffix(Self.recentHistoryCount)
             guard let first = shown.first?.date, let last = shown.last?.date else {
@@ -308,6 +308,7 @@ struct ExerciseTileSparkline: View {
 
     var body: some View {
         let maxValue = points.map(\.value).max() ?? 1
+        let domain = xDomain()
         let chartView = Chart {
             tileSparklineMarks(
                 points: points,
@@ -315,10 +316,13 @@ struct ExerciseTileSparkline: View {
                 // The all-time line is a single clean curve — no per-session dots, no crest marker.
                 // The windowed sparklines keep a dot per session.
                 showsSymbols: window != .allTime,
-                showsCarryForward: window == .currentBest
+                showsCarryForward: window == .currentBest,
+                // Carry the area (and the dashed carry-forward) out to the domain's trailing edge so the
+                // fill bleeds to the tile's right edge, past where the latest dot sits.
+                carryForwardArea: window == .currentBest ? domain.upperBound : nil
             )
         }
-        .chartXScale(domain: xDomain())
+        .chartXScale(domain: domain)
         .chartYScale(domain: 0 ... max(maxValue * 1.15, 1))
         .chartXAxis {}
         .chartYAxis {}

--- a/LOGIT/SharedUI/Charts/TileSparklineStyle.swift
+++ b/LOGIT/SharedUI/Charts/TileSparklineStyle.swift
@@ -98,7 +98,8 @@ func tileSparklineMarks(
     interpolation: InterpolationMethod = TileSparklineStyle.interpolation,
     showsSymbols: Bool = true,
     showsCarryForward: Bool = true,
-    carryForwardEnd: Date = .now
+    carryForwardEnd: Date = .now,
+    carryForwardArea: Date? = nil
 ) -> some ChartContent {
     // Leading entry pinned to the far past so the line and area enter from the left edge instead of
     // starting mid-chart (the domain clips it).
@@ -128,12 +129,20 @@ func tileSparklineMarks(
             .interpolationMethod(interpolation)
             .foregroundStyle(TileSparklineStyle.areaGradient(color))
     }
+    // Extend the area flat to the chart's trailing edge, so the gradient fill bleeds all the way to
+    // the tile's right edge even though the latest dot (and the window) stop short of it — including
+    // under the dashed carry-forward line.
+    if let carryForwardArea, let last = points.last {
+        AreaMark(x: .value("Date", carryForwardArea, unit: .day), y: .value("Value", last.value))
+            .interpolationMethod(interpolation)
+            .foregroundStyle(TileSparklineStyle.areaGradient(color))
+    }
     if showsCarryForward, let last = points.last,
        last.date < carryForwardEnd,
        !Calendar.current.isDate(last.date, inSameDayAs: carryForwardEnd) {
         RuleMark(
             xStart: .value("Start", last.date),
-            xEnd: .value("End", carryForwardEnd),
+            xEnd: .value("End", carryForwardArea ?? carryForwardEnd),
             y: .value("Value", last.value)
         )
         .foregroundStyle(color.opacity(TileSparklineStyle.carryForwardOpacity))


### PR DESCRIPTION
## What

Follow-up to #34. On the current-best line tiles, the gradient area ended at the last logged session — so the dashed "held since" carry-forward line floated over bare background and the fill didn't reach the tile's right edge.

## Fix

`tileSparklineMarks` gains a `carryForwardArea` parameter: an `AreaMark` carries the fill flat from the last point out to the chart's trailing edge, under the dashed carry-forward, so the gradient bleeds all the way to the corner. The dashed line reaches that same edge.

The domain keeps its +2-day margin so the latest dot is never sliced by the right edge — the area now reaches the edge *independently* of where the dot sits. So a best set "just now" shows a full, un-clipped dot **and** a fill that still bleeds to the edge.

## Testing

Built and verified on the iPhone 17 Pro simulator (exercise detail — Weight / e1RM / Reps / Set Volume tiles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
