### PR TITLE
Use a filled SF Symbol set for the tab bar

### DIFF
--- a/LOGIT/App/LOGITApp.swift
+++ b/LOGIT/App/LOGITApp.swift
@@ -94,18 +94,18 @@ struct LOGIT: App {
     var body: some Scene {
         WindowGroup {
             TabView {
-                    Tab("summary", systemImage: "house") {
+                    Tab("summary", systemImage: "square.grid.2x2.fill") {
                         HomeScreen()
         //                #if targetEnvironment(simulator)
         //                    .statusBarHidden(true)
         //                #endif
                     }
-                    Tab(NSLocalizedString("history", comment: ""), systemImage: "clock.arrow.circlepath") {
+                    Tab(NSLocalizedString("history", comment: ""), systemImage: "clock.fill") {
                         NavigationStack {
                             WorkoutListScreen()
                         }
                     }
-                    Tab(NSLocalizedString("templates", comment: ""), systemImage: "list.bullet.rectangle.portrait") {
+                    Tab(NSLocalizedString("templates", comment: ""), systemImage: "list.bullet.rectangle.portrait.fill") {
                         NavigationStack {
                             TemplateListScreen()
                         }


### PR DESCRIPTION
Switches the tab bar to a consistently **filled** icon set, and gives the **Summary** tab a dashboard-style glyph that matches its grid of tiles (the old `house` read as "home", which the screen isn't).

| Tab | Before | After |
|---|---|---|
| summary | `house` | `square.grid.2x2.fill` |
| history | `clock.arrow.circlepath` | `clock.fill` |
| templates | `list.bullet.rectangle.portrait` | `list.bullet.rectangle.portrait.fill` |
| search | `magnifyingglass` | *(unchanged)* |

Two glyphs have no `.fill` variant in the SF Symbols catalog:
- **history** — `clock.arrow.circlepath` has no fill, so it becomes `clock.fill` (drops the rewind arrow).
- **search** — there is no filled magnifying glass (only `magnifyingglass.circle.fill`, which boxes it in a circle); it's also the dedicated `.search`-role tab the system styles on its own, so it stays `magnifyingglass`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)