### PR TITLE
Share the records row and inset it like the set cells

### DIFF
--- a/LOGIT.xcodeproj/project.pbxproj
+++ b/LOGIT.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		2BD2E4720FB2C657F8CA372B /* CompletionRing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C72085C4C10146858277690 /* CompletionRing.swift */; };
 		77B7E6990E4C00B75D9BC6ED /* PeriodPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA597E1519E8F6D2CBC8F9E /* PeriodPicker.swift */; };
 		E1E1E1000000000000000B12 /* ProgressIndicatorPill.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1E1E1000000000000000F12 /* ProgressIndicatorPill.swift */; };
+		E1E1E1000000000000000B16 /* PersonalBestRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1E1E1000000000000000F16 /* PersonalBestRow.swift */; };
 		E1E1E1000000000000000B15 /* MetricComparisonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1E1E1000000000000000F15 /* MetricComparisonView.swift */; };
 		2A384BE3816900000002 /* ExerciseSuggestionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54EE2592821500000001 /* ExerciseSuggestionService.swift */; };
 		396ADE67CD8C1D14F7A8D82A /* LOGITWidgetExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3BDDD14FE5BF0C275AF30C5 /* LOGITWidgetExtension.swift */; };
@@ -349,6 +350,7 @@
 		3C72085C4C10146858277690 /* CompletionRing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionRing.swift; sourceTree = "<group>"; };
 		BEA597E1519E8F6D2CBC8F9E /* PeriodPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeriodPicker.swift; sourceTree = "<group>"; };
 		E1E1E1000000000000000F12 /* ProgressIndicatorPill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressIndicatorPill.swift; sourceTree = "<group>"; };
+		E1E1E1000000000000000F16 /* PersonalBestRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonalBestRow.swift; sourceTree = "<group>"; };
 		E1E1E1000000000000000F15 /* MetricComparisonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetricComparisonView.swift; sourceTree = "<group>"; };
 		0E384D0F4B54340F910F6813 /* ExerciseMergingSheet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ExerciseMergingSheet.swift; sourceTree = "<group>"; };
 		144AED8F76DE3EBB1A1752AD /* LOGITUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LOGITUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1248,6 +1250,7 @@
 				3C72085C4C10146858277690 /* CompletionRing.swift */,
 				BEA597E1519E8F6D2CBC8F9E /* PeriodPicker.swift */,
 				E1E1E1000000000000000F12 /* ProgressIndicatorPill.swift */,
+				E1E1E1000000000000000F16 /* PersonalBestRow.swift */,
 				E1E1E1000000000000000F15 /* MetricComparisonView.swift */,
 				801BBD5B2DF7338A00CDB1FB /* WidgetCollectionView.swift */,
 				80B387BA2EBA187100AD7EFC /* DecimalField.swift */,
@@ -1647,6 +1650,7 @@
 				2BD2E4720FB2C657F8CA372B /* CompletionRing.swift in Sources */,
 				77B7E6990E4C00B75D9BC6ED /* PeriodPicker.swift in Sources */,
 				E1E1E1000000000000000B12 /* ProgressIndicatorPill.swift in Sources */,
+				E1E1E1000000000000000B16 /* PersonalBestRow.swift in Sources */,
 				E1E1E1000000000000000B15 /* MetricComparisonView.swift in Sources */,
 				801BBD9D2DF7338A00CDB1FB /* SuperSet+.swift in Sources */,
 				801BBD9E2DF7338A00CDB1FB /* TileHeaderStyle.swift in Sources */,

--- a/LOGIT/Features/Home/SummaryRecords.swift
+++ b/LOGIT/Features/Home/SummaryRecords.swift
@@ -52,14 +52,16 @@ struct SummaryRecordsTile: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             header
+                .padding([.top, .horizontal], CELL_PADDING)
             VStack(spacing: 8) {
                 ForEach(Array(records.prefix(maxShown))) { record in
                     PersonalBestRow(record: record)
                 }
             }
             .padding(.top, 10)
+            .padding(.horizontal, CELL_PADDING / 2)
+            .padding(.bottom, CELL_PADDING / 2)
         }
-        .padding(CELL_PADDING)
         .frame(maxWidth: .infinity, alignment: .leading)
         .tileStyle()
     }

--- a/LOGIT/Features/Workout/WorkoutDetailScreen.swift
+++ b/LOGIT/Features/Workout/WorkoutDetailScreen.swift
@@ -276,7 +276,6 @@ struct WorkoutDetailScreen: View {
             isShowingPersonalRecords = true
         } label: {
             WorkoutPersonalBestsTile(workout: workout, report: progressReport ?? .empty)
-                .padding(CELL_PADDING)
                 .frame(maxWidth: .infinity, alignment: .topLeading)
                 .tileStyle()
         }

--- a/LOGIT/Features/Workout/WorkoutProgressSection.swift
+++ b/LOGIT/Features/Workout/WorkoutProgressSection.swift
@@ -170,16 +170,6 @@ private func personalRecordsHeadline(count: Int) -> String {
         : String(format: NSLocalizedString("personalRecordsCount", comment: ""), count)
 }
 
-/// A record's base value as a display string and its unit, in the metric's units. The tile and the
-/// card both render it through `UnitView`, which uppercases the unit, so the casing can't drift.
-private func personalRecordDisplay(_ base: Int, metric: ExercisePrimaryMetric) -> (value: String, unit: String) {
-    switch metric {
-    case .estimatedOneRepMax: return (formatEstimatedOneRepMax(base), WeightUnit.used.rawValue)
-    case .weight: return (formatWeightForDisplay(base), WeightUnit.used.rawValue)
-    case .repetitions: return (String(base), NSLocalizedString("reps", comment: ""))
-    }
-}
-
 /// The metric's base value of a single set for `exercise` — the per-day series behind the records
 /// screen's sparkline, matching the detection in `WorkoutProgressReport.compute`.
 private func personalRecordSetValue(_ workoutSet: WorkoutSet, exercise: Exercise, metric: ExercisePrimaryMetric) -> Int {
@@ -188,15 +178,6 @@ private func personalRecordSetValue(_ workoutSet: WorkoutSet, exercise: Exercise
     case .weight: return workoutSet.maximum(.weight, for: exercise)
     case .repetitions: return workoutSet.maximum(.repetitions, for: exercise)
     }
-}
-
-/// A record's value as `UnitView` — the caller tints it in the exercise's muscle-group gradient.
-private func personalRecordValueView(
-    for record: WorkoutProgressReport.PRRecord,
-    configuration: UnitViewConfiguration = .normal
-) -> some View {
-    let display = personalRecordDisplay(record.value, metric: record.metric)
-    return UnitView(value: display.value, unit: display.unit, configuration: configuration)
 }
 
 // MARK: - Records tile
@@ -249,12 +230,15 @@ struct WorkoutPersonalBestsTile: View {
                         .foregroundStyle(.secondary)
                 }
             }
+            .padding([.top, .horizontal], CELL_PADDING)
             VStack(spacing: 8) {
                 ForEach(shown) { record in
                     PersonalBestRow(record: record)
                 }
             }
             .padding(.top, 8)
+            .padding(.horizontal, CELL_PADDING / 2)
+            .padding(.bottom, CELL_PADDING / 2)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
     }
@@ -504,44 +488,5 @@ struct WorkoutPersonalRecords_Previews: PreviewProvider {
     static var previews: some View {
         PreviewWrapperView()
             .previewEnvironmentObjects()
-    }
-}
-
-// MARK: - Shared record row
-
-/// One record on its own secondary tile — the muscle-tinted trophy badge, the exercise + metric, and
-/// the new best in its muscle-group gradient. Shared by the workout-detail records tile and the
-/// Summary records tile so the rows render identically.
-struct PersonalBestRow: View {
-    let record: WorkoutProgressReport.PRRecord
-
-    var body: some View {
-        let color = record.exercise.muscleGroup?.color ?? .accentColor
-        return HStack(spacing: 12) {
-            ZStack {
-                Circle()
-                    .fill(color.opacity(0.15))
-                    .frame(width: 34, height: 34)
-                Image(systemName: "trophy.fill")
-                    .font(.caption)
-                    .foregroundStyle(color.gradient)
-            }
-            VStack(alignment: .leading, spacing: 2) {
-                Text(record.exercise.displayName)
-                    .font(.subheadline.weight(.semibold))
-                    .foregroundStyle(Color.label)
-                    .lineLimit(1)
-                Text(record.metric.title)
-                    .font(.caption2.weight(.medium))
-                    .foregroundStyle(.secondary)
-            }
-            Spacer(minLength: 8)
-            personalRecordValueView(for: record, configuration: .normal)
-                .foregroundStyle(color.gradient)
-        }
-        .padding(.vertical, 12)
-        .padding(.horizontal, 14)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .secondaryTileStyle(insetShadow: true)
     }
 }

--- a/LOGIT/SharedUI/Views/PersonalBestRow.swift
+++ b/LOGIT/SharedUI/Views/PersonalBestRow.swift
@@ -1,0 +1,69 @@
+//
+//  PersonalBestRow.swift
+//  LOGIT
+//
+//  Created by Lukas Kaibel on 29.06.26.
+//
+
+import SwiftUI
+
+// MARK: - Shared record row
+
+/// One record on its own secondary tile — the muscle-tinted trophy badge, the exercise + metric, and
+/// the new best in its muscle-group gradient. Shared by the workout-detail records tile and the
+/// Summary records tile so the rows render identically; lives in SharedUI so both surfaces use the
+/// one component.
+struct PersonalBestRow: View {
+    let record: WorkoutProgressReport.PRRecord
+
+    var body: some View {
+        let color = record.exercise.muscleGroup?.color ?? .accentColor
+        return HStack(spacing: 12) {
+            ZStack {
+                Circle()
+                    .fill(color.opacity(0.15))
+                    .frame(width: 34, height: 34)
+                Image(systemName: "trophy.fill")
+                    .font(.caption)
+                    .foregroundStyle(color.gradient)
+            }
+            VStack(alignment: .leading, spacing: 2) {
+                Text(record.exercise.displayName)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(Color.label)
+                    .lineLimit(1)
+                Text(record.metric.title)
+                    .font(.caption2.weight(.medium))
+                    .foregroundStyle(.secondary)
+            }
+            Spacer(minLength: 8)
+            personalRecordValueView(for: record, configuration: .normal)
+                .foregroundStyle(color.gradient)
+        }
+        .padding(.vertical, 12)
+        .padding(.horizontal, 14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .secondaryTileStyle(insetShadow: true)
+    }
+}
+
+// MARK: - Record value rendering
+
+/// A record's base value as a display string and its unit, in the metric's units. The tile and the
+/// card both render it through `UnitView`, which uppercases the unit, so the casing can't drift.
+func personalRecordDisplay(_ base: Int, metric: ExercisePrimaryMetric) -> (value: String, unit: String) {
+    switch metric {
+    case .estimatedOneRepMax: return (formatEstimatedOneRepMax(base), WeightUnit.used.rawValue)
+    case .weight: return (formatWeightForDisplay(base), WeightUnit.used.rawValue)
+    case .repetitions: return (String(base), NSLocalizedString("reps", comment: ""))
+    }
+}
+
+/// A record's value as `UnitView` — the caller tints it in the exercise's muscle-group gradient.
+private func personalRecordValueView(
+    for record: WorkoutProgressReport.PRRecord,
+    configuration: UnitViewConfiguration = .normal
+) -> some View {
+    let display = personalRecordDisplay(record.value, metric: record.metric)
+    return UnitView(value: display.value, unit: display.unit, configuration: configuration)
+}


### PR DESCRIPTION
Extracts `PersonalBestRow` — the personal-record secondary tile shown on both the Summary "New Records" card and the workout-detail records tile — into `SharedUI/Views/`, alongside its value-rendering helpers, so both surfaces use one shared component.

Insets the record rows by `CELL_PADDING/2` from the outer card border (horizontally and at the bottom), matching how `WorkoutSetCell` sits inside `WorkoutSetGroupCell`. The header keeps the standard `CELL_PADDING` inset, so the rows read slightly wider than the header — the same look as the set group.

Verified: zero-warning build on iPhone 17 Pro; simulator screenshots of both the Summary and workout-detail records tiles confirm the rows render identically with the tighter border inset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)