### PR TITLE
Redesign the Summary empty states + put pinned exercises above measurements

### DIFF
--- a/LOGIT.xcodeproj/project.pbxproj
+++ b/LOGIT.xcodeproj/project.pbxproj
@@ -208,6 +208,7 @@
 		E18E0521AED5762B30E5FA1F /* MuscleGroupDetailScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFD9E1A9B2D266CBA7AE5F18 /* MuscleGroupDetailScreen.swift */; };
 		D0AF3C855D8D73E72DA7AF92 /* SummaryWelcomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E62F41D02C28CB089872E955 /* SummaryWelcomeView.swift */; };
 		23A5FD0EA5AC115CC0EC34E6 /* SummaryRecords.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADFEC5772AE8932AA1089603 /* SummaryRecords.swift */; };
+		79BB043F7BA96F3DE3739FB7 /* SummaryEmptyStates.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC42311A655A248061E11238 /* SummaryEmptyStates.swift */; };
 		BACD36D82914BE00C27FE040 /* MuscleTargetSplitScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80C7068F531DB65831E8FA8F /* MuscleTargetSplitScreen.swift */; };
 		07A5D2C54CA81141164E3D9D /* MuscleGroupsOverviewScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54FB7DD2DDA0DE70BD366F9C /* MuscleGroupsOverviewScreen.swift */; };
 		85D5027D8B1FA8DB36998EBC /* SummaryStatScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE557E27ADC9A2C02BE79DBE /* SummaryStatScreen.swift */; };
@@ -477,6 +478,7 @@
 		FFD9E1A9B2D266CBA7AE5F18 /* MuscleGroupDetailScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MuscleGroupDetailScreen.swift; sourceTree = "<group>"; };
 		E62F41D02C28CB089872E955 /* SummaryWelcomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryWelcomeView.swift; sourceTree = "<group>"; };
 		ADFEC5772AE8932AA1089603 /* SummaryRecords.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryRecords.swift; sourceTree = "<group>"; };
+		DC42311A655A248061E11238 /* SummaryEmptyStates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryEmptyStates.swift; sourceTree = "<group>"; };
 		80C7068F531DB65831E8FA8F /* MuscleTargetSplitScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MuscleTargetSplitScreen.swift; sourceTree = "<group>"; };
 		54FB7DD2DDA0DE70BD366F9C /* MuscleGroupsOverviewScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MuscleGroupsOverviewScreen.swift; sourceTree = "<group>"; };
 		DE557E27ADC9A2C02BE79DBE /* SummaryStatScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryStatScreen.swift; sourceTree = "<group>"; };
@@ -1024,6 +1026,7 @@
 				FFD9E1A9B2D266CBA7AE5F18 /* MuscleGroupDetailScreen.swift */,
 				E62F41D02C28CB089872E955 /* SummaryWelcomeView.swift */,
 				ADFEC5772AE8932AA1089603 /* SummaryRecords.swift */,
+				DC42311A655A248061E11238 /* SummaryEmptyStates.swift */,
 				80C7068F531DB65831E8FA8F /* MuscleTargetSplitScreen.swift */,
 				54FB7DD2DDA0DE70BD366F9C /* MuscleGroupsOverviewScreen.swift */,
 				DE557E27ADC9A2C02BE79DBE /* SummaryStatScreen.swift */,
@@ -1772,6 +1775,7 @@
 				E18E0521AED5762B30E5FA1F /* MuscleGroupDetailScreen.swift in Sources */,
 				D0AF3C855D8D73E72DA7AF92 /* SummaryWelcomeView.swift in Sources */,
 				23A5FD0EA5AC115CC0EC34E6 /* SummaryRecords.swift in Sources */,
+				79BB043F7BA96F3DE3739FB7 /* SummaryEmptyStates.swift in Sources */,
 				BACD36D82914BE00C27FE040 /* MuscleTargetSplitScreen.swift in Sources */,
 				07A5D2C54CA81141164E3D9D /* MuscleGroupsOverviewScreen.swift in Sources */,
 				85D5027D8B1FA8DB36998EBC /* SummaryStatScreen.swift in Sources */,

--- a/LOGIT/Core/Environment/de.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/de.lproj/Localizable.strings
@@ -984,3 +984,8 @@
 "bestStreakLabel" = "Best · %d Wo.";
 "monthWorkoutsCount" = "%d Workouts";
 "muscleBalanceEmptySubtitle" = "Logge ein Workout, um deine Muskelverteilung zu sehen.";
+"pinKeyLifts" = "Hefte deine wichtigsten Übungen an";
+"chooseExercises" = "Übungen auswählen";
+"pinAMeasurement" = "Maß anheften";
+"trackMeasurements" = "Verfolge deine Maße";
+"unlockWithPro" = "Mit Pro freischalten";

--- a/LOGIT/Core/Environment/en.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/en.lproj/Localizable.strings
@@ -988,3 +988,8 @@
 "bestStreakLabel" = "Best · %d wks";
 "monthWorkoutsCount" = "%d workouts";
 "muscleBalanceEmptySubtitle" = "Log a workout to see your muscle split.";
+"pinKeyLifts" = "Pin your key lifts";
+"chooseExercises" = "Choose exercises";
+"pinAMeasurement" = "Pin a measurement";
+"trackMeasurements" = "Track your measurements";
+"unlockWithPro" = "Unlock with Pro";

--- a/LOGIT/Core/Environment/es.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/es.lproj/Localizable.strings
@@ -988,3 +988,8 @@
 "bestStreakLabel" = "Mejor · %d sem";
 "monthWorkoutsCount" = "%d entrenamientos";
 "muscleBalanceEmptySubtitle" = "Registra un entrenamiento para ver tu reparto muscular.";
+"pinKeyLifts" = "Fija tus ejercicios clave";
+"chooseExercises" = "Elegir ejercicios";
+"pinAMeasurement" = "Fijar una medida";
+"trackMeasurements" = "Registra tus medidas";
+"unlockWithPro" = "Desbloquear con Pro";

--- a/LOGIT/Core/Environment/fr.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/fr.lproj/Localizable.strings
@@ -988,3 +988,8 @@
 "bestStreakLabel" = "Record · %d sem";
 "monthWorkoutsCount" = "%d séances";
 "muscleBalanceEmptySubtitle" = "Enregistre une séance pour voir ta répartition musculaire.";
+"pinKeyLifts" = "Épingle tes exercices clés";
+"chooseExercises" = "Choisir des exercices";
+"pinAMeasurement" = "Épingler une mesure";
+"trackMeasurements" = "Suis tes mesures";
+"unlockWithPro" = "Débloquer avec Pro";

--- a/LOGIT/Core/Environment/it.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/it.lproj/Localizable.strings
@@ -988,3 +988,8 @@
 "bestStreakLabel" = "Migliore · %d sett";
 "monthWorkoutsCount" = "%d allenamenti";
 "muscleBalanceEmptySubtitle" = "Registra un allenamento per vedere la tua ripartizione muscolare.";
+"pinKeyLifts" = "Fissa i tuoi esercizi chiave";
+"chooseExercises" = "Scegli esercizi";
+"pinAMeasurement" = "Fissa una misura";
+"trackMeasurements" = "Monitora le tue misure";
+"unlockWithPro" = "Sblocca con Pro";

--- a/LOGIT/Core/Environment/ja.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/ja.lproj/Localizable.strings
@@ -988,3 +988,8 @@
 "bestStreakLabel" = "最高 · %d週";
 "monthWorkoutsCount" = "%d回";
 "muscleBalanceEmptySubtitle" = "ワークアウトを記録すると筋肉の配分が表示されます。";
+"pinKeyLifts" = "主要種目をピン留め";
+"chooseExercises" = "種目を選ぶ";
+"pinAMeasurement" = "測定値をピン留め";
+"trackMeasurements" = "測定値を記録";
+"unlockWithPro" = "Proで解除";

--- a/LOGIT/Core/Environment/ko.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/ko.lproj/Localizable.strings
@@ -988,3 +988,8 @@
 "bestStreakLabel" = "최고 · %d주";
 "monthWorkoutsCount" = "%d회";
 "muscleBalanceEmptySubtitle" = "운동을 기록하면 근육 분포가 표시됩니다.";
+"pinKeyLifts" = "주요 운동 고정";
+"chooseExercises" = "운동 선택";
+"pinAMeasurement" = "측정값 고정";
+"trackMeasurements" = "측정값 추적";
+"unlockWithPro" = "Pro로 잠금 해제";

--- a/LOGIT/Core/Environment/pt-BR.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/pt-BR.lproj/Localizable.strings
@@ -988,3 +988,8 @@
 "bestStreakLabel" = "Melhor · %d sem";
 "monthWorkoutsCount" = "%d treinos";
 "muscleBalanceEmptySubtitle" = "Registre um treino para ver sua divisão muscular.";
+"pinKeyLifts" = "Fixe seus exercícios principais";
+"chooseExercises" = "Escolher exercícios";
+"pinAMeasurement" = "Fixar uma medida";
+"trackMeasurements" = "Acompanhe suas medidas";
+"unlockWithPro" = "Desbloquear com Pro";

--- a/LOGIT/Features/Home/HomeScreen.swift
+++ b/LOGIT/Features/Home/HomeScreen.swift
@@ -164,10 +164,10 @@ struct HomeScreen: View {
                                 )
                             }
 
-                            measurementsSection
+                            exercisesSection
                                 .padding(.horizontal)
 
-                            exercisesSection
+                            measurementsSection
                                 .padding(.horizontal)
                             }
 
@@ -358,22 +358,12 @@ struct HomeScreen: View {
                 }
             }
             VStack(spacing: 8) {
-                if pinnedMeasurements.isEmpty && isShowingMeasurementsTip {
-                    TipView(
-                        title: NSLocalizedString("pinMeasurementsTip", comment: ""),
-                        description: NSLocalizedString("pinMeasurementsTipDescription", comment: ""),
-                        buttonAction: .init(
-                            title: NSLocalizedString("addPin", comment: ""),
-                            action: { isShowingMeasurementsEditSheet = true }
-                        ),
-                        isShown: $isShowingMeasurementsTip
-                    )
-                }
-                if !pinnedMeasurements.isEmpty {
+                if pinnedMeasurements.isEmpty {
+                    MeasurementsEmptyState(onAdd: { isShowingMeasurementsEditSheet = true })
+                } else {
                     MeasurementWatchlist(types: pinnedMeasurements) { measurementType in
                         homeNavigationCoordinator.path.append(.measurementDetail(measurementType))
                     }
-                }
                 
                 Button {
                     homeNavigationCoordinator.path.append(.measurements)
@@ -394,8 +384,9 @@ struct HomeScreen: View {
                     .tileStyle()
                 }
                 .buttonStyle(TileButtonStyle())
+                }
             }
-            .isBlockedWithoutPro()
+            .isBlockedWithoutPro(!pinnedMeasurements.isEmpty)
         }
     }
     
@@ -429,17 +420,9 @@ struct HomeScreen: View {
                 .fontWeight(.semibold)
             }
             VStack(spacing: 8) {
-                if pinnedExerciseTiles.isEmpty && isShowingExercisesTip {
-                    TipView(
-                        title: NSLocalizedString("pinExercisesTip", comment: ""),
-                        description: NSLocalizedString("pinExercisesTipDescription", comment: ""),
-                        buttonAction: .init(
-                            title: NSLocalizedString("addPin", comment: ""),
-                            action: { isShowingExercisesPinEditSheet = true }
-                        ),
-                        isShown: $isShowingExercisesTip
-                    )
-                }
+                if pinnedExerciseTiles.isEmpty {
+                    PinnedExercisesEmptyState(onAdd: { isShowingExercisesPinEditSheet = true })
+                } else {
                 LazyVGrid(
                     columns: [GridItem(.flexible(), spacing: 8), GridItem(.flexible(), spacing: 8)],
                     spacing: 8
@@ -469,6 +452,7 @@ struct HomeScreen: View {
                     .tileStyle()
                 }
                 .buttonStyle(TileButtonStyle())
+                }
             }
         }
     }

--- a/LOGIT/Features/Home/SummaryEmptyStates.swift
+++ b/LOGIT/Features/Home/SummaryEmptyStates.swift
@@ -1,0 +1,218 @@
+//
+//  SummaryEmptyStates.swift
+//  LOGIT
+//
+//  Created by Lukas Kaibel on 29.06.26.
+//
+
+import SwiftUI
+
+// MARK: - Pinned exercises empty state
+
+/// Shown in the Summary's pinned-exercises section when nothing is pinned: two dimmed sample tiles
+/// behind a "Pin your key lifts" call-to-action. The samples preview the real pinned-tile look —
+/// which doubles as a Pro teaser, since the marquee metrics they show (Est. 1RM, volume) are exactly
+/// what's gated. Replaces the old gray tip card.
+struct PinnedExercisesEmptyState: View {
+    let onAdd: () -> Void
+
+    var body: some View {
+        ZStack {
+            HStack(spacing: 8) {
+                GhostExerciseTile(
+                    name: "Bench Press",
+                    value: "102",
+                    unit: WeightUnit.used.rawValue,
+                    color: MuscleGroup.chest.color,
+                    points: [0.35, 0.5, 0.45, 0.7, 1.0]
+                )
+                GhostExerciseTile(
+                    name: "Squat",
+                    value: "145",
+                    unit: WeightUnit.used.rawValue,
+                    color: MuscleGroup.legs.color,
+                    points: [0.4, 0.55, 0.5, 0.8, 1.0]
+                )
+            }
+            .opacity(0.3)
+            .allowsHitTesting(false)
+            callToAction(title: NSLocalizedString("pinKeyLifts", comment: ""), buttonTitle: NSLocalizedString("chooseExercises", comment: ""), onAdd: onAdd)
+        }
+    }
+}
+
+// MARK: - Measurements empty state
+
+/// The measurements echo of the pinned teaser — two dimmed sample watchlist rows in a single card
+/// (the same dimming as the pinned tiles) behind a "Track your measurements" call-to-action, so the
+/// two sections read as one family.
+struct MeasurementsEmptyState: View {
+    @EnvironmentObject private var purchaseManager: PurchaseManager
+    let onAdd: () -> Void
+    @State private var isShowingUpgrade = false
+
+    var body: some View {
+        ZStack {
+            VStack(spacing: 0) {
+                ghostRow(icon: "scalemass", name: NSLocalizedString("bodyweight", comment: ""), value: "78.4", unit: WeightUnit.used.rawValue, points: [0.75, 0.55, 0.6, 0.4, 0.45, 0.3])
+                Divider()
+                ghostRow(icon: "percentage", name: NSLocalizedString("bodyFatPercentage", comment: ""), value: "14.2", unit: "%", points: [0.85, 0.7, 0.6, 0.5, 0.4, 0.35])
+            }
+            .padding(.horizontal, CELL_PADDING)
+            .tileStyle()
+            .opacity(0.3)
+            .allowsHitTesting(false)
+            VStack(spacing: 12) {
+                Text(NSLocalizedString("trackMeasurements", comment: ""))
+                    .font(.headline)
+                    .foregroundStyle(Color.label)
+                    .multilineTextAlignment(.center)
+                    .shadow(color: .black.opacity(0.6), radius: 8)
+                // Measurements are a Pro feature: a free user can't pin, so the empty state is the
+                // upgrade hook — a clean teaser + "Unlock with Pro" rather than a blurred section.
+                if purchaseManager.hasUnlockedPro {
+                    SummaryPillButton(title: NSLocalizedString("pinAMeasurement", comment: ""), systemImage: "plus", action: onAdd)
+                } else {
+                    SummaryPillButton(title: NSLocalizedString("unlockWithPro", comment: ""), systemImage: "crown.fill") {
+                        isShowingUpgrade = true
+                    }
+                }
+            }
+        }
+        .sheet(isPresented: $isShowingUpgrade) {
+            NavigationStack { UpgradeToProScreen() }
+        }
+    }
+
+    private func ghostRow(icon: String, name: String, value: String, unit: String, points: [CGFloat]) -> some View {
+        HStack(spacing: 11) {
+            Image(systemName: icon)
+                .font(.body)
+                .foregroundStyle(.secondary)
+                .frame(width: 22)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(name)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(Color.label)
+                    .lineLimit(1)
+                Text(NSLocalizedString("current", comment: ""))
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer(minLength: 8)
+            GhostTrendLine(points: points, color: .secondary)
+                .frame(width: 50, height: 22)
+            UnitView(value: value, unit: unit, unitColor: .secondaryLabel)
+                .foregroundStyle(Color.label)
+        }
+        .padding(.vertical, 11)
+    }
+}
+
+// MARK: - Shared pieces
+
+/// The centered headline + accent pill overlaid on a dimmed sample — the shared call-to-action both
+/// empty states wear.
+private func callToAction(title: String, buttonTitle: String, onAdd: @escaping () -> Void) -> some View {
+    VStack(spacing: 12) {
+        Text(title)
+            .font(.headline)
+            .foregroundStyle(Color.label)
+            .multilineTextAlignment(.center)
+            .shadow(color: .black.opacity(0.6), radius: 8)
+        SummaryPillButton(title: buttonTitle, systemImage: "plus", action: onAdd)
+    }
+}
+
+/// A dimmed sample of a pinned exercise tile — mirrors the `MetricTile` pinned look (muscle dot + name,
+/// Est. 1RM caption, value, corner sparkline) closely enough to read as a believable preview.
+private struct GhostExerciseTile: View {
+    let name: String
+    let value: String
+    let unit: String
+    let color: Color
+    let points: [CGFloat]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(spacing: 6) {
+                RoundedRectangle(cornerRadius: 3).fill(color).frame(width: 9, height: 9)
+                Text(name)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(Color.label)
+                    .lineLimit(1)
+                Spacer(minLength: 0)
+            }
+            Text(NSLocalizedString("estimatedOneRepMax", comment: ""))
+                .font(.caption2.weight(.bold))
+                .textCase(.uppercase)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .padding(.top, 10)
+            UnitView(value: value, unit: unit, configuration: .large, unitColor: .secondaryLabel)
+                .foregroundStyle(Color.label)
+                .padding(.top, 2)
+            Spacer(minLength: 8)
+            GhostTrendLine(points: points, color: color)
+                .frame(height: 24)
+        }
+        .padding(CELL_PADDING)
+        .frame(height: 150, alignment: .topLeading)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .tileStyle()
+    }
+}
+
+/// A simple rounded-cap line through normalized 0…1 points — the sample sparkline on both empty states.
+private struct GhostTrendLine: View {
+    let points: [CGFloat]
+    let color: Color
+
+    var body: some View {
+        GeometryReader { geometry in
+            Path { path in
+                let w = geometry.size.width
+                let h = geometry.size.height
+                for (index, value) in points.enumerated() {
+                    let x = w * CGFloat(index) / CGFloat(max(points.count - 1, 1))
+                    let y = h * (1 - value)
+                    if index == 0 { path.move(to: CGPoint(x: x, y: y)) } else { path.addLine(to: CGPoint(x: x, y: y)) }
+                }
+            }
+            .stroke(color, style: StrokeStyle(lineWidth: 2.5, lineCap: .round, lineJoin: .round))
+        }
+    }
+}
+
+/// A compact accent pill button — the call-to-action on the Summary empty states.
+struct SummaryPillButton: View {
+    let title: String
+    var systemImage: String? = nil
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 6) {
+                if let systemImage {
+                    Image(systemName: systemImage)
+                }
+                Text(title)
+            }
+            .font(.subheadline.weight(.bold))
+            .foregroundStyle(Color.black)
+            .padding(.horizontal, 18)
+            .padding(.vertical, 10)
+            .background(Capsule().fill(Color.accentColor))
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+#Preview {
+    VStack(spacing: 24) {
+        PinnedExercisesEmptyState(onAdd: {})
+        MeasurementsEmptyState(onAdd: {})
+    }
+    .padding()
+    .previewEnvironmentObjects()
+}


### PR DESCRIPTION
Follow-up polish on the Summary redesign, all in the pinned-exercises and measurements sections.

## Reorder
**Pinned Exercises** now sits **above** Measurements, matching `design-mockups/summary-redesign.html` (the original build kept the old order).

## Empty states (replacing the gray tip cards)
- **Pinned exercises** — two dimmed sample tiles (Est. 1RM + sparkline) behind a "Pin your key lifts" + **Choose exercises** CTA. The samples preview the real pinned-tile look and double as a soft Pro tease, since Est. 1RM is gated.
- **Measurements** — a matching two-row dimmed teaser (Bodyweight, Body Fat). Same shading as the pinned tiles so the two sections read as one family.

## Free tier / Pro incentive
Measurements is a Pro feature, so a free user can never pin one. Instead of blurring the whole section into mud, the empty state is now the upgrade hook: a clean teaser + a crown **"Unlock with Pro"** button → the upgrade screen. The section only blurs when it actually holds data (`isBlockedWithoutPro(!pinnedMeasurements.isEmpty)`), covering the lapsed-Pro edge case. Pinned exercises stays free (it shows "Choose exercises").

New `SummaryEmptyStates.swift` (with a shared `GhostTrendLine` and accent pill button) + five localized keys across all 8 locales. Zero-warning build on iPhone 17 Pro; verified on the simulator in both Pro and free (`-UITEST_FORCE_FREE`) tiers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)