### PR TITLE
Polish Settings: align Feedback & About rows, strengthen mail icons

### DIFF
--- a/LOGIT/Features/SettingsScreen.swift
+++ b/LOGIT/Features/SettingsScreen.swift
@@ -131,14 +131,14 @@ struct SettingsScreen: View {
                                 .foregroundStyle(.secondary)
                         }
                         Spacer()
-                        Image(systemName: "envelope")
+                        Image(systemName: "envelope.fill")
                             .foregroundStyle(.secondary)
                     }
                     .padding(CELL_PADDING)
                     .tileStyle()
                 }
                 Link(destination: URL(string: "mailto:\(FEEDBACK_EMAIL)?subject=LOGIT%20Support")!) {
-                    settingsRow(NSLocalizedString("support", comment: ""), icon: "questionmark.circle", trailingSystemImage: "envelope")
+                    settingsRow(NSLocalizedString("support", comment: ""), icon: "questionmark.circle.fill", trailingSystemImage: "envelope.fill")
                 }
                 Button { requestReview() } label: {
                     settingsRow(NSLocalizedString("rateLogit", comment: ""), icon: "star.fill", trailingChevron: true)
@@ -151,13 +151,13 @@ struct SettingsScreen: View {
         section(NSLocalizedString("about", comment: "")) {
             VStack(spacing: CELL_SPACING) {
                 Button { isShowingPrivacyPolicy = true } label: {
-                    settingsRow(NSLocalizedString("privacyPolicy", comment: ""), trailingChevron: true)
+                    settingsRow(NSLocalizedString("privacyPolicy", comment: ""), icon: "hand.raised.fill", trailingChevron: true)
                 }
                 Button { isShowingTermsAndConditions = true } label: {
-                    settingsRow(NSLocalizedString("termsAndConditions", comment: ""), trailingChevron: true)
+                    settingsRow(NSLocalizedString("termsAndConditions", comment: ""), icon: "doc.text.fill", trailingChevron: true)
                 }
                 Link(destination: URL(string: "https://www.apple.com/legal/internet-services/itunes/dev/stdeula/")!) {
-                    settingsRow(NSLocalizedString("licenceAgreement", comment: ""), trailingSystemImage: "arrow.up.forward.square")
+                    settingsRow(NSLocalizedString("licenceAgreement", comment: ""), icon: "checkmark.seal.fill", trailingSystemImage: "arrow.up.forward.square")
                 }
             }
         }


### PR DESCRIPTION
## What

The Settings **Feedback & Support** and **About** sections were misaligned, and the mail icons looked weak.

- **Alignment:** every row now carries a filled leading icon, so all labels line up on one vertical edge. Previously the `settingsRow` helper only reserved the icon column when an icon was passed, so the icon-less About rows (Privacy Policy / Terms & Conditions / Licence Agreement) sat ~36pt further left than the Feedback rows.
- **Stronger mail glyphs:** the outline `envelope` icons are now `envelope.fill` — solid instead of hollow.
- `questionmark.circle` → `questionmark.circle.fill` so all leading icons share one weight (matching `lightbulb.fill` / `star.fill`).

New About icons: Privacy Policy `hand.raised.fill`, Terms & Conditions `doc.text.fill`, Licence Agreement `checkmark.seal.fill`.

Verified on the iPhone 17 Pro simulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
