### PR TITLE
Redesign the Weekly Goal screen and add the Summary streak scoreboard

### DIFF
--- a/LOGIT/Core/Environment/de.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/de.lproj/Localizable.strings
@@ -989,3 +989,12 @@
 "pinAMeasurement" = "Maß anheften";
 "trackMeasurements" = "Verfolge deine Maße";
 "unlockWithPro" = "Mit Pro freischalten";
+
+"currentWeekNumber" = "Woche %d";
+"nextMilestone" = "Nächster Meilenstein";
+"streakFactHalfYear" = "Ein halbes Jahr";
+"streakFactMonth" = "Ein ganzer Monat";
+"streakFactQuarter" = "Ein ganzes Quartal";
+"streakFactTwoYears" = "Zwei Jahre";
+"streakFactYear" = "Ein ganzes Jahr";
+"weeks" = "Wochen";

--- a/LOGIT/Core/Environment/en.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/en.lproj/Localizable.strings
@@ -993,3 +993,12 @@
 "pinAMeasurement" = "Pin a measurement";
 "trackMeasurements" = "Track your measurements";
 "unlockWithPro" = "Unlock with Pro";
+
+"currentWeekNumber" = "Week %d";
+"nextMilestone" = "Next Milestone";
+"streakFactHalfYear" = "Half a year";
+"streakFactMonth" = "A full month";
+"streakFactQuarter" = "A full quarter";
+"streakFactTwoYears" = "Two years";
+"streakFactYear" = "A full year";
+"weeks" = "Weeks";

--- a/LOGIT/Core/Environment/es.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/es.lproj/Localizable.strings
@@ -993,3 +993,12 @@
 "pinAMeasurement" = "Fijar una medida";
 "trackMeasurements" = "Registra tus medidas";
 "unlockWithPro" = "Desbloquear con Pro";
+
+"currentWeekNumber" = "Semana %d";
+"nextMilestone" = "Próximo hito";
+"streakFactHalfYear" = "Medio año";
+"streakFactMonth" = "Un mes completo";
+"streakFactQuarter" = "Un trimestre completo";
+"streakFactTwoYears" = "Dos años";
+"streakFactYear" = "Un año completo";
+"weeks" = "Semanas";

--- a/LOGIT/Core/Environment/fr.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/fr.lproj/Localizable.strings
@@ -993,3 +993,12 @@
 "pinAMeasurement" = "Épingler une mesure";
 "trackMeasurements" = "Suis tes mesures";
 "unlockWithPro" = "Débloquer avec Pro";
+
+"currentWeekNumber" = "Semaine %d";
+"nextMilestone" = "Prochain palier";
+"streakFactHalfYear" = "Une demi-année";
+"streakFactMonth" = "Un mois complet";
+"streakFactQuarter" = "Un trimestre complet";
+"streakFactTwoYears" = "Deux ans";
+"streakFactYear" = "Une année complète";
+"weeks" = "Semaines";

--- a/LOGIT/Core/Environment/it.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/it.lproj/Localizable.strings
@@ -993,3 +993,12 @@
 "pinAMeasurement" = "Fissa una misura";
 "trackMeasurements" = "Monitora le tue misure";
 "unlockWithPro" = "Sblocca con Pro";
+
+"currentWeekNumber" = "Settimana %d";
+"nextMilestone" = "Prossimo traguardo";
+"streakFactHalfYear" = "Mezzo anno";
+"streakFactMonth" = "Un mese intero";
+"streakFactQuarter" = "Un trimestre intero";
+"streakFactTwoYears" = "Due anni";
+"streakFactYear" = "Un anno intero";
+"weeks" = "Settimane";

--- a/LOGIT/Core/Environment/ja.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/ja.lproj/Localizable.strings
@@ -993,3 +993,12 @@
 "pinAMeasurement" = "測定値をピン留め";
 "trackMeasurements" = "測定値を記録";
 "unlockWithPro" = "Proで解除";
+
+"currentWeekNumber" = "第%d週";
+"nextMilestone" = "次のマイルストーン";
+"streakFactHalfYear" = "半年";
+"streakFactMonth" = "まる1か月";
+"streakFactQuarter" = "まる3か月";
+"streakFactTwoYears" = "2年";
+"streakFactYear" = "まる1年";
+"weeks" = "週";

--- a/LOGIT/Core/Environment/ko.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/ko.lproj/Localizable.strings
@@ -993,3 +993,12 @@
 "pinAMeasurement" = "측정값 고정";
 "trackMeasurements" = "측정값 추적";
 "unlockWithPro" = "Pro로 잠금 해제";
+
+"currentWeekNumber" = "%d주차";
+"nextMilestone" = "다음 마일스톤";
+"streakFactHalfYear" = "반년";
+"streakFactMonth" = "꼬박 한 달";
+"streakFactQuarter" = "꼬박 한 분기";
+"streakFactTwoYears" = "2년";
+"streakFactYear" = "꼬박 1년";
+"weeks" = "주";

--- a/LOGIT/Core/Environment/pt-BR.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/pt-BR.lproj/Localizable.strings
@@ -993,3 +993,12 @@
 "pinAMeasurement" = "Fixar uma medida";
 "trackMeasurements" = "Acompanhe suas medidas";
 "unlockWithPro" = "Desbloquear com Pro";
+
+"currentWeekNumber" = "Semana %d";
+"nextMilestone" = "Próximo marco";
+"streakFactHalfYear" = "Meio ano";
+"streakFactMonth" = "Um mês inteiro";
+"streakFactQuarter" = "Um trimestre inteiro";
+"streakFactTwoYears" = "Dois anos";
+"streakFactYear" = "Um ano inteiro";
+"weeks" = "Semanas";

--- a/LOGIT/Features/Home/SummaryViewModel.swift
+++ b/LOGIT/Features/Home/SummaryViewModel.swift
@@ -141,4 +141,74 @@ final class SummaryViewModel: ObservableObject {
         }
         return streak
     }
+
+    /// The all-time longest run of consecutive weeks meeting the target — the record the current
+    /// streak is chasing. Walks every week from the first workout to now so empty weeks break the run.
+    nonisolated static func longestWeeklyStreak(workouts: [Workout], target: Int) -> Int {
+        var countsByWeek: [Date: Int] = [:]
+        for workout in workouts where !workout.isEmpty {
+            guard let date = workout.date else { continue }
+            countsByWeek[date.startOfWeek, default: 0] += 1
+        }
+        return longestWeeklyStreak(countsByWeek: countsByWeek, target: target)
+    }
+
+    /// The pure core of the longest-streak calc, keyed by week-start → workout count, so it can be
+    /// unit-tested without a Core Data store. Iterates week-by-week (not just weeks with workouts) so
+    /// an empty week correctly resets the run.
+    nonisolated static func longestWeeklyStreak(countsByWeek: [Date: Int], target: Int, reference: Date = .now) -> Int {
+        guard target > 0, let earliest = countsByWeek.keys.min() else { return 0 }
+        let calendar = Calendar.current
+        var best = 0
+        var run = 0
+        var weekStart = earliest
+        let lastWeek = reference.startOfWeek
+        while weekStart <= lastWeek {
+            if (countsByWeek[weekStart] ?? 0) >= target {
+                run += 1
+                best = max(best, run)
+            } else {
+                run = 0
+            }
+            weekStart = (calendar.date(byAdding: .weekOfYear, value: 1, to: weekStart) ?? weekStart).startOfWeek
+        }
+        return best
+    }
+
+    /// The longest COMPLETED weekly streak that is not the current ongoing run — i.e. the record the
+    /// current streak is chasing, or the one it just surpassed. Excludes the run ending at `reference`.
+    nonisolated static func previousBestWeeklyStreak(workouts: [Workout], target: Int) -> Int {
+        var countsByWeek: [Date: Int] = [:]
+        for workout in workouts where !workout.isEmpty {
+            guard let date = workout.date else { continue }
+            countsByWeek[date.startOfWeek, default: 0] += 1
+        }
+        return previousBestWeeklyStreak(countsByWeek: countsByWeek, target: target)
+    }
+
+    nonisolated static func previousBestWeeklyStreak(countsByWeek: [Date: Int], target: Int, reference: Date = .now) -> Int {
+        guard target > 0, let earliest = countsByWeek.keys.min() else { return 0 }
+        let calendar = Calendar.current
+        var runs: [Int] = []
+        var run = 0
+        var weekStart = earliest
+        let referenceWeekStart = reference.startOfWeek
+        while weekStart <= referenceWeekStart {
+            if (countsByWeek[weekStart] ?? 0) >= target {
+                run += 1
+            } else {
+                if run > 0 { runs.append(run) }
+                run = 0
+            }
+            weekStart = (calendar.date(byAdding: .weekOfYear, value: 1, to: weekStart) ?? weekStart).startOfWeek
+        }
+        if run > 0 { runs.append(run) }
+        // The most recent run (last element) is the current ongoing streak; the record being chased is
+        // the longest of the rest. With no current run, every run counts.
+        let current = weeklyStreak(countsByWeek: countsByWeek, target: target, reference: reference)
+        if current > 0 {
+            return runs.dropLast().max() ?? 0
+        }
+        return runs.max() ?? 0
+    }
 }

--- a/LOGIT/Features/Home/Tiles/WeeklyGoalHeroTile.swift
+++ b/LOGIT/Features/Home/Tiles/WeeklyGoalHeroTile.swift
@@ -8,10 +8,9 @@
 import SwiftUI
 
 /// The always-on weekly-goal hero at the top of the Summary screen — the fix for the dead Monday: it
-/// has something to show even before the first workout of the week. A locale-ordered 7-day check
-/// strip (each day done / today / rest from this week's workouts grouped by calendar day), a
-/// "N workouts to go" footer, and a flame streak pill counting consecutive met weeks. Carried by the
-/// streak so a fresh week still reads as a continuing run. Free.
+/// has something to show even before the first workout of the week. Shows the shared `WeeklyGoalStrip`
+/// (this week's 7 days as muscle-group rings with the weekday letter + the week's completion ring) and,
+/// once a run is going, the streak scoreboard (the goal ahead vs. the current streak). Free.
 struct WeeklyGoalHeroTile: View {
     let workouts: [Workout]
 
@@ -26,107 +25,262 @@ struct WeeklyGoalHeroTile: View {
                 NavigationChevron()
                     .foregroundStyle(.secondary)
             }
-            strip
-            HStack {
-                Text(footerText)
-                    .font(.subheadline.weight(.semibold))
-                    .foregroundStyle(.secondary)
-                Spacer()
-                if streak > 0 {
-                    streakPill
-                }
+            WeeklyGoalStrip(workouts: workouts, target: target)
+            if streak > 0 {
+                StreakScoreboard(current: streak, target: streakGoal.value, targetIsBest: streakGoal.isBest)
+                    .padding(CELL_PADDING - 2)
+                    .secondaryTileStyle()
             }
         }
         .padding(CELL_PADDING)
         .tileStyle()
     }
 
-    // MARK: - Strip
+    private var streak: Int {
+        SummaryViewModel.currentWeeklyStreak(workouts: workouts, target: target)
+    }
 
-    private var strip: some View {
-        HStack(spacing: 6) {
-            ForEach(days) { day in
-                VStack(spacing: 7) {
-                    marker(for: day.state)
-                    Text(day.letter)
-                        .font(.caption2.weight(.semibold))
-                        .foregroundStyle(day.state == .today ? Color.accentColor : .secondary)
-                }
-                .frame(maxWidth: .infinity)
+    private var previousBest: Int {
+        SummaryViewModel.previousBestWeeklyStreak(workouts: workouts, target: target)
+    }
+
+    /// The goal shown in the scoreboard — the next milestone, or the best when it's the nearer goal.
+    private var streakGoal: (value: Int, isBest: Bool) {
+        StreakMilestone.target(current: streak, previousBest: previousBest)
+    }
+}
+
+// MARK: - Weekly goal strip (shared)
+
+/// This week rendered like a calendar week row: each day is a muscle-group occurrence ring with the
+/// weekday letter inside (accent outline for today, plain letter on rest days), followed by the week's
+/// completion ring on the right edge. Shared by `WeeklyGoalHeroTile` (Summary) and `WorkoutGoalScreen`'s
+/// "This week" tile so the two read identically.
+struct WeeklyGoalStrip: View {
+    let workouts: [Workout]
+    let target: Int
+    /// When `true`, the date sits inside each ring (the calendar "This week" tile, so its dates line up
+    /// with the month grid above). When `false` (default) the weekday letter sits inside the ring — the
+    /// standalone Summary hero.
+    var showsDate: Bool = false
+
+    @EnvironmentObject private var muscleGroupService: MuscleGroupService
+    private let calendar = Calendar.current
+
+    var body: some View {
+        // 8 equal columns: the 7 days + the completion ring, each centred in its column, so the leading
+        // and trailing insets match (no flush-right ring) and the columns line up with the calendar grid.
+        HStack(spacing: 0) {
+            ForEach(weekDays, id: \.self) { day in
+                dayCircle(day)
             }
+            completionRing
+                .frame(maxWidth: .infinity)
         }
+    }
+
+    private var weekDays: [Date] {
+        let start = Date.now.startOfWeek
+        return (0 ..< 7).map { calendar.date(byAdding: .day, value: $0, to: start) ?? start }
+    }
+
+    private func dayCircle(_ day: Date) -> some View {
+        let isToday = calendar.isDateInToday(day)
+        let occurrences = muscleGroupService.getMuscleGroupOccurances(in: dayWorkouts(on: day))
+        let hasWorkout = !occurrences.isEmpty
+        let centerLabel = showsDate
+            ? "\(calendar.component(.day, from: day))"
+            : day.formatted(.dateTime.weekday(.narrow))
+        return ZStack {
+            if isToday {
+                Circle()
+                    .strokeBorder(Color.accentColor, lineWidth: 1.7)
+                    .frame(width: 32, height: 32)
+            } else if hasWorkout {
+                MuscleOccurrenceRing(occurrences: occurrences, lineWidth: 4)
+                    .frame(width: 32, height: 32)
+                    .accessibilityHidden(true)
+            }
+            Text(centerLabel)
+                .font(.system(size: 13, weight: (isToday || hasWorkout) ? .bold : .semibold))
+                .foregroundStyle(isToday ? Color.accentColor : (hasWorkout ? Color.primary : Color.secondaryLabel))
+        }
+        .frame(width: 34, height: 34)
+        .frame(maxWidth: .infinity)
     }
 
     @ViewBuilder
-    private func marker(for state: DayMark.State) -> some View {
-        switch state {
-        case .done:
+    private var completionRing: some View {
+        let count = weekWorkoutCount
+        if target > 0, count >= target {
             ZStack {
                 Circle().fill(Color.accentColor)
-                Image(systemName: "checkmark")
-                    .font(.caption2.weight(.bold))
-                    .foregroundStyle(Color.black)
+                Image(systemName: "checkmark").font(.caption.weight(.bold)).foregroundStyle(.black)
             }
-            .frame(width: 26, height: 26)
-        case .today:
+            .frame(width: 34, height: 34)
+        } else if count > 0 {
+            ZStack {
+                CompletionRing(progress: Double(count) / Double(max(target, 1)), lineWidth: 3.5)
+                Text("\(count)").font(.caption2.weight(.bold)).foregroundStyle(Color.accentColor)
+            }
+            .frame(width: 34, height: 34)
+        } else {
             Circle()
-                .strokeBorder(Color.accentColor, lineWidth: 1.6)
-                .frame(width: 26, height: 26)
-        case .rest:
-            Circle()
-                .fill(Color.fill)
-                .frame(width: 26, height: 26)
+                .strokeBorder(Color.fill, lineWidth: 2)
+                .frame(width: 34, height: 34)
         }
     }
 
-    private var streakPill: some View {
-        ProgressIndicatorPill(symbol: "flame.fill", color: .orange) {
-            Text(String(format: NSLocalizedString("weeklyStreakWeeks", comment: ""), streak))
-                .font(.system(.footnote, design: .rounded, weight: .bold))
+    private func dayWorkouts(on day: Date) -> [Workout] {
+        workouts.filter {
+            guard !$0.isEmpty, let d = $0.date else { return false }
+            return calendar.isDate(d, inSameDayAs: day)
         }
     }
 
-    // MARK: - Data
-
-    private struct DayMark: Identifiable {
-        enum State { case done, today, rest }
-        let id: Int
-        let letter: String
-        let state: State
-    }
-
-    private var currentWeekWorkouts: [Workout] {
+    private var weekWorkoutCount: Int {
         let range = Date.now.startOfWeek ... Date.now.endOfWeek
-        return workouts.filter { workout in
-            guard !workout.isEmpty, let date = workout.date else { return false }
-            return range.contains(date)
+        return workouts.filter {
+            guard !$0.isEmpty, let d = $0.date else { return false }
+            return range.contains(d)
+        }.count
+    }
+}
+
+// MARK: - Streak line (shared)
+
+/// A small flame + "N week streak" line shown under the weekly strip once a run is going.
+struct StreakLine: View {
+    let streak: Int
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "flame.fill")
+                .foregroundStyle(Color.accentColor)
+            Text("\(streak)")
+                .font(.subheadline.weight(.bold))
+                .foregroundStyle(Color.accentColor)
+            Text(NSLocalizedString("weekStreakSuffix", comment: ""))
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(.secondary)
+        }
+    }
+}
+
+// MARK: - Streak milestones + scoreboard (shared)
+
+/// The weekly-streak milestone ladder — a month, quarter, half-year, year, two years — shared by the
+/// Summary hero and the Workout Goal screen so the two never disagree on what the next goal is.
+enum StreakMilestone {
+    static let all: [Int] = [4, 12, 26, 52, 104]
+
+    /// The first milestone beyond `current`; once every milestone is passed, keep pulling a year ahead.
+    static func next(after current: Int) -> Int {
+        all.first(where: { $0 > current }) ?? (current + 52)
+    }
+
+    /// A calendar meaning for a milestone ("a full quarter", "a full year"). Empty for off-ladder values.
+    static func fact(for weeks: Int) -> String {
+        switch weeks {
+        case 4: return NSLocalizedString("streakFactMonth", comment: "")
+        case 12: return NSLocalizedString("streakFactQuarter", comment: "")
+        case 26: return NSLocalizedString("streakFactHalfYear", comment: "")
+        case 52: return NSLocalizedString("streakFactYear", comment: "")
+        case 104: return NSLocalizedString("streakFactTwoYears", comment: "")
+        default: return ""
         }
     }
 
-    private var days: [DayMark] {
-        let calendar = Calendar.current
-        let weekStart = Date.now.startOfWeek
-        let workoutDays = Set(currentWeekWorkouts.compactMap(\.date).map { calendar.startOfDay(for: $0) })
-        return (0 ..< 7).map { offset in
-            let day = calendar.date(byAdding: .day, value: offset, to: weekStart) ?? weekStart
-            let hasWorkout = workoutDays.contains(calendar.startOfDay(for: day))
-            let state: DayMark.State = hasWorkout ? .done : (calendar.isDateInToday(day) ? .today : .rest)
-            return DayMark(id: offset, letter: day.formatted(.dateTime.weekday(.narrow)), state: state)
+    /// The goal to chase: the next milestone by default, so there's always a near goal ahead — unless the
+    /// previous best falls between the current streak and that milestone, in which case the best is the
+    /// nearer goal worth beating first.
+    static func target(current: Int, previousBest: Int) -> (value: Int, isBest: Bool) {
+        let next = next(after: current)
+        let bestIsNearer = previousBest > current && previousBest < next
+        return bestIsNearer ? (previousBest, true) : (next, false)
+    }
+}
+
+/// The streak scoreboard: the goal ahead on the leading side — the next milestone (flag) or, when it's
+/// the nearer goal, the personal best (flame), with a ring tracking progress — and the current streak,
+/// the hero, on the trailing side. Shared by the Summary hero (in a secondary tile) and the Workout Goal
+/// screen so the two read identically.
+struct StreakScoreboard: View {
+    let current: Int
+    let target: Int
+    let targetIsBest: Bool
+
+    private var progress: Double { target > 0 ? min(Double(current) / Double(target), 1) : 0 }
+    private var fact: String { targetIsBest ? "" : StreakMilestone.fact(for: target) }
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 12) {
+            HStack(spacing: 11) {
+                ZStack {
+                    CompletionRing(progress: progress, lineWidth: 3)
+                    Image(systemName: targetIsBest ? "flame.fill" : "flag")
+                        .font(.system(size: 13, weight: .bold))
+                        .foregroundStyle(Color.accentColor)
+                }
+                .frame(width: 38, height: 38)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(NSLocalizedString(targetIsBest ? "personalBest" : "nextMilestone", comment: ""))
+                        .font(.system(size: 10, weight: .heavy))
+                        .foregroundStyle(Color.accentColor)
+                    UnitView(value: "\(target)", unit: Self.weeksUnit(target), configuration: .normal, unitColor: Color.secondaryLabel)
+                    if !fact.isEmpty {
+                        Text(fact)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+            Spacer(minLength: 12)
+            VStack(alignment: .trailing, spacing: 2) {
+                Text(NSLocalizedString("current", comment: ""))
+                    .font(.system(size: 10, weight: .heavy))
+                    .foregroundStyle(.secondary)
+                UnitView(value: "\(current)", unit: Self.weeksUnit(current), configuration: .large, unitColor: Color.secondaryLabel)
+                    .foregroundStyle(Color.accentColor)
+            }
         }
     }
 
-    private var remaining: Int { max(0, target - currentWeekWorkouts.count) }
+    static func weeksUnit(_ n: Int) -> String {
+        NSLocalizedString(n == 1 ? "week" : "weeks", comment: "")
+    }
+}
 
-    private var footerText: String {
-        switch remaining {
-        case 0: return NSLocalizedString("weeklyGoalReached", comment: "")
-        case 1: return NSLocalizedString("weeklyGoalToGoOne", comment: "")
-        default: return String(format: NSLocalizedString("weeklyGoalToGoMany", comment: ""), remaining)
+// MARK: - Muscle occurrence ring (shared)
+
+/// A thin ring split into arcs — one per muscle group trained that day, each arc sized by that group's
+/// share of the day's sets (via `getMuscleGroupOccurances`). The centre stays transparent so the day
+/// number / weekday letter reads on whatever tile sits behind it.
+struct MuscleOccurrenceRing: View {
+    let occurrences: [(MuscleGroup, Int)]
+    var lineWidth: CGFloat = 4
+
+    var body: some View {
+        let total = max(occurrences.reduce(0) { $0 + $1.1 }, 1)
+        return ZStack {
+            ForEach(Array(arcs(total: total).enumerated()), id: \.offset) { _, arc in
+                Circle()
+                    .trim(from: arc.start, to: arc.end)
+                    .stroke(arc.color, style: StrokeStyle(lineWidth: lineWidth, lineCap: .butt))
+                    .rotationEffect(.degrees(-90))
+            }
         }
     }
 
-    private var streak: Int {
-        SummaryViewModel.currentWeeklyStreak(workouts: workouts, target: target)
+    private func arcs(total: Int) -> [(start: CGFloat, end: CGFloat, color: Color)] {
+        var result: [(start: CGFloat, end: CGFloat, color: Color)] = []
+        var cursor: CGFloat = 0
+        for (group, count) in occurrences {
+            let end = cursor + CGFloat(count) / CGFloat(total)
+            result.append((start: cursor, end: end, color: group.color))
+            cursor = end
+        }
+        return result
     }
 }
 

--- a/LOGIT/Features/Home/WorkoutGoalScreen.swift
+++ b/LOGIT/Features/Home/WorkoutGoalScreen.swift
@@ -7,10 +7,13 @@
 
 import SwiftUI
 
-/// The rich weekly-goal detail (`goal-screen-v2.html`): a goal-ring + streak hero, a "This Year" band
-/// of 12 monthly completion rings, and a muscle-coloured month calendar where each workout day is
-/// tinted by that day's dominant muscle group, with a per-week completion ring on the right edge.
-/// Reached from the Summary's Weekly Goal hero. All rings are the shared `CompletionRing`.
+/// The weekly-goal detail screen, reached from the Summary's Weekly Goal hero. Three stacked,
+/// self-labeling tiles — no hero, no section headers:
+///  1. a muscle-coloured month **calendar** where each workout day is an occurrence ring (arcs sized
+///     by that day's muscle-group set counts) and the current week is lifted into a highlighted tile
+///     carrying its progress;
+///  2. a **streak comparison** — the current weekly streak racing toward the all-time record;
+///  3. a year-navigable **52-week strip**, one cell per week (filled = on target), with prev/next year.
 struct WorkoutGoalScreen: View {
     let workouts: [Workout]
 
@@ -18,15 +21,17 @@ struct WorkoutGoalScreen: View {
     @EnvironmentObject private var muscleGroupService: MuscleGroupService
 
     @State private var displayedMonth: Date = .now.startOfMonth
+    @State private var displayedYear: Int = Calendar.current.component(.year, from: .now)
+    @State private var isShowingChangeGoalScreen = false
 
     private let calendar = Calendar.current
 
     var body: some View {
         ScrollView {
             VStack(spacing: SECTION_SPACING) {
-                hero
-                yearSection
-                monthSection
+                calendarTile
+                streakTile
+                yearTile
             }
             .padding(.horizontal)
             .padding(.top)
@@ -38,159 +43,22 @@ struct WorkoutGoalScreen: View {
                 Text(NSLocalizedString("workoutGoal", comment: ""))
                     .font(.headline)
             }
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    isShowingChangeGoalScreen = true
+                } label: {
+                    Image(systemName: "plusminus.circle")
+                }
+            }
+        }
+        .sheet(isPresented: $isShowingChangeGoalScreen) {
+            NavigationStack {
+                ChangeWeeklyWorkoutGoalScreen()
+            }
         }
     }
 
-    // MARK: - Hero
-
-    private var hero: some View {
-        let count = currentWeekCount
-        let progress = target > 0 ? min(Double(count) / Double(target), 1) : 0
-        let streak = SummaryViewModel.currentWeeklyStreak(workouts: workouts, target: target)
-        let remaining = max(0, target - count)
-        return HStack(spacing: 18) {
-            CompletionRing(progress: progress, lineWidth: 9) {
-                HStack(alignment: .lastTextBaseline, spacing: 1) {
-                    Text("\(count)")
-                        .font(.system(size: 30, weight: .bold))
-                        .foregroundStyle(Color.accentColor)
-                    Text("/\(max(target, 0))")
-                        .font(.subheadline.weight(.semibold))
-                        .foregroundStyle(.secondary)
-                }
-            }
-            .frame(width: 88, height: 88)
-            VStack(alignment: .leading, spacing: 7) {
-                if streak > 0 {
-                    HStack(spacing: 6) {
-                        Image(systemName: "flame.fill")
-                            .foregroundStyle(.orange)
-                        Text("\(streak)")
-                            .font(.title2.weight(.bold))
-                            .foregroundStyle(Color.accentColor)
-                        Text(NSLocalizedString("weekStreakSuffix", comment: ""))
-                            .font(.subheadline.weight(.semibold))
-                            .foregroundStyle(.secondary)
-                    }
-                }
-                Text(remaining == 0
-                    ? NSLocalizedString("weeklyGoalReached", comment: "")
-                    : (remaining == 1
-                        ? NSLocalizedString("weeklyGoalToGoOne", comment: "")
-                        : String(format: NSLocalizedString("weeklyGoalToGoMany", comment: ""), remaining)))
-                    .font(.subheadline.weight(.bold))
-            }
-            Spacer()
-        }
-        .padding(16)
-        .tileStyle()
-    }
-
-    // MARK: - Year
-
-    private var yearSection: some View {
-        let counts = weeklyCounts(in: Date.now.startOfYear ... Date.now.endOfYear)
-        let currentMonth = calendar.component(.month, from: .now)
-        let year = calendar.component(.year, from: .now)
-        var totalOnTarget = 0
-        var totalWeeks = 0
-        var best = 0
-        var run = 0
-        let orderedWeekStarts = counts.keys.sorted()
-        for start in orderedWeekStarts where start <= Date.now {
-            totalWeeks += 1
-            if (counts[start] ?? 0) >= target, target > 0 {
-                totalOnTarget += 1
-                run += 1
-                best = max(best, run)
-            } else {
-                run = 0
-            }
-        }
-        return VStack(alignment: .leading, spacing: SECTION_HEADER_SPACING) {
-            HStack {
-                Text(NSLocalizedString("thisYear", comment: ""))
-                    .sectionHeaderStyle2()
-                Spacer()
-                Text(verbatim: "\(year)")
-                    .font(.subheadline.weight(.semibold))
-                    .foregroundStyle(.secondary)
-            }
-            VStack(spacing: 16) {
-                LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 4), count: 6), spacing: 14) {
-                    ForEach(1 ... 12, id: \.self) { month in
-                        monthRing(month: month, year: year, currentMonth: currentMonth, counts: counts)
-                    }
-                }
-                HStack {
-                    Text(String(format: NSLocalizedString("yearWeeksOnTarget", comment: ""), totalOnTarget, totalWeeks))
-                    Spacer()
-                    Text(String(format: NSLocalizedString("bestStreakLabel", comment: ""), best))
-                }
-                .font(.caption.weight(.semibold))
-                .foregroundStyle(.secondary)
-                .padding(.top, 4)
-                .overlay(alignment: .top) {
-                    Rectangle().fill(Color.white.opacity(0.07)).frame(height: 0.5)
-                }
-            }
-            .padding(CELL_PADDING)
-            .tileStyle()
-        }
-    }
-
-    private func monthRing(month: Int, year: Int, currentMonth: Int, counts: [Date: Int]) -> some View {
-        let monthStart = firstOfMonth(year: year, month: month)
-        let weekStarts = self.weekStarts(in: monthStart)
-        let onTarget = weekStarts.filter { (counts[$0] ?? 0) >= target && target > 0 }.count
-        let progress = weekStarts.isEmpty ? 0 : Double(onTarget) / Double(weekStarts.count)
-        let isFuture = month > currentMonth
-        let isCurrent = month == currentMonth
-        let complete = progress >= 1 && !weekStarts.isEmpty
-        return VStack(spacing: 7) {
-            ZStack {
-                CompletionRing(
-                    progress: isFuture ? 0 : progress,
-                    lineWidth: 4,
-                    trackColor: isFuture ? Color.secondaryBackground : Color.fill
-                )
-                .frame(width: 36, height: 36)
-                .overlay {
-                    if isCurrent {
-                        Circle().strokeBorder(Color.accentColor, lineWidth: 2)
-                    }
-                }
-                if complete {
-                    Image(systemName: "checkmark")
-                        .font(.caption2.weight(.bold))
-                        .foregroundStyle(Color.accentColor)
-                }
-            }
-            Text(monthAbbreviation(month))
-                .font(.system(size: 10, weight: .semibold))
-                .foregroundStyle(isCurrent ? Color.accentColor : .secondary)
-        }
-    }
-
-    // MARK: - Month calendar
-
-    private var monthSection: some View {
-        let monthWorkouts = workouts.filter {
-            guard !$0.isEmpty, let d = $0.date else { return false }
-            return d >= displayedMonth.startOfMonth && d <= displayedMonth.endOfMonth
-        }
-        return VStack(alignment: .leading, spacing: SECTION_HEADER_SPACING) {
-            HStack {
-                Text(displayedMonth.formatted(.dateTime.month(.wide)))
-                    .sectionHeaderStyle2()
-                Spacer()
-                Text(String(format: NSLocalizedString("monthWorkoutsCount", comment: ""), monthWorkouts.count))
-                    .font(.subheadline.weight(.semibold))
-                    .foregroundStyle(.secondary)
-            }
-            calendarTile
-        }
-    }
+    // MARK: - Calendar
 
     private var calendarTile: some View {
         VStack(spacing: 12) {
@@ -204,57 +72,98 @@ struct WorkoutGoalScreen: View {
                     .disabled(displayedMonth.startOfMonth >= Date.now.startOfMonth)
             }
             .foregroundStyle(.secondary)
-            HStack(spacing: 12) {
-                HStack(spacing: 0) {
-                    ForEach(weekdaySymbols, id: \.self) { symbol in
-                        Text(symbol)
-                            .font(.caption2.weight(.bold))
-                            .foregroundStyle(.tertiary)
-                            .frame(maxWidth: .infinity)
-                    }
+            .padding(.horizontal, CELL_PADDING)
+            HStack(spacing: 0) {
+                ForEach(weekdaySymbols, id: \.self) { symbol in
+                    Text(symbol)
+                        .font(.caption2.weight(.bold))
+                        .foregroundStyle(.tertiary)
+                        .frame(maxWidth: .infinity)
                 }
                 Image(systemName: "target")
                     .font(.caption)
                     .foregroundStyle(.tertiary)
                     .frame(width: 34)
+                    .frame(maxWidth: .infinity)
             }
+            .padding(.horizontal, CELL_PADDING)
             ForEach(weeksOfMonth, id: \.self) { week in
-                HStack(spacing: 12) {
-                    HStack(spacing: 0) {
-                        ForEach(week, id: \.self) { day in
-                            dayCell(day)
-                        }
-                    }
-                    weekRing(for: week)
-                }
+                weekRowView(week)
             }
         }
-        .padding(CELL_PADDING)
+        .padding(.top, CELL_PADDING)
+        .padding(.bottom, CELL_PADDING / 2)
         .tileStyle()
+    }
+
+    @ViewBuilder
+    private func weekRowView(_ week: [Date]) -> some View {
+        if isCurrentWeek(week) {
+            currentWeekRow(week)
+        } else {
+            // 8 equal columns (7 days + the completion ring), each centred in its own column, so the
+            // ring isn't flush-right and the layout matches the shared `WeeklyGoalStrip` below.
+            HStack(spacing: 0) {
+                ForEach(week, id: \.self) { day in
+                    dayCell(day)
+                }
+                weekRing(for: week)
+                    .frame(maxWidth: .infinity)
+            }
+            .padding(.horizontal, CELL_PADDING)
+        }
+    }
+
+    /// The current week, lifted into a secondary tile that mirrors the Summary screen's
+    /// `WeeklyGoalHeroTile` exactly — the shared `WeeklyGoalStrip` (muscle-ring days with weekday letters
+    /// + the week's completion ring) and a `StreakLine`. Inset CELL_PADDING/2, like a set cell sits
+    /// inside a set-group cell.
+    private func currentWeekRow(_ week: [Date]) -> some View {
+        let streak = SummaryViewModel.currentWeeklyStreak(workouts: workouts, target: target)
+        return VStack(alignment: .leading, spacing: 14) {
+            Text(NSLocalizedString("thisWeek", comment: ""))
+                .tileHeaderStyle()
+                .frame(maxWidth: .infinity, alignment: .leading)
+            WeeklyGoalStrip(workouts: workouts, target: target, showsDate: true)
+            if streak > 0 {
+                StreakLine(streak: streak)
+            }
+        }
+        // Horizontal stays CELL_PADDING/2 so the dates line up with the month grid; vertical gets a
+        // touch more breathing room.
+        .padding(.vertical, CELL_PADDING * 3 / 4)
+        .padding(.horizontal, CELL_PADDING / 2)
+        .secondaryTileStyle()
+        .padding(.horizontal, CELL_PADDING / 2)
     }
 
     private func dayCell(_ day: Date) -> some View {
         let inMonth = calendar.isDate(day, equalTo: displayedMonth, toGranularity: .month)
         let isToday = calendar.isDateInToday(day)
         let isFuture = day > Date.now && !isToday
-        let muscleColor = dominantMuscleColor(on: day)
-        return Text("\(calendar.component(.day, from: day))")
-            .font(.system(size: 13, weight: muscleColor != nil ? .bold : .semibold))
-            .foregroundStyle(dayForeground(inMonth: inMonth, isToday: isToday, isFuture: isFuture, tinted: muscleColor != nil))
-            .frame(width: 34, height: 34)
-            .background {
-                if let muscleColor {
-                    Circle().fill(muscleColor)
-                } else if isToday {
-                    Circle().strokeBorder(Color.accentColor, lineWidth: 1.6)
-                }
+        let occurrences = muscleOccurrences(on: day)
+        let hasWorkout = !occurrences.isEmpty
+        return ZStack {
+            if isToday {
+                Circle()
+                    .strokeBorder(Color.accentColor, lineWidth: 1.7)
+                    .frame(width: 32, height: 32)
+            } else if hasWorkout {
+                MuscleOccurrenceRing(occurrences: occurrences, lineWidth: 4)
+                    .frame(width: 32, height: 32)
+                    .accessibilityHidden(true)
             }
-            .frame(maxWidth: .infinity)
+            Text("\(calendar.component(.day, from: day))")
+                .font(.system(size: 13, weight: (isToday || hasWorkout) ? .bold : .semibold))
+                .foregroundStyle(dayForeground(inMonth: inMonth, isToday: isToday, isFuture: isFuture, hasWorkout: hasWorkout))
+        }
+        .frame(width: 34, height: 34)
+        .frame(maxWidth: .infinity)
     }
 
-    private func dayForeground(inMonth: Bool, isToday: Bool, isFuture: Bool, tinted: Bool) -> Color {
-        if tinted { return .black }
+    private func dayForeground(inMonth: Bool, isToday: Bool, isFuture: Bool, hasWorkout: Bool) -> Color {
         if isToday { return .accentColor }
+        if hasWorkout { return .primary }
         if !inMonth { return Color.white.opacity(0.18) }
         if isFuture { return .tertiaryLabel }
         return .secondaryLabel
@@ -284,6 +193,210 @@ struct WorkoutGoalScreen: View {
         }
     }
 
+    // MARK: - Streak
+
+    private var streakTile: some View {
+        let current = SummaryViewModel.currentWeeklyStreak(workouts: workouts, target: target)
+        let previousBest = SummaryViewModel.previousBestWeeklyStreak(workouts: workouts, target: target)
+        let allTimeBest = max(previousBest, current)
+        // Chase the next milestone by default (always a near goal ahead); the best steps in only when it's
+        // the nearer goal — see StreakMilestone.target. A bigger past record beyond the milestone keeps its
+        // own row below instead, so it's never lost.
+        let goal = StreakMilestone.target(current: current, previousBest: previousBest)
+        return VStack(alignment: .leading, spacing: 12) {
+            StreakScoreboard(current: current, target: goal.value, targetIsBest: goal.isBest)
+            milestoneList(current: current, best: allTimeBest, showBest: allTimeBest > current && !goal.isBest)
+        }
+        .padding(CELL_PADDING)
+        .tileStyle()
+    }
+
+    /// The next milestone on top, then the milestones already reached (newest first) — each in its own
+    /// secondary tile with a flag, the date it was (or will be) hit, and a calendar-meaning fact.
+    private func milestoneList(current: Int, best: Int, showBest: Bool) -> some View {
+        let achieved = StreakMilestone.all.filter { $0 <= current }.sorted(by: >)
+        return VStack(spacing: 8) {
+            if showBest, best > 0 {
+                personalBestTile(best)
+            }
+            ForEach(achieved, id: \.self) { milestone in
+                achievedMilestoneTile(milestone: milestone, current: current)
+            }
+        }
+    }
+
+    /// The all-time best streak, kept in its own row with the flame that marks a record throughout the
+    /// app. The comparison above now chases milestones rather than the record, so this is where the best
+    /// stays visible — shown unless the best is already the goal being chased in the scoreboard.
+    private func personalBestTile(_ best: Int) -> some View {
+        HStack(spacing: 12) {
+            ZStack {
+                Circle().fill(Color.accentColor.opacity(0.18))
+                Image(systemName: "flame.fill")
+                    .font(.system(size: 13, weight: .bold))
+                    .foregroundStyle(Color.accentColor)
+            }
+            .frame(width: 30, height: 30)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(NSLocalizedString("personalBest", comment: ""))
+                    .font(.system(size: 10, weight: .heavy))
+                    .foregroundStyle(Color.accentColor)
+                UnitView(value: "\(best)", unit: weeksUnit(best), configuration: .small, unitColor: Color.secondaryLabel)
+            }
+            Spacer(minLength: 8)
+        }
+        .padding(CELL_PADDING - 2)
+        .secondaryTileStyle()
+    }
+
+    private func achievedMilestoneTile(milestone: Int, current: Int) -> some View {
+        let fact = StreakMilestone.fact(for: milestone)
+        return HStack(spacing: 12) {
+            ZStack {
+                Circle().fill(Color.accentColor)
+                Image(systemName: "flag.fill")
+                    .font(.system(size: 12, weight: .bold))
+                    .foregroundStyle(.black)
+            }
+            .frame(width: 30, height: 30)
+            VStack(alignment: .leading, spacing: 1) {
+                UnitView(value: "\(milestone)", unit: weeksUnit(milestone), configuration: .small, unitColor: Color.secondaryLabel)
+                if !fact.isEmpty {
+                    Text(fact)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            Spacer(minLength: 8)
+            Text(shortDate(milestoneWeek(offset: milestone - current)))
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(.secondary)
+        }
+        .padding(CELL_PADDING - 2)
+        .secondaryTileStyle()
+    }
+
+    private func milestoneWeek(offset: Int) -> Date {
+        calendar.date(byAdding: .weekOfYear, value: offset, to: Date.now.startOfWeek) ?? .now
+    }
+
+    private func shortDate(_ date: Date) -> String {
+        let sameYear = calendar.component(.year, from: date) == calendar.component(.year, from: .now)
+        return sameYear
+            ? date.formatted(.dateTime.month(.abbreviated).day())
+            : date.formatted(.dateTime.month(.abbreviated).day().year())
+    }
+
+    private func weeksUnit(_ n: Int) -> String {
+        NSLocalizedString(n == 1 ? "week" : "weeks", comment: "")
+    }
+
+    // MARK: - Year strip
+
+    private var yearTile: some View {
+        let weeks = weekStartsInYear(displayedYear)
+        let counts = weeklyCounts(in: yearRange(displayedYear))
+        let now = Date.now
+        let nowYear = calendar.component(.year, from: now)
+        // Percentage is over every week of the year that has already elapsed — future weeks
+        // haven't happened yet, so they're excluded from both the count and the denominator.
+        var onTarget = 0
+        var elapsedWeeks = 0
+        for ws in weeks where ws <= now {
+            elapsedWeeks += 1
+            if target > 0, (counts[ws] ?? 0) >= target { onTarget += 1 }
+        }
+        let percent = elapsedWeeks > 0 ? Int((Double(onTarget) / Double(elapsedWeeks) * 100).rounded()) : 0
+        return VStack(spacing: 14) {
+            HStack {
+                Button { displayedYear -= 1 } label: { Image(systemName: "chevron.left") }
+                    .disabled(displayedYear <= earliestYear)
+                Spacer()
+                Text(verbatim: "\(displayedYear)")
+                    .font(.headline)
+                Spacer()
+                Button { displayedYear += 1 } label: { Image(systemName: "chevron.right") }
+                    .disabled(displayedYear >= nowYear)
+            }
+            .foregroundStyle(.secondary)
+            VStack(spacing: 5) {
+                HStack(spacing: 3) {
+                    ForEach(weeks, id: \.self) { ws in
+                        yearCell(ws, now: now, counts: counts)
+                    }
+                }
+                if let currentIndex = currentWeekIndex(in: weeks, now: now) {
+                    weekNumberRow(
+                        weeks: weeks,
+                        currentIndex: currentIndex,
+                        weekNumber: calendar.component(.weekOfYear, from: now)
+                    )
+                }
+            }
+            HStack(spacing: 0) {
+                ForEach(Array(calendar.veryShortMonthSymbols.enumerated()), id: \.offset) { _, symbol in
+                    Text(symbol)
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundStyle(.tertiary)
+                        .frame(maxWidth: .infinity)
+                }
+            }
+            HStack {
+                Text(String(format: NSLocalizedString("yearWeeksOnTarget", comment: ""), onTarget, elapsedWeeks))
+                Spacer()
+                Text(verbatim: "\(percent)%")
+            }
+            .font(.caption.weight(.semibold))
+            .foregroundStyle(.secondary)
+            .padding(.top, 2)
+            .overlay(alignment: .top) {
+                Rectangle().fill(Color.white.opacity(0.07)).frame(height: 0.5)
+            }
+        }
+        .padding(CELL_PADDING)
+        .tileStyle()
+    }
+
+    private func yearCell(_ ws: Date, now: Date, counts: [Date: Int]) -> some View {
+        // Three clearly separated tiers: accent (target met) · solid gray (an elapsed week that
+        // missed) · faint ghost (a future week that hasn't happened yet).
+        let isFuture = ws > now
+        let met = !isFuture && target > 0 && (counts[ws] ?? 0) >= target
+        let fill: Color = met
+            ? Color.accentColor
+            : (isFuture ? Color.white.opacity(0.08) : Color.white.opacity(0.3))
+        return RoundedRectangle(cornerRadius: 2)
+            .fill(fill)
+            .frame(height: 22)
+            .frame(maxWidth: .infinity)
+    }
+
+    /// Index of the week cell containing today, or `nil` when the displayed year isn't the current one.
+    private func currentWeekIndex(in weeks: [Date], now: Date) -> Int? {
+        weeks.firstIndex { calendar.isDate($0, equalTo: now, toGranularity: .weekOfYear) }
+    }
+
+    /// A thin row beneath the strip carrying a white "Week N" label aligned under the current-week cell.
+    /// Mirrors the strip's equal-width columns so the label sits directly under its tick; the text is
+    /// drawn in a zero-impact overlay so a long label can overhang neighbouring (empty) columns.
+    private func weekNumberRow(weeks: [Date], currentIndex: Int, weekNumber: Int) -> some View {
+        HStack(spacing: 3) {
+            ForEach(Array(weeks.enumerated()), id: \.offset) { index, _ in
+                Color.clear
+                    .frame(height: 13)
+                    .frame(maxWidth: .infinity)
+                    .overlay {
+                        if index == currentIndex {
+                            Text(String(format: NSLocalizedString("currentWeekNumber", comment: ""), weekNumber))
+                                .font(.system(size: 11, weight: .bold))
+                                .foregroundStyle(.white)
+                                .fixedSize()
+                        }
+                    }
+            }
+        }
+    }
+
     // MARK: - Data
 
     private var currentWeekCount: Int {
@@ -310,13 +423,17 @@ struct WorkoutGoalScreen: View {
         }.count
     }
 
-    private func dominantMuscleColor(on day: Date) -> Color? {
+    private func muscleOccurrences(on day: Date) -> [(MuscleGroup, Int)] {
         let dayWorkouts = workouts.filter {
             guard !$0.isEmpty, let d = $0.date else { return false }
             return calendar.isDate(d, inSameDayAs: day)
         }
-        guard !dayWorkouts.isEmpty else { return nil }
-        return muscleGroupService.getMuscleGroupOccurances(in: dayWorkouts).first?.0.color
+        guard !dayWorkouts.isEmpty else { return [] }
+        return muscleGroupService.getMuscleGroupOccurances(in: dayWorkouts)
+    }
+
+    private func isCurrentWeek(_ week: [Date]) -> Bool {
+        week.contains { calendar.isDateInToday($0) }
     }
 
     private var weeksOfMonth: [[Date]] {
@@ -331,27 +448,30 @@ struct WorkoutGoalScreen: View {
         return weeks
     }
 
-    private func weekStarts(in monthStart: Date) -> [Date] {
-        let days = calendar.range(of: .day, in: .month, for: monthStart)?.count ?? 30
-        var starts = Set<Date>()
-        for offset in 0 ..< days {
-            let date = calendar.date(byAdding: .day, value: offset, to: monthStart) ?? monthStart
-            starts.insert(date.startOfWeek)
+    /// Ordered week-start dates belonging to the given calendar year (52 or 53 of them).
+    private func weekStartsInYear(_ year: Int) -> [Date] {
+        guard let yearStart = calendar.date(from: DateComponents(year: year)),
+              let nextYearStart = calendar.date(from: DateComponents(year: year + 1)) else { return [] }
+        var weeks: [Date] = []
+        var cursor = yearStart.startOfWeek
+        while cursor < nextYearStart {
+            weeks.append(cursor)
+            cursor = (calendar.date(byAdding: .weekOfYear, value: 1, to: cursor) ?? cursor).startOfWeek
         }
-        return starts.sorted()
+        return weeks
     }
 
-    private func firstOfMonth(year: Int, month: Int) -> Date {
-        var components = DateComponents()
-        components.year = year
-        components.month = month
-        components.day = 1
-        return (calendar.date(from: components) ?? .now).startOfMonth
+    private func yearRange(_ year: Int) -> ClosedRange<Date> {
+        let start = (calendar.date(from: DateComponents(year: year)) ?? .now).startOfWeek
+        let nextStart = calendar.date(from: DateComponents(year: year + 1)) ?? .now
+        let end = calendar.date(byAdding: .second, value: -1, to: nextStart) ?? nextStart
+        return start ... max(end, start)
     }
 
-    private func monthAbbreviation(_ month: Int) -> String {
-        let symbols = calendar.shortMonthSymbols
-        return month >= 1 && month <= symbols.count ? symbols[month - 1] : "\(month)"
+    private var earliestYear: Int {
+        let nowYear = calendar.component(.year, from: .now)
+        guard let earliest = workouts.compactMap({ $0.date }).min() else { return nowYear }
+        return min(calendar.component(.year, from: earliest), nowYear)
     }
 
     private var weekdaySymbols: [String] {


### PR DESCRIPTION
## What

Lands the Weekly Goal experience: the calendar-first **goal detail screen** and the **Summary weekly-goal tile**, sharing one streak scoreboard.

### Goal detail screen (`WorkoutGoalScreen`)
- **Calendar** — a muscle-occurrence-ring month grid; the current week is lifted into a highlighted "This week" tile.
- **Streak scoreboard** — the goal ahead on the left (the next milestone, or the **personal best** when it falls before that milestone, so there's always a near goal), the current streak on the right. Beneath it, a Personal Best row (when the best is a record beyond the milestone) and the achieved milestones.
- **Year strip** — a year-navigable 52-week on-target grid.

### Summary weekly-goal tile (`WeeklyGoalHeroTile`)
- The shared weekly-goal day strip plus the **same `StreakScoreboard`** in a nested secondary tile, so Summary and detail can't drift.

### Streak model (`SummaryViewModel`)
- Adds `longestWeeklyStreak` and `previousBestWeeklyStreak`. Target selection and the scoreboard/milestone helpers live in a shared `StreakMilestone` type.

### Localization
- Adds `nextMilestone`, `streakFact{Month,Quarter,HalfYear,Year,TwoYears}`, `weeks`, `currentWeekNumber` across all 8 locales.

## Test plan
- [x] Builds clean (0 warnings) off `main` in an isolated worktree.
- [x] Summary tile and detail scoreboard render the same goal for the same data (verified across "next milestone" and "best is nearer" states).
- [x] Streak count is ≤ the year strip's on-target week count (they measure the current run vs. all met weeks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
