### PR TITLE
Polish the Weekly Goal streak UI

### DIFF
--- a/LOGIT/Core/Environment/de.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/de.lproj/Localizable.strings
@@ -998,3 +998,4 @@
 "streakFactTwoYears" = "Zwei Jahre";
 "streakFactYear" = "Ein ganzes Jahr";
 "weeks" = "Wochen";
+"streak" = "Streak";

--- a/LOGIT/Core/Environment/en.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/en.lproj/Localizable.strings
@@ -1002,3 +1002,4 @@
 "streakFactTwoYears" = "Two years";
 "streakFactYear" = "A full year";
 "weeks" = "Weeks";
+"streak" = "Streak";

--- a/LOGIT/Core/Environment/es.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/es.lproj/Localizable.strings
@@ -1002,3 +1002,4 @@
 "streakFactTwoYears" = "Dos años";
 "streakFactYear" = "Un año completo";
 "weeks" = "Semanas";
+"streak" = "Racha";

--- a/LOGIT/Core/Environment/fr.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/fr.lproj/Localizable.strings
@@ -1002,3 +1002,4 @@
 "streakFactTwoYears" = "Deux ans";
 "streakFactYear" = "Une année complète";
 "weeks" = "Semaines";
+"streak" = "Série";

--- a/LOGIT/Core/Environment/it.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/it.lproj/Localizable.strings
@@ -1002,3 +1002,4 @@
 "streakFactTwoYears" = "Due anni";
 "streakFactYear" = "Un anno intero";
 "weeks" = "Settimane";
+"streak" = "Serie";

--- a/LOGIT/Core/Environment/ja.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/ja.lproj/Localizable.strings
@@ -1002,3 +1002,4 @@
 "streakFactTwoYears" = "2年";
 "streakFactYear" = "まる1年";
 "weeks" = "週";
+"streak" = "連続記録";

--- a/LOGIT/Core/Environment/ko.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/ko.lproj/Localizable.strings
@@ -1002,3 +1002,4 @@
 "streakFactTwoYears" = "2년";
 "streakFactYear" = "꼬박 1년";
 "weeks" = "주";
+"streak" = "연속 기록";

--- a/LOGIT/Core/Environment/pt-BR.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/pt-BR.lproj/Localizable.strings
@@ -1002,3 +1002,4 @@
 "streakFactTwoYears" = "Dois anos";
 "streakFactYear" = "Um ano inteiro";
 "weeks" = "Semanas";
+"streak" = "Sequência";

--- a/LOGIT/Features/Home/Tiles/WeeklyGoalHeroTile.swift
+++ b/LOGIT/Features/Home/Tiles/WeeklyGoalHeroTile.swift
@@ -10,7 +10,8 @@ import SwiftUI
 /// The always-on weekly-goal hero at the top of the Summary screen — the fix for the dead Monday: it
 /// has something to show even before the first workout of the week. Shows the shared `WeeklyGoalStrip`
 /// (this week's 7 days as muscle-group rings with the weekday letter + the week's completion ring) and,
-/// once a run is going, the streak scoreboard (the goal ahead vs. the current streak). Free.
+/// once a run is going, a minimal flame streak line. Free. The full milestone scoreboard lives on the
+/// Workout Goal detail screen this tile taps into — the Summary stays a glance.
 struct WeeklyGoalHeroTile: View {
     let workouts: [Workout]
 
@@ -27,9 +28,7 @@ struct WeeklyGoalHeroTile: View {
             }
             WeeklyGoalStrip(workouts: workouts, target: target)
             if streak > 0 {
-                StreakScoreboard(current: streak, target: streakGoal.value, targetIsBest: streakGoal.isBest)
-                    .padding(CELL_PADDING - 2)
-                    .secondaryTileStyle()
+                StreakLine(streak: streak)
             }
         }
         .padding(CELL_PADDING)
@@ -38,15 +37,6 @@ struct WeeklyGoalHeroTile: View {
 
     private var streak: Int {
         SummaryViewModel.currentWeeklyStreak(workouts: workouts, target: target)
-    }
-
-    private var previousBest: Int {
-        SummaryViewModel.previousBestWeeklyStreak(workouts: workouts, target: target)
-    }
-
-    /// The goal shown in the scoreboard — the next milestone, or the best when it's the nearer goal.
-    private var streakGoal: (value: Int, isBest: Bool) {
-        StreakMilestone.target(current: streak, previousBest: previousBest)
     }
 }
 

--- a/LOGIT/Features/Home/WorkoutGoalScreen.swift
+++ b/LOGIT/Features/Home/WorkoutGoalScreen.swift
@@ -123,6 +123,7 @@ struct WorkoutGoalScreen: View {
         return VStack(alignment: .leading, spacing: 14) {
             Text(NSLocalizedString("thisWeek", comment: ""))
                 .tileHeaderStyle()
+                .padding(.leading, CELL_PADDING / 2)
                 .frame(maxWidth: .infinity, alignment: .leading)
             WeeklyGoalStrip(workouts: workouts, target: target, showsDate: true)
             if streak > 0 {
@@ -203,9 +204,17 @@ struct WorkoutGoalScreen: View {
         // the nearer goal — see StreakMilestone.target. A bigger past record beyond the milestone keeps its
         // own row below instead, so it's never lost.
         let goal = StreakMilestone.target(current: current, previousBest: previousBest)
+        let showBest = allTimeBest > current && !goal.isBest
+        // Drop the milestone list (and the VStack spacing above it) when there's nothing to show — no
+        // achieved milestones and no personal-best row — so the tile isn't bottom-heavy.
+        let hasMilestones = showBest || StreakMilestone.all.contains { $0 <= current }
         return VStack(alignment: .leading, spacing: 12) {
+            Text(NSLocalizedString("streak", comment: ""))
+                .tileHeaderStyle()
             StreakScoreboard(current: current, target: goal.value, targetIsBest: goal.isBest)
-            milestoneList(current: current, best: allTimeBest, showBest: allTimeBest > current && !goal.isBest)
+            if hasMilestones {
+                milestoneList(current: current, best: allTimeBest, showBest: showBest)
+            }
         }
         .padding(CELL_PADDING)
         .tileStyle()


### PR DESCRIPTION
Follow-up polish to the Weekly Goal experience (#45), from local testing.

- **"Streak" header** on the detail streak tile — it previously showed only "Personal Best / Current" with no indication it was about your streak.
- **"This Week" leading padding** — the label was flush against the tight day-column inset; now indented like the Summary's equivalent header.
- **Streak tile bottom padding** — when there are no milestones (e.g. `current = 0`), the milestone list rendered empty but still added a 12pt gap; now dropped entirely so the tile isn't bottom-heavy.
- **Summary tile → just the streak** — the milestone scoreboard was overloading the Summary dashboard tile; reverted it to the minimal streak line. The full scoreboard stays on the detail screen this tile taps into.
- **Localization** — adds the `streak` key across all 8 locales.

Built clean (0 warnings) off `main` in an isolated worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
