### PR TITLE
Muscle balance: donut hero, diverging bars & slim history chart

### DIFF
--- a/LOGIT.xcodeproj/project.pbxproj
+++ b/LOGIT.xcodeproj/project.pbxproj
@@ -137,6 +137,7 @@
 		801BBDBB2DF7338A00CDB1FB /* ExerciseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBCCB2DF7338A00CDB1FB /* ExerciseDTO.swift */; };
 		801BBDBC2DF7338A00CDB1FB /* MuscleGroupService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBD332DF7338A00CDB1FB /* MuscleGroupService.swift */; };
 		53B547C48713887B1E5542EE /* MuscleBalanceCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0258213863A5C9812190A44D /* MuscleBalanceCalculator.swift */; };
+		A1B2C3D4E5F600000001B001 /* MuscleBalanceHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F600000001F001 /* MuscleBalanceHistory.swift */; };
 		F344926EBBAE89A564139E06 /* MuscleTargetSplitStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DDAB0743896FB9245B6D5A9 /* MuscleTargetSplitStore.swift */; };
 		801BBDBD2DF7338A00CDB1FB /* Int+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBCB22DF7338A00CDB1FB /* Int+.swift */; };
 		801BBDBE2DF7338A00CDB1FB /* WidgetCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBD5B2DF7338A00CDB1FB /* WidgetCollectionView.swift */; };
@@ -255,6 +256,7 @@
 		8C6BE79BA086E3876A56C1D7 /* SharedWithYouBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3184F4CAAB24791B6F5AC79A /* SharedWithYouBanner.swift */; };
 		8E306606440725A568FE5F1A /* ExerciseMergeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF0CFD6EDA94DA1792A2CA82 /* ExerciseMergeService.swift */; };
 		8F4A3C022E5A9B0100D4E5F2 /* SetVolumeBarChart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F4A3C012E5A9B0100D4E5F1 /* SetVolumeBarChart.swift */; };
+		A1B2C3D4E5F600000003B003 /* MuscleBalanceHistoryChart.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F600000003F003 /* MuscleBalanceHistoryChart.swift */; };
 		E1E1E1000000000000000B13 /* TileBarChartStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1E1E1000000000000000F13 /* TileBarChartStyle.swift */; };
 		E1E1E1000000000000000B14 /* TileSparklineStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1E1E1000000000000000F14 /* TileSparklineStyle.swift */; };
 		9392C43C9501E6676A02488A /* WorkoutLiveActivitySnapshotBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B6F634C95B552C305EA0055 /* WorkoutLiveActivitySnapshotBuilder.swift */; };
@@ -522,6 +524,7 @@
 		801BBD312DF7338A00CDB1FB /* UpgradeToProScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpgradeToProScreen.swift; sourceTree = "<group>"; };
 		801BBD332DF7338A00CDB1FB /* MuscleGroupService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MuscleGroupService.swift; sourceTree = "<group>"; };
 		0258213863A5C9812190A44D /* MuscleBalanceCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MuscleBalanceCalculator.swift; sourceTree = "<group>"; };
+		A1B2C3D4E5F600000001F001 /* MuscleBalanceHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MuscleBalanceHistory.swift; sourceTree = "<group>"; };
 		4DDAB0743896FB9245B6D5A9 /* MuscleTargetSplitStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MuscleTargetSplitStore.swift; sourceTree = "<group>"; };
 		801BBD352DF7338A00CDB1FB /* DateBarChart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateBarChart.swift; sourceTree = "<group>"; };
 		801BBD362DF7338A00CDB1FB /* DateLineChart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateLineChart.swift; sourceTree = "<group>"; };
@@ -596,6 +599,7 @@
 		80NEWTEST00C /* WorkoutSharingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutSharingTests.swift; sourceTree = "<group>"; };
 		829F12D41C231764936B6B83 /* WorkoutLiveActivityAttributes.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkoutLiveActivityAttributes.swift; sourceTree = "<group>"; };
 		8F4A3C012E5A9B0100D4E5F1 /* SetVolumeBarChart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetVolumeBarChart.swift; sourceTree = "<group>"; };
+		A1B2C3D4E5F600000003F003 /* MuscleBalanceHistoryChart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MuscleBalanceHistoryChart.swift; sourceTree = "<group>"; };
 		E1E1E1000000000000000F13 /* TileBarChartStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TileBarChartStyle.swift; sourceTree = "<group>"; };
 		E1E1E1000000000000000F14 /* TileSparklineStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TileSparklineStyle.swift; sourceTree = "<group>"; };
 		9D2E7A012F30AA0100C1D2E1 /* DemoWorkoutSeeder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DemoWorkoutSeeder.swift; sourceTree = "<group>"; };
@@ -1176,6 +1180,7 @@
 				8085497A2EE9A34400761706 /* DefaultExerciseService.swift */,
 				801BBD332DF7338A00CDB1FB /* MuscleGroupService.swift */,
 				0258213863A5C9812190A44D /* MuscleBalanceCalculator.swift */,
+				A1B2C3D4E5F600000001F001 /* MuscleBalanceHistory.swift */,
 				4DDAB0743896FB9245B6D5A9 /* MuscleTargetSplitStore.swift */,
 				54EE2592821500000001 /* ExerciseSuggestionService.swift */,
 				1EB3B92BF7A5E9FE9E442716 /* WorkoutSharingService.swift */,
@@ -1192,6 +1197,7 @@
 				801BBD372DF7338A00CDB1FB /* MuscleGroupOccurancesChart.swift */,
 				801BBD382DF7338A00CDB1FB /* PieGraph.swift */,
 				8F4A3C012E5A9B0100D4E5F1 /* SetVolumeBarChart.swift */,
+				A1B2C3D4E5F600000003F003 /* MuscleBalanceHistoryChart.swift */,
 				E1E1E1000000000000000F13 /* TileBarChartStyle.swift */,
 				E1E1E1000000000000000F14 /* TileSparklineStyle.swift */,
 			);
@@ -1689,6 +1695,7 @@
 				8085497B2EE9A34400761706 /* DefaultExerciseService.swift in Sources */,
 				801BBDBC2DF7338A00CDB1FB /* MuscleGroupService.swift in Sources */,
 				53B547C48713887B1E5542EE /* MuscleBalanceCalculator.swift in Sources */,
+				A1B2C3D4E5F600000001B001 /* MuscleBalanceHistory.swift in Sources */,
 				F344926EBBAE89A564139E06 /* MuscleTargetSplitStore.swift in Sources */,
 				2A384BE3816900000002 /* ExerciseSuggestionService.swift in Sources */,
 				801BBDBD2DF7338A00CDB1FB /* Int+.swift in Sources */,
@@ -1724,6 +1731,7 @@
 				801BBDD92DF7338A00CDB1FB /* View+.swift in Sources */,
 				801BBDDA2DF7338A00CDB1FB /* DateBarChart.swift in Sources */,
 				8F4A3C022E5A9B0100D4E5F2 /* SetVolumeBarChart.swift in Sources */,
+				A1B2C3D4E5F600000003B003 /* MuscleBalanceHistoryChart.swift in Sources */,
 				E1E1E1000000000000000B13 /* TileBarChartStyle.swift in Sources */,
 				E1E1E1000000000000000B14 /* TileSparklineStyle.swift in Sources */,
 				801BBDDB2DF7338A00CDB1FB /* WorkoutCell.swift in Sources */,

--- a/LOGIT/Core/Enums/MuscleTargetSplit.swift
+++ b/LOGIT/Core/Enums/MuscleTargetSplit.swift
@@ -70,8 +70,8 @@ struct MuscleTargetSplit: Codable, Equatable {
 
     // MARK: - Defaults
 
-    /// How many percentage points under target a group must fall before it's flagged "behind" — the
-    /// editor's threshold note and `MuscleBalanceCalculator`'s `isBehind` both read this.
+    /// How many percentage points off target a group must fall before it counts as under/over — the
+    /// editor's threshold note, the on-target band, and `MuscleBalanceEntry.state` all read this.
     static let behindThreshold = 5
 
     /// The app's default target split — the balanced preset.

--- a/LOGIT/Core/Environment/de.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/de.lproj/Localizable.strings
@@ -999,3 +999,11 @@
 "streakFactYear" = "Ein ganzes Jahr";
 "weeks" = "Wochen";
 "streak" = "Streak";
+
+/* Muscle Balance — donut overview, sections & history chart */
+"muscleBalanceMore" = "+%d weitere";
+"muscleBalanceOverTime" = "Balance im Zeitverlauf";
+"muscleDetailEmptySubtitle" = "Du hast diese Muskelgruppe im gewählten Zeitraum nicht trainiert.";
+"muscleBalanceBelowTarget" = "Unter dem Ziel";
+"muscleBalanceAboveTarget" = "Über dem Ziel";
+"muscleBalanceOnTargetSection" = "Im Ziel";

--- a/LOGIT/Core/Environment/en.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/en.lproj/Localizable.strings
@@ -1003,3 +1003,11 @@
 "streakFactYear" = "A full year";
 "weeks" = "Weeks";
 "streak" = "Streak";
+
+/* Muscle Balance — donut overview, sections & history chart */
+"muscleBalanceMore" = "+%d more";
+"muscleBalanceOverTime" = "Balance over time";
+"muscleDetailEmptySubtitle" = "You haven't trained this muscle in the selected period.";
+"muscleBalanceBelowTarget" = "Below target";
+"muscleBalanceAboveTarget" = "Above target";
+"muscleBalanceOnTargetSection" = "On target";

--- a/LOGIT/Core/Environment/es.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/es.lproj/Localizable.strings
@@ -1003,3 +1003,11 @@
 "streakFactYear" = "Un año completo";
 "weeks" = "Semanas";
 "streak" = "Racha";
+
+/* Muscle Balance — donut overview, sections & history chart */
+"muscleBalanceMore" = "+%d más";
+"muscleBalanceOverTime" = "Equilibrio a lo largo del tiempo";
+"muscleDetailEmptySubtitle" = "No has entrenado este músculo en el periodo seleccionado.";
+"muscleBalanceBelowTarget" = "Bajo el objetivo";
+"muscleBalanceAboveTarget" = "Sobre el objetivo";
+"muscleBalanceOnTargetSection" = "En objetivo";

--- a/LOGIT/Core/Environment/fr.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/fr.lproj/Localizable.strings
@@ -1003,3 +1003,11 @@
 "streakFactYear" = "Une année complète";
 "weeks" = "Semaines";
 "streak" = "Série";
+
+/* Muscle Balance — donut overview, sections & history chart */
+"muscleBalanceMore" = "+%d de plus";
+"muscleBalanceOverTime" = "Équilibre dans le temps";
+"muscleDetailEmptySubtitle" = "Vous n'avez pas entraîné ce muscle sur la période sélectionnée.";
+"muscleBalanceBelowTarget" = "Sous la cible";
+"muscleBalanceAboveTarget" = "Au-dessus de la cible";
+"muscleBalanceOnTargetSection" = "Dans la cible";

--- a/LOGIT/Core/Environment/it.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/it.lproj/Localizable.strings
@@ -1003,3 +1003,11 @@
 "streakFactYear" = "Un anno intero";
 "weeks" = "Settimane";
 "streak" = "Serie";
+
+/* Muscle Balance — donut overview, sections & history chart */
+"muscleBalanceMore" = "+%d altri";
+"muscleBalanceOverTime" = "Equilibrio nel tempo";
+"muscleDetailEmptySubtitle" = "Non hai allenato questo muscolo nel periodo selezionato.";
+"muscleBalanceBelowTarget" = "Sotto il target";
+"muscleBalanceAboveTarget" = "Sopra il target";
+"muscleBalanceOnTargetSection" = "A target";

--- a/LOGIT/Core/Environment/ja.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/ja.lproj/Localizable.strings
@@ -1003,3 +1003,11 @@
 "streakFactYear" = "まる1年";
 "weeks" = "週";
 "streak" = "連続記録";
+
+/* Muscle Balance — donut overview, sections & history chart */
+"muscleBalanceMore" = "他%d件";
+"muscleBalanceOverTime" = "時間ごとのバランス";
+"muscleDetailEmptySubtitle" = "選択した期間にこの部位はトレーニングしていません。";
+"muscleBalanceBelowTarget" = "目標未満";
+"muscleBalanceAboveTarget" = "目標超過";
+"muscleBalanceOnTargetSection" = "目標どおり";

--- a/LOGIT/Core/Environment/ko.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/ko.lproj/Localizable.strings
@@ -1003,3 +1003,11 @@
 "streakFactYear" = "꼬박 1년";
 "weeks" = "주";
 "streak" = "연속 기록";
+
+/* Muscle Balance — donut overview, sections & history chart */
+"muscleBalanceMore" = "외 %d개";
+"muscleBalanceOverTime" = "기간별 균형";
+"muscleDetailEmptySubtitle" = "선택한 기간에 이 부위를 운동하지 않았습니다.";
+"muscleBalanceBelowTarget" = "목표 미만";
+"muscleBalanceAboveTarget" = "목표 초과";
+"muscleBalanceOnTargetSection" = "목표 달성";

--- a/LOGIT/Core/Environment/pt-BR.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/pt-BR.lproj/Localizable.strings
@@ -1003,3 +1003,11 @@
 "streakFactYear" = "Um ano inteiro";
 "weeks" = "Semanas";
 "streak" = "Sequência";
+
+/* Muscle Balance — donut overview, sections & history chart */
+"muscleBalanceMore" = "+%d mais";
+"muscleBalanceOverTime" = "Equilíbrio ao longo do tempo";
+"muscleDetailEmptySubtitle" = "Você não treinou este músculo no período selecionado.";
+"muscleBalanceBelowTarget" = "Abaixo da meta";
+"muscleBalanceAboveTarget" = "Acima da meta";
+"muscleBalanceOnTargetSection" = "No alvo";

--- a/LOGIT/Features/Home/MuscleGroupDetailScreen.swift
+++ b/LOGIT/Features/Home/MuscleGroupDetailScreen.swift
@@ -9,9 +9,10 @@ import Charts
 import CoreData
 import SwiftUI
 
-/// The single-muscle detail (`muscle-group-screens.html` screen 2): a muscle-coloured gradient header
-/// with the `BodyMapFigure`, a target-share tile, a 2×2 stat grid, a 12-week sets chart, and the top
-/// exercises that train it. Pro — the full per-muscle breakdown is the analytics behind the wall.
+/// The single-muscle detail: a target-share tile (the diverging `MuscleBalanceBar` showing how the
+/// group's share sits against target, with a "↓ Below target / ↑ Above target / ✓ On target" pill),
+/// a 2×2 stat grid, a 12-week sets chart, and the top exercises that train it. Pro — the full
+/// per-muscle breakdown is the analytics behind the wall.
 struct MuscleGroupDetailScreen: View {
     let muscleGroup: MuscleGroup
 
@@ -50,61 +51,104 @@ struct MuscleGroupDetailScreen: View {
 
         return ScrollView {
             VStack(spacing: SECTION_SPACING) {
-                header(percent: percent)
-                VStack(spacing: 16) {
-                    PeriodPicker(selection: $period)
-                    targetShareTile(entry: entry)
+                PeriodPicker(selection: $period)
+                if groupSetCount > 0 {
+                    targetShare(entry: entry, percent: percent)
                     statGrid(setCount: groupSetCount, volume: volume, sessions: sessions, rank: rank)
                     weeklyChart(allWorkouts: allWorkouts)
                     topExercises(in: periodWorkouts)
+                } else {
+                    emptyState
+                        .containerRelativeFrame(.vertical, alignment: .center) { height, _ in
+                            max(height - 96, 320)
+                        }
                 }
-                .padding(.horizontal)
             }
+            .padding(.horizontal)
+            .padding(.top)
             .padding(.bottom, SCROLLVIEW_BOTTOM_PADDING)
         }
         .isBlockedWithoutPro()
         .navigationBarTitleDisplayMode(.inline)
-        .ignoresSafeArea(edges: .top)
-    }
-
-    // MARK: - Header
-
-    private func header(percent: Int) -> some View {
-        HStack(spacing: 16) {
-            BodyMapFigure(
-                highlighted: BodyRegion(muscleGroup),
-                color: .black.opacity(0.5),
-                baseColor: .black.opacity(0.28)
-            )
-            .frame(width: 52, height: 116)
-            VStack(alignment: .leading, spacing: 4) {
+        .toolbar {
+            ToolbarItem(placement: .principal) {
+                // Muscle names carry their colour themselves — bold, rounded, no identity dot.
                 Text(muscleGroup.description)
-                    .font(.largeTitle.weight(.bold))
-                    .foregroundStyle(.black)
-                Text(String(format: NSLocalizedString("muscleDetailPercentOfSets", comment: ""), percent))
-                    .font(.subheadline.weight(.semibold))
-                    .foregroundStyle(.black.opacity(0.6))
+                    .font(.system(.headline, design: .rounded, weight: .bold))
+                    .foregroundStyle(color)
             }
-            Spacer()
         }
-        .padding(.horizontal)
-        .padding(.top, 60)
-        .padding(.bottom, 20)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(color.gradient)
     }
 
-    // MARK: - Target share
+    // MARK: - Hero
 
-    private func targetShareTile(entry: MuscleBalanceEntry) -> some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text(NSLocalizedString("targetShare", comment: ""))
-                .font(.subheadline.weight(.semibold))
+    /// The target-share tile: the group's standing (↓ Below target / ↑ Above target / ✓ On target) +
+    /// its share of sets, over the diverging `MuscleBalanceBar` — the fill grows out of the centred
+    /// target tick, left when under, right when over.
+    private func targetShare(entry: MuscleBalanceEntry, percent: Int) -> some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HStack {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(NSLocalizedString("targetShare", comment: ""))
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(Color.label)
+                    Text(String(format: NSLocalizedString("muscleDetailPercentOfSets", comment: ""), percent))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                stateBadge(entry.state)
+            }
             MuscleBalanceBar(entry: entry, showsName: false, showsDelta: true)
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
         .padding(CELL_PADDING)
         .tileStyle()
+    }
+
+    private func stateBadge(_ state: MuscleBalanceState) -> some View {
+        let word: String
+        let icon: String
+        let isGood: Bool
+        switch state {
+        case .under: word = "muscleBalanceBelowTarget"; icon = "arrow.down"; isGood = false
+        case .over: word = "muscleBalanceAboveTarget"; icon = "arrow.up"; isGood = false
+        case .onTarget: word = "muscleBalanceOnTargetSection"; icon = "checkmark"; isGood = true
+        }
+        return HStack(spacing: 5) {
+            Image(systemName: icon)
+                .font(.caption2.weight(.bold))
+            Text(NSLocalizedString(word, comment: ""))
+                .font(.caption.weight(.bold))
+        }
+        .foregroundStyle(isGood ? Color.accentColor : Color.secondaryLabel)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 5)
+        .background(Capsule().fill(isGood ? Color.accentColor.opacity(0.16) : Color.secondaryFill))
+    }
+
+    // MARK: - Empty
+
+    private var emptyState: some View {
+        VStack(spacing: 14) {
+            ZStack {
+                Circle()
+                    .fill(color.opacity(0.16))
+                    .frame(width: 76, height: 76)
+                Image(systemName: "dumbbell.fill")
+                    .font(.system(size: 30, weight: .semibold))
+                    .foregroundStyle(color.gradient)
+            }
+            VStack(spacing: 6) {
+                Text(NSLocalizedString("muscleBalanceEmpty", comment: ""))
+                    .font(.headline)
+                Text(NSLocalizedString("muscleDetailEmptySubtitle", comment: ""))
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.horizontal)
     }
 
     // MARK: - Stat grid

--- a/LOGIT/Features/Home/MuscleGroupsOverviewScreen.swift
+++ b/LOGIT/Features/Home/MuscleGroupsOverviewScreen.swift
@@ -7,13 +7,17 @@
 
 import SwiftUI
 
-/// The Muscle Groups overview (`muscle-group-screens.html` screen 1): a period-scoped set-distribution
-/// donut, a neutral "on target" insight banner (no alarm colour — muscle hues are identity, not
-/// warning), the full eight-group balance-vs-target list (worst gap first) built from the shared
-/// `MuscleBalanceBar`, and a row into the target-split editor. The full breakdown is Pro; the
-/// Summary's Muscle Balance tile is the free hook into it. Replaces the 2022 `MuscleGroupSplitScreen`.
+/// The Muscle Groups overview: the muscle-group occurrence donut leads — the same circle the app uses
+/// everywhere for muscle groups, with the period's total sets in its centre — over the groups grouped
+/// by standing (↓ Below target · ↑ Above target · ✓ On target), each row the diverging
+/// `MuscleBalanceBar` growing out of the target tick. Below, the slim segmented "Balance over time"
+/// chart: Week / Month / Year sets its grouping and tapping a bar rebinds the donut and sections to
+/// that period. Rows tap through to the muscle's own page. Pro; the Summary's Muscle Balance tile is
+/// the free hook into it.
 struct MuscleGroupsOverviewScreen: View {
     @State private var period: StatPeriod = .month
+    /// The bar the gesture last selected (a bucket id), or nil for "none tapped yet" → newest with data.
+    @State private var rawSelection: String?
 
     @EnvironmentObject private var muscleGroupService: MuscleGroupService
     @EnvironmentObject private var targetSplitStore: MuscleTargetSplitStore
@@ -25,33 +29,62 @@ struct MuscleGroupsOverviewScreen: View {
             sortDescriptors: [SortDescriptor(\.date, order: .reverse)],
             predicate: WorkoutPredicateFactory.getWorkouts()
         ) { allWorkouts in
-            let range = period.currentRange()
-            content(workouts: allWorkouts.filter { ($0.date).map { range.contains($0) } ?? false })
+            content(allWorkouts: allWorkouts)
         }
     }
 
-    private func content(workouts: [Workout]) -> some View {
-        let occurrences = muscleGroupService.getMuscleGroupOccurances(in: workouts)
-        let totalSets = occurrences.reduce(0) { $0 + $1.1 }
-        let calculator = MuscleBalanceCalculator(
-            workouts: workouts,
-            target: targetSplitStore.split,
+    private func content(allWorkouts: [Workout]) -> some View {
+        let target = targetSplitStore.split
+        let buckets = MuscleBalanceHistory.buckets(
+            from: allWorkouts,
+            period: period,
+            target: target,
             muscleGroupService: muscleGroupService
         )
+        let orderedGroups = orderedGroups(for: target)
+        let hasData = buckets.contains { $0.totalSets > 0 }
+        let selected = resolveSelected(in: buckets)
+
         return ScrollView {
             VStack(spacing: SECTION_SPACING) {
-                VStack(spacing: 16) {
-                    PeriodPicker(selection: $period)
-                    donut(occurrences: occurrences, totalSets: totalSets)
-                    insightBanner(calculator)
+                PeriodPicker(selection: $period)
+                if hasData {
+                    if selected.totalSets > 0 {
+                        donutHero(selected)
+                        section(
+                            titleKey: "muscleBalanceBelowTarget",
+                            systemImage: "arrow.down",
+                            entries: selected.calculator.underTargets()
+                        )
+                        section(
+                            titleKey: "muscleBalanceAboveTarget",
+                            systemImage: "arrow.up",
+                            entries: selected.calculator.overTargets()
+                        )
+                        section(
+                            titleKey: "muscleBalanceOnTargetSection",
+                            systemImage: "checkmark",
+                            entries: selected.calculator.entries
+                                .filter(\.isOnTarget)
+                                .sorted { $0.actualPercent > $1.actualPercent },
+                            isGood: true
+                        )
+                    } else {
+                        emptyBucketNote
+                    }
+                    chartSection(buckets: buckets, orderedGroups: orderedGroups, selectedID: selected.id)
+                } else {
+                    emptyState
                 }
-                balanceList(calculator)
                 adjustRow
             }
             .padding(.horizontal)
             .padding(.top)
             .padding(.bottom, SCROLLVIEW_BOTTOM_PADDING)
         }
+        // Selecting a bar re-splits the sections, morphs the donut, and ticks a selection haptic.
+        .animation(.snappy(duration: 0.3), value: selected.id)
+        .sensoryFeedback(.selection, trigger: selected.id)
         .isBlockedWithoutPro()
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
@@ -60,82 +93,159 @@ struct MuscleGroupsOverviewScreen: View {
                     .font(.headline)
             }
         }
+        .onChange(of: period) { rawSelection = nil }
     }
 
-    private func donut(occurrences: [(MuscleGroup, Int)], totalSets: Int) -> some View {
-        ZStack {
-            MuscleGroupOccurancesChart(muscleGroupOccurances: occurrences)
-                .frame(width: 170, height: 170)
-            VStack(spacing: 2) {
-                Text("\(totalSets)")
-                    .font(.system(size: 34, weight: .bold))
-                    .fontDesign(.rounded)
-                Text(NSLocalizedString("sets", comment: ""))
-                    .font(.caption2.weight(.semibold))
-                    .textCase(.uppercase)
-                    .foregroundStyle(.secondary)
-            }
-        }
-        .frame(maxWidth: .infinity)
-        .padding(.vertical, 8)
-    }
+    // MARK: - Donut hero
 
-    private func insightBanner(_ calculator: MuscleBalanceCalculator) -> some View {
-        HStack(spacing: 12) {
-            Image(systemName: "chart.pie.fill")
-                .font(.body)
-                .foregroundStyle(Color.accentColor)
-                .frame(width: 32, height: 32)
-                .background(Circle().fill(Color.accentColor.opacity(0.15)))
-            VStack(alignment: .leading, spacing: 2) {
-                Text(bannerTitle(calculator))
-                    .font(.subheadline.weight(.bold))
-                Text(String(format: NSLocalizedString("muscleBalanceOnTarget", comment: ""), calculator.onTargetCount()))
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-            Spacer()
-        }
-        .padding(CELL_PADDING)
-        .tileStyle()
-    }
-
-    private func bannerTitle(_ calculator: MuscleBalanceCalculator) -> String {
-        if calculator.totalSets == 0 { return NSLocalizedString("muscleBalanceEmpty", comment: "") }
-        return calculator.onTargetCount() >= 6
-            ? NSLocalizedString("muscleBalanceOnTrack", comment: "")
-            : NSLocalizedString("muscleBalanceRoomToBalance", comment: "")
-    }
-
-    private func balanceList(_ calculator: MuscleBalanceCalculator) -> some View {
-        VStack(spacing: SECTION_HEADER_SPACING) {
-            Text(NSLocalizedString("balanceVsTarget", comment: ""))
-                .sectionHeaderStyle2()
-                .frame(maxWidth: .infinity, alignment: .leading)
-            let entries = calculator.worstGapSorted()
-            VStack(spacing: 0) {
-                ForEach(Array(entries.enumerated()), id: \.element.id) { index, entry in
-                    Button {
-                        homeNavigationCoordinator.path.append(.muscleGroupDetail(entry.muscleGroup))
-                    } label: {
-                        HStack(spacing: 8) {
-                            MuscleBalanceBar(entry: entry, showsName: true, showsDelta: true)
-                            NavigationChevron()
-                                .foregroundStyle(.secondary)
-                        }
-                        .padding(.vertical, 10)
-                        .contentShape(Rectangle())
-                    }
-                    .buttonStyle(.plain)
-                    if index < entries.count - 1 {
-                        Divider()
-                    }
+    /// The muscle-group occurrence donut with the period's total sets in the centre and the period's
+    /// name beneath — the name keeps time-travel legible when a past bar is selected.
+    private func donutHero(_ bucket: MuscleBalanceBucket) -> some View {
+        VStack(spacing: 12) {
+            ZStack {
+                MuscleGroupOccurancesChart(muscleGroupOccurances: occurrences(in: bucket))
+                VStack(spacing: 1) {
+                    Text("\(bucket.totalSets)")
+                        .font(.system(size: 34, weight: .bold, design: .rounded))
+                        .monospacedDigit()
+                        .contentTransition(.numericText())
+                        .foregroundStyle(Color.label)
+                    Text(NSLocalizedString("sets", comment: ""))
+                        .font(.system(size: 12, weight: .bold, design: .rounded))
+                        .textCase(.uppercase)
+                        .foregroundStyle(.secondary)
                 }
             }
-            .padding(.horizontal, CELL_PADDING)
+            .frame(width: 190, height: 190)
+            Text(bucket.title)
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(.secondary)
+                .contentTransition(.numericText())
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.top, 6)
+    }
+
+    /// The donut's input: this bucket's set occurrences per group, canonical order, untrained groups
+    /// omitted (the chart draws slices only for what was trained).
+    private func occurrences(in bucket: MuscleBalanceBucket) -> [(MuscleGroup, Int)] {
+        bucket.calculator.entries
+            .filter { $0.setCount > 0 }
+            .map { ($0.muscleGroup, $0.setCount) }
+    }
+
+    // MARK: - Grouped sections
+
+    @ViewBuilder
+    private func section(
+        titleKey: String,
+        systemImage: String,
+        entries: [MuscleBalanceEntry],
+        isGood: Bool = false
+    ) -> some View {
+        if !entries.isEmpty {
+            VStack(spacing: SECTION_HEADER_SPACING) {
+                HStack(spacing: 8) {
+                    Image(systemName: systemImage)
+                        .font(.system(size: 13, weight: .bold))
+                        .foregroundStyle(isGood ? Color.accentColor : Color.secondaryLabel)
+                        .frame(width: 24, height: 24)
+                        .background(
+                            RoundedRectangle(cornerRadius: 7)
+                                .fill(isGood ? Color.accentColor.opacity(0.16) : Color.fill)
+                        )
+                    Text(NSLocalizedString(titleKey, comment: ""))
+                        .font(.subheadline.weight(.bold))
+                        .foregroundStyle(Color.label)
+                    Spacer()
+                    Text("\(entries.count)")
+                        .font(.subheadline.weight(.bold))
+                        .foregroundStyle(.tertiary)
+                        .monospacedDigit()
+                        .contentTransition(.numericText())
+                }
+                .padding(.horizontal, 4)
+                VStack(spacing: 0) {
+                    ForEach(Array(entries.enumerated()), id: \.element.id) { index, entry in
+                        Button {
+                            homeNavigationCoordinator.path.append(.muscleGroupDetail(entry.muscleGroup))
+                        } label: {
+                            barRow(entry)
+                        }
+                        .buttonStyle(.plain)
+                        if index < entries.count - 1 {
+                            Divider()
+                        }
+                    }
+                }
+                .padding(.horizontal, CELL_PADDING)
+                .tileStyle()
+            }
+        }
+    }
+
+    private func barRow(_ entry: MuscleBalanceEntry) -> some View {
+        HStack(spacing: 8) {
+            MuscleBalanceBar(entry: entry, showsName: true, showsDelta: true)
+            NavigationChevron()
+                .foregroundStyle(.secondary)
+        }
+        .padding(.vertical, 10)
+        .contentShape(Rectangle())
+    }
+
+    // MARK: - Chart
+
+    private func chartSection(
+        buckets: [MuscleBalanceBucket],
+        orderedGroups: [MuscleGroup],
+        selectedID: String
+    ) -> some View {
+        VStack(alignment: .leading, spacing: SECTION_HEADER_SPACING) {
+            Text(NSLocalizedString("muscleBalanceOverTime", comment: ""))
+                .sectionHeaderStyle2()
+                .frame(maxWidth: .infinity, alignment: .leading)
+            MuscleBalanceHistoryChart(
+                buckets: buckets,
+                orderedGroups: orderedGroups,
+                selectedID: selectedID,
+                rawSelection: $rawSelection
+            )
+            .padding(CELL_PADDING)
             .tileStyle()
         }
     }
+
+    // MARK: - Empty states
+
+    /// The selected bucket has no sets (the user tapped an empty bar) though other periods do.
+    private var emptyBucketNote: some View {
+        Text(NSLocalizedString("noData", comment: ""))
+            .font(.subheadline.weight(.semibold))
+            .foregroundStyle(.secondary)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 30)
+            .tileStyle()
+    }
+
+    /// No sets anywhere in the window — nothing to chart at all.
+    private var emptyState: some View {
+        VStack(spacing: 10) {
+            BodyMapFigure(highlighted: nil)
+                .frame(width: 44, height: 92)
+                .opacity(0.7)
+            Text(NSLocalizedString("muscleBalanceEmpty", comment: ""))
+                .font(.headline)
+            Text(NSLocalizedString("muscleBalanceEmptySubtitle", comment: ""))
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 40)
+    }
+
+    // MARK: - Adjust
 
     private var adjustRow: some View {
         Button {
@@ -156,6 +266,29 @@ struct MuscleGroupsOverviewScreen: View {
             .tileStyle()
         }
         .buttonStyle(TileButtonStyle())
+    }
+
+    // MARK: - Helpers
+
+    /// The bar currently selected, or — before any tap, or after a period switch — the most recent
+    /// bucket that has sets (so the donut and sections always open on real data).
+    private func resolveSelected(in buckets: [MuscleBalanceBucket]) -> MuscleBalanceBucket {
+        if let rawSelection, let match = buckets.first(where: { $0.id == rawSelection }) {
+            return match
+        }
+        return buckets.last(where: { $0.totalSets > 0 }) ?? buckets[buckets.count - 1]
+    }
+
+    /// Chart stack order: biggest target share first, so the composition is stable across periods.
+    private func orderedGroups(for target: MuscleTargetSplit) -> [MuscleGroup] {
+        MuscleGroup.allCases.sorted {
+            let lhs = target.percentage(for: $0)
+            let rhs = target.percentage(for: $1)
+            if lhs != rhs { return lhs > rhs }
+            let li = MuscleGroup.allCases.firstIndex(of: $0) ?? 0
+            let ri = MuscleGroup.allCases.firstIndex(of: $1) ?? 0
+            return li < ri
+        }
     }
 }
 

--- a/LOGIT/Features/Home/MuscleTargetSplitScreen.swift
+++ b/LOGIT/Features/Home/MuscleTargetSplitScreen.swift
@@ -78,11 +78,10 @@ struct MuscleTargetSplitScreen: View {
 
     private func row(_ group: MuscleGroup) -> some View {
         HStack(spacing: 11) {
-            RoundedRectangle(cornerRadius: 3)
-                .fill(group.color)
-                .frame(width: 9, height: 9)
+            // Muscle names carry their colour themselves — bold, rounded, no identity dot.
             Text(group.description)
-                .font(.system(size: 15, weight: .semibold))
+                .font(.system(size: 15, weight: .bold, design: .rounded))
+                .foregroundStyle(group.color)
             Spacer()
             stepper(group)
         }

--- a/LOGIT/Features/Home/SummaryEmptyStates.swift
+++ b/LOGIT/Features/Home/SummaryEmptyStates.swift
@@ -124,8 +124,8 @@ private func callToAction(title: String, buttonTitle: String, onAdd: @escaping (
     }
 }
 
-/// A dimmed sample of a pinned exercise tile — mirrors the `MetricTile` pinned look (muscle dot + name,
-/// Est. 1RM caption, value, corner sparkline) closely enough to read as a believable preview.
+/// A dimmed sample of a pinned exercise tile — mirrors the `MetricTile` pinned look (name, Est. 1RM
+/// caption, value, corner sparkline) closely enough to read as a believable preview.
 private struct GhostExerciseTile: View {
     let name: String
     let value: String
@@ -136,7 +136,6 @@ private struct GhostExerciseTile: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             HStack(spacing: 6) {
-                RoundedRectangle(cornerRadius: 3).fill(color).frame(width: 9, height: 9)
                 Text(name)
                     .font(.subheadline.weight(.semibold))
                     .foregroundStyle(Color.label)

--- a/LOGIT/Features/Home/Tiles/MuscleBalanceTile.swift
+++ b/LOGIT/Features/Home/Tiles/MuscleBalanceTile.swift
@@ -8,10 +8,11 @@
 import SwiftUI
 
 /// The Summary screen's period-scoped Muscle Balance tile — the free, actionable hook (same pattern as
-/// Records: tile free, detail Pro). It leads with a one-line, period-aware insight, shows the couple
-/// of groups furthest from target as diverging `MuscleBalanceBar` rows, and footers "N of 8 on
-/// target". Non-nagging: the insight only ever flags a major/compound group under target, never an
-/// "over" and never a deliberately-light abs/cardio. Taps into the Muscle Groups overview.
+/// Records: tile free, detail Pro). It leads with the groups that are below their target (then the
+/// ones above), three at a time — each row the diverging `MuscleBalanceBar` growing out of the target
+/// tick, the same language as the overview's sections — with a "+N more" hint by the chevron, and
+/// rolls the rest into one encouraging line ("N of 8 on target"). Taps into the Muscle Groups
+/// overview.
 struct MuscleBalanceTile: View {
     /// Workouts already filtered to the Summary's selected period.
     let workouts: [Workout]
@@ -19,6 +20,9 @@ struct MuscleBalanceTile: View {
 
     @EnvironmentObject private var targetSplitStore: MuscleTargetSplitStore
     @EnvironmentObject private var muscleGroupService: MuscleGroupService
+
+    /// How many off-target rows the tile shows before collapsing the rest into "+N more".
+    private static let maxRows = 3
 
     private var calculator: MuscleBalanceCalculator {
         MuscleBalanceCalculator(
@@ -30,33 +34,65 @@ struct MuscleBalanceTile: View {
 
     var body: some View {
         let calculator = self.calculator
-        VStack(alignment: .leading, spacing: 12) {
-            HStack {
+        // Below-target first — the under-target groups are the actionable ones; the above ones trail.
+        let offTarget = calculator.totalSets > 0
+            ? calculator.underTargets() + calculator.overTargets()
+            : []
+        return VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 8) {
                 Text(NSLocalizedString("muscleBalance", comment: ""))
                     .tileHeaderStyle()
                 Spacer()
+                if offTarget.count > Self.maxRows {
+                    Text(String(format: NSLocalizedString("muscleBalanceMore", comment: ""), offTarget.count - Self.maxRows))
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.tertiary)
+                }
                 NavigationChevron()
                     .foregroundStyle(.secondary)
             }
             if calculator.totalSets > 0 {
-                Text(insightText(calculator.insight(for: period)))
-                    .font(.subheadline.weight(.semibold))
-                    .foregroundStyle(Color.label)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                VStack(spacing: 11) {
-                    ForEach(topEntries(calculator)) { entry in
-                        MuscleBalanceBar(entry: entry, showsName: true, showsDelta: true)
-                    }
-                }
-                Text(String(format: NSLocalizedString("muscleBalanceOnTarget", comment: ""), calculator.onTargetCount()))
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                balance(calculator, offTarget: offTarget)
             } else {
                 emptyState
             }
         }
         .padding(CELL_PADDING)
         .tileStyle()
+    }
+
+    @ViewBuilder
+    private func balance(_ calculator: MuscleBalanceCalculator, offTarget: [MuscleBalanceEntry]) -> some View {
+        if offTarget.isEmpty {
+            // Everything's in range — a calm, positive read.
+            HStack(spacing: 8) {
+                Image(systemName: "checkmark.circle.fill")
+                    .foregroundStyle(Color.accentColor)
+                Text(NSLocalizedString("muscleBalanceBalanced", comment: ""))
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(Color.label)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.vertical, 4)
+        } else {
+            VStack(spacing: 7) {
+                ForEach(offTarget.prefix(Self.maxRows)) { entry in
+                    row(entry)
+                }
+            }
+            Text(String(format: NSLocalizedString("muscleBalanceOnTarget", comment: ""), calculator.onTargetCount()))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    /// One off-target group: the diverging bar with its coloured name and signed delta — the same
+    /// language the overview's sections use, so tile and detail read as one.
+    private func row(_ entry: MuscleBalanceEntry) -> some View {
+        MuscleBalanceBar(entry: entry, showsName: true, showsDelta: true)
+            .padding(.horizontal, 13)
+            .padding(.vertical, 9)
+            .background(RoundedRectangle(cornerRadius: 14).fill(Color.tertiaryBackground))
     }
 
     /// A muted body silhouette + message when the period has no sets — themed to the muscle split
@@ -76,31 +112,6 @@ struct MuscleBalanceTile: View {
         }
         .frame(maxWidth: .infinity)
         .padding(.vertical, 14)
-    }
-
-    /// The two groups furthest from target — the most informative rows for a compact tile.
-    private func topEntries(_ calculator: MuscleBalanceCalculator) -> [MuscleBalanceEntry] {
-        Array(calculator.entries.sorted { abs($0.deviation) > abs($1.deviation) }.prefix(2))
-    }
-
-    private func insightText(_ insight: MuscleBalanceInsight) -> String {
-        switch insight {
-        case .empty:
-            return NSLocalizedString("muscleBalanceEmpty", comment: "")
-        case .balanced:
-            return NSLocalizedString("muscleBalanceBalanced", comment: "")
-        case let .mostTrained(group):
-            return String(format: NSLocalizedString("muscleBalanceMostTrained", comment: ""), group.description)
-        case let .behind(group, setsToGo):
-            switch period {
-            case .week:
-                return String(format: NSLocalizedString("muscleBalanceSetsToGo", comment: ""), group.description, setsToGo)
-            case .month:
-                return String(format: NSLocalizedString("muscleBalanceLightMonth", comment: ""), group.description)
-            case .year:
-                return String(format: NSLocalizedString("muscleBalanceLightYear", comment: ""), group.description)
-            }
-        }
     }
 }
 

--- a/LOGIT/Services/MuscleBalanceCalculator.swift
+++ b/LOGIT/Services/MuscleBalanceCalculator.swift
@@ -7,9 +7,14 @@
 
 import Foundation
 
+/// Where a muscle group sits against its target — under (too little), on target, or over (too much).
+enum MuscleBalanceState {
+    case under, onTarget, over
+}
+
 /// One muscle group's standing against its target, for a given period: how many sets trained it, what
 /// share of the period that is, and how far that share sits from the user's target. The diverging
-/// `MuscleBalanceBar` and the Summary tile render off these.
+/// `MuscleBalanceBar` (Summary tile, overview sections, single-muscle detail) renders off these.
 struct MuscleBalanceEntry: Identifiable {
     let muscleGroup: MuscleGroup
     /// Set occurrences training this group in the period (a super set counts toward both its groups,
@@ -23,44 +28,33 @@ struct MuscleBalanceEntry: Identifiable {
 
     var id: MuscleGroup { muscleGroup }
 
-    /// Signed gap from target in percentage points — negative means under-trained.
+    /// Signed gap from target in percentage points — negative means under-trained. The diverging
+    /// `MuscleBalanceBar` grows out of the target tick by this much, left (under) or right (over).
     var deviation: Int { actualPercent - targetPercent }
 
-    /// Under target by more than the threshold — the only state the bars and insight ever call out
-    /// (over is never flagged; muscle hues are identity, not warning).
-    var isBehind: Bool { deviation < -MuscleTargetSplit.behindThreshold }
+    /// Where the group sits relative to target: under / over (more than `behindThreshold` points off)
+    /// or on target (within the band). Drives the grouped lists and the state pill.
+    var state: MuscleBalanceState {
+        if deviation < -MuscleTargetSplit.behindThreshold { return .under }
+        if deviation > MuscleTargetSplit.behindThreshold { return .over }
+        return .onTarget
+    }
+
+    /// Under target by more than the threshold ("build up").
+    var isBehind: Bool { state == .under }
 
     /// Within the threshold band either side of target.
-    var isOnTarget: Bool { abs(deviation) <= MuscleTargetSplit.behindThreshold }
+    var isOnTarget: Bool { state == .onTarget }
 }
 
-/// A period-aware, one-line read of a balance — what the Summary Muscle Balance tile leads with. Kept
-/// as data (not a localized string) so the calculator stays pure and testable; the view turns it into
-/// period-aware copy ("Legs 3 sets to go" for a week, "Legs light this month" for a month).
-enum MuscleBalanceInsight: Equatable {
-    /// No sets logged in the period.
-    case empty
-    /// A major/compound group (legs, back) is meaningfully under target. `setsToGo` is how many more
-    /// sets would reach the target share — the concrete week framing.
-    case behind(MuscleGroup, setsToGo: Int)
-    /// One group dominates the spread, but nothing's under target — a neutral "most trained" read.
-    case mostTrained(MuscleGroup)
-    /// Everything sits close to target.
-    case balanced
-}
-
-/// Turns a period's workouts + the user's target split into per-group balance entries and a single
-/// non-nagging insight. Period-agnostic: the caller supplies the date window (filtering the top-level
-/// `[Workout]` in memory, or via `WorkoutPredicateFactory.getWorkouts(from:to:)`).
+/// Turns a period's workouts + the user's target split into per-group balance entries. Period-agnostic:
+/// the caller supplies the date window (filtering the top-level `[Workout]` in memory, or via
+/// `WorkoutPredicateFactory.getWorkouts(from:to:)`).
 struct MuscleBalanceCalculator {
     /// One entry per muscle group, in `MuscleGroup.allCases` order (zero-filled for untrained groups).
     let entries: [MuscleBalanceEntry]
     /// Total set occurrences across all groups in the period.
     let totalSets: Int
-
-    /// Major/compound groups — the only ones whose under-training the insight will flag, per the
-    /// non-nagging rule (never nag a deliberately-light abs/cardio, never flag "over").
-    private static let majorGroups: [MuscleGroup] = [.legs, .back]
 
     init(
         workouts: [Workout],
@@ -92,42 +86,15 @@ struct MuscleBalanceCalculator {
         entries.filter(\.isOnTarget).count
     }
 
-    /// Entries sorted most-under-target first — the Overview list and the Summary tile show the
-    /// largest gaps at the top.
-    func worstGapSorted() -> [MuscleBalanceEntry] {
-        entries.sorted { $0.deviation < $1.deviation }
+    /// Under-target groups, most points under first (longest bar first) — the "Below target" list;
+    /// the Summary tile leads with these.
+    func underTargets() -> [MuscleBalanceEntry] {
+        entries.filter { $0.state == .under }.sorted { $0.deviation < $1.deviation }
     }
 
-    // MARK: - Insight
-
-    func insight(for period: StatPeriod) -> MuscleBalanceInsight {
-        guard totalSets > 0 else { return .empty }
-
-        // Weekly set counts are noisy, so a week needs a wider gap before it flags anything.
-        let tolerance = period == .week
-            ? MuscleTargetSplit.behindThreshold + 3
-            : MuscleTargetSplit.behindThreshold
-
-        let behindMajor = entries
-            .filter { Self.majorGroups.contains($0.muscleGroup) && $0.deviation <= -tolerance }
-            .min { $0.deviation < $1.deviation }
-        if let entry = behindMajor {
-            return .behind(entry.muscleGroup, setsToGo: setsToGo(for: entry))
-        }
-
-        // Nothing under target. Call out a clearly-dominant group, else read as balanced.
-        if let top = entries.max(by: { $0.deviation < $1.deviation }),
-           top.deviation >= MuscleTargetSplit.behindThreshold,
-           top.setCount > 0 {
-            return .mostTrained(top.muscleGroup)
-        }
-        return .balanced
-    }
-
-    /// How many more sets the group needs to reach its target share of the current total.
-    private func setsToGo(for entry: MuscleBalanceEntry) -> Int {
-        let targetSets = Int((Double(entry.targetPercent) / 100.0 * Double(totalSets)).rounded())
-        return max(0, targetSets - entry.setCount)
+    /// Over-target groups, most over first — the "Above target" list, shown after the under ones.
+    func overTargets() -> [MuscleBalanceEntry] {
+        entries.filter { $0.state == .over }.sorted { $0.deviation > $1.deviation }
     }
 
     // MARK: - Rounding

--- a/LOGIT/Services/MuscleBalanceHistory.swift
+++ b/LOGIT/Services/MuscleBalanceHistory.swift
@@ -1,0 +1,101 @@
+//
+//  MuscleBalanceHistory.swift
+//  LOGIT
+//
+//  Created by Lukas Kaibel on 01.07.26.
+//
+
+import Foundation
+
+/// One period instance (a specific week / month / year) in the Muscle Groups overview's history strip:
+/// its start date, the short label under its bar, the fuller title the selected-period header shows, and
+/// the balance calculator for the sets trained in it. The overview builds `bucketCount(for:)` of these
+/// back from now, renders them as the normalized segmented bar chart, and drives the value columns off
+/// whichever bucket is selected.
+struct MuscleBalanceBucket: Identifiable {
+    /// Stable, unique key — the period start's epoch seconds. Used as the chart's x-category and the
+    /// selection value, since the human labels aren't guaranteed unique across a window.
+    let id: String
+    let start: Date
+    /// Short label under the bar (e.g. "16", "Jun", "2026").
+    let axisLabel: String
+    /// Full title for the selected-period header (e.g. "This Week", "Jun 9", "June", "2026").
+    let title: String
+    let calculator: MuscleBalanceCalculator
+
+    var totalSets: Int { calculator.totalSets }
+}
+
+/// Builds the Muscle Groups overview's history strip: a run of `MuscleBalanceBucket`s, oldest first, one
+/// per period back from now — reusing `StatPeriod.range(periodsAgo:)` (the same windowing every trend
+/// pill uses) so the week boundary respects the user's locale.
+enum MuscleBalanceHistory {
+    /// How many periods back the chart shows for each granularity — sized for the slim-candle chart,
+    /// which trades bar width for a longer window.
+    static func bucketCount(for period: StatPeriod) -> Int {
+        switch period {
+        case .week: return 12
+        case .month: return 12
+        case .year: return 6
+        }
+    }
+
+    /// The history strip, oldest bucket first → newest last (index `count - 1` is the current period).
+    static func buckets(
+        from workouts: [Workout],
+        period: StatPeriod,
+        target: MuscleTargetSplit,
+        muscleGroupService: MuscleGroupService,
+        now: Date = .now
+    ) -> [MuscleBalanceBucket] {
+        let count = bucketCount(for: period)
+        return (0 ..< count).reversed().map { periodsAgo in
+            let range = period.range(periodsAgo: periodsAgo, from: now)
+            let start = range.lowerBound
+            let periodWorkouts = workouts.filter { ($0.date).map { range.contains($0) } ?? false }
+            return MuscleBalanceBucket(
+                id: String(Int(start.timeIntervalSince1970)),
+                start: start,
+                axisLabel: axisLabel(for: start, period: period),
+                title: title(for: start, period: period, isCurrent: periodsAgo == 0),
+                calculator: MuscleBalanceCalculator(
+                    workouts: periodWorkouts,
+                    target: target,
+                    muscleGroupService: muscleGroupService
+                )
+            )
+        }
+    }
+
+    // MARK: - Labels
+
+    private static func axisLabel(for date: Date, period: StatPeriod) -> String {
+        switch period {
+        case .week: return date.formatted(.dateTime.day())
+        // Single-letter months — twelve slim candles leave no room for "Jun"-style labels.
+        case .month: return date.formatted(.dateTime.month(.narrow))
+        case .year: return date.formatted(.dateTime.year())
+        }
+    }
+
+    private static func title(for date: Date, period: StatPeriod, isCurrent: Bool) -> String {
+        if isCurrent {
+            switch period {
+            case .week: return NSLocalizedString("thisWeek", comment: "")
+            case .month: return NSLocalizedString("thisMonth", comment: "")
+            case .year: return NSLocalizedString("thisYear", comment: "")
+            }
+        }
+        switch period {
+        case .week:
+            return date.formatted(.dateTime.month(.abbreviated).day())
+        case .month:
+            let sameYear = Calendar.current.isDate(date, equalTo: .now, toGranularity: .year)
+            return sameYear
+                ? date.formatted(.dateTime.month(.wide))
+                : date.formatted(.dateTime.month(.abbreviated).year())
+        case .year:
+            return date.formatted(.dateTime.year())
+        }
+    }
+}

--- a/LOGIT/SharedUI/Charts/MuscleBalanceHistoryChart.swift
+++ b/LOGIT/SharedUI/Charts/MuscleBalanceHistoryChart.swift
@@ -1,0 +1,84 @@
+//
+//  MuscleBalanceHistoryChart.swift
+//  LOGIT
+//
+//  Created by Lukas Kaibel on 01.07.26.
+//
+
+import Charts
+import SwiftUI
+
+/// The Muscle Groups overview's history chart: one slim, normalized (0–100 %) candle per period, each
+/// a continuous stack of the muscle-group colours — segments fused with no gaps and no inner rounding,
+/// the whole candle capped once at its top and bottom. Tapping a candle selects that period — the
+/// parent's donut and sections rebind to it — and the selected candle shows in full colour with an
+/// accent-underlined label while the rest dim. The x-categories are the buckets' stable ids (not their
+/// labels, which needn't be unique across a window).
+struct MuscleBalanceHistoryChart: View {
+    let buckets: [MuscleBalanceBucket]
+    /// Bottom→top stack order — biggest target share first, stable across periods.
+    let orderedGroups: [MuscleGroup]
+    /// The resolved selection (falls back to the newest bucket with sets when nothing is tapped yet).
+    let selectedID: String
+    @Binding var rawSelection: String?
+
+    private static let barWidth: CGFloat = 10
+    private static let capRadius: CGFloat = 5
+
+    var body: some View {
+        Chart {
+            ForEach(buckets) { bucket in
+                let stacked = stackedGroups(in: bucket)
+                ForEach(Array(stacked.enumerated()), id: \.element.group) { index, item in
+                    BarMark(
+                        x: .value("Period", bucket.id),
+                        y: .value("Share", item.percent),
+                        width: .fixed(Self.barWidth)
+                    )
+                    .foregroundStyle(item.group.color)
+                    .opacity(bucket.id == selectedID ? 1 : 0.32)
+                    // Segments fuse into one candle: square inner edges, the candle's own ends capped.
+                    .clipShape(UnevenRoundedRectangle(
+                        topLeadingRadius: index == stacked.count - 1 ? Self.capRadius : 0,
+                        bottomLeadingRadius: index == 0 ? Self.capRadius : 0,
+                        bottomTrailingRadius: index == 0 ? Self.capRadius : 0,
+                        topTrailingRadius: index == stacked.count - 1 ? Self.capRadius : 0
+                    ))
+                }
+            }
+        }
+        .chartXScale(domain: buckets.map(\.id))
+        .chartYScale(domain: 0 ... 100)
+        .chartXSelection(value: $rawSelection)
+        .chartYAxis(.hidden)
+        .chartXAxis {
+            AxisMarks(values: buckets.map(\.id)) { value in
+                if let id = value.as(String.self), let bucket = buckets.first(where: { $0.id == id }) {
+                    AxisValueLabel {
+                        VStack(spacing: 3) {
+                            Text(bucket.axisLabel)
+                                .font(.system(size: 10, weight: id == selectedID ? .bold : .semibold, design: .rounded))
+                                .foregroundStyle(id == selectedID ? Color.label : Color.secondaryLabel)
+                                .fixedSize()
+                            Capsule()
+                                .fill(id == selectedID ? Color.accentColor : Color.clear)
+                                .frame(width: 14, height: 2.5)
+                        }
+                    }
+                }
+            }
+        }
+        .animation(.snappy(duration: 0.3), value: selectedID)
+        .frame(height: 150)
+    }
+
+    /// The bucket's trained groups in stack order (bottom first) — Charts stacks marks in declaration
+    /// order, and knowing the first/last lets the candle's outer ends carry the only rounding.
+    private func stackedGroups(in bucket: MuscleBalanceBucket) -> [(group: MuscleGroup, percent: Int)] {
+        orderedGroups.compactMap { group in
+            guard let entry = bucket.calculator.entries.first(where: { $0.muscleGroup == group }),
+                  entry.actualPercent > 0 else { return nil }
+            return (group, entry.actualPercent)
+        }
+    }
+}

--- a/LOGIT/SharedUI/Views/MuscleBalanceBar.swift
+++ b/LOGIT/SharedUI/Views/MuscleBalanceBar.swift
@@ -7,21 +7,21 @@
 
 import SwiftUI
 
-/// The shared "balance vs target" diverging bar (`balance-row-lab.html` variant 1): a centred white
-/// tick marks the target, and a capsule in the muscle's own colour grows left (under target) or right
-/// (over target) by how far the actual share sits from it — never amber/red, since muscle hues are
-/// identity, not warning. The target percent is printed above the tick; the signed deviation sits to
-/// the right. Shared by the Summary Muscle Balance tile, the Muscle Groups overview list, and the
-/// muscle-detail target-share tile.
+/// The shared "balance vs target" diverging bar: a centred white tick marks the target, and a fill in
+/// the muscle's own colour grows out of it — left when under target, right when over — by how far the
+/// actual share sits from it. The fill is flat on the side that touches the tick and rounded only at
+/// its outer end, so it visibly grows out of the target. The target percent sits above the tick; the
+/// signed deviation to the right. Never amber/red — muscle hues are identity, not warning. Shared by
+/// the Summary Muscle Balance tile, the Muscle Groups overview sections, and the single-muscle
+/// detail's target-share tile.
 struct MuscleBalanceBar: View {
     let entry: MuscleBalanceEntry
-    /// Leading muscle name + colour dot — on in the lists, off where a row already names the group.
+    /// Leading muscle name in its colour — on in the lists, off where a row already names the group.
     var showsName: Bool = false
     /// Trailing signed deviation label.
     var showsDelta: Bool = true
 
-    /// A deviation of this many percentage points fills half the track; beyond it the capsule is
-    /// clamped to the half-track. 10pt → half.
+    /// A deviation of this many percentage points fills half the track; beyond it the fill clamps.
     private static let half: Double = 10
 
     private var color: Color { entry.muscleGroup.color }
@@ -30,35 +30,27 @@ struct MuscleBalanceBar: View {
 
     var body: some View {
         HStack(spacing: 10) {
-            if showsName {
-                name
-            }
+            if showsName { name }
             VStack(spacing: 5) {
                 Text("\(entry.targetPercent)%")
-                    .font(.system(size: 11, weight: .bold))
+                    .font(.system(size: 11, weight: .bold, design: .rounded))
                     .foregroundStyle(.secondary)
                     .monospacedDigit()
                 bar
             }
-            if showsDelta {
-                delta
-            }
+            if showsDelta { delta }
         }
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(accessibilityLabel)
     }
 
     private var name: some View {
-        HStack(spacing: 7) {
-            RoundedRectangle(cornerRadius: 3)
-                .fill(color)
-                .frame(width: 9, height: 9)
-            Text(entry.muscleGroup.description)
-                .font(.system(size: 13, weight: .semibold))
-                .lineLimit(1)
-                .minimumScaleFactor(0.8)
-        }
-        .frame(width: 78, alignment: .leading)
+        Text(entry.muscleGroup.description)
+            .font(.system(size: 13, weight: .bold, design: .rounded))
+            .foregroundStyle(color)
+            .lineLimit(1)
+            .minimumScaleFactor(0.8)
+            .frame(width: 78, alignment: .leading)
     }
 
     private var bar: some View {
@@ -69,10 +61,17 @@ struct MuscleBalanceBar: View {
                 Capsule()
                     .fill(Color.white.opacity(0.06))
                     .frame(height: 2)
-                Capsule()
-                    .fill(color)
-                    .frame(width: fillWidth, height: 9)
-                    .offset(x: deviation >= 0 ? fillWidth / 2 : -fillWidth / 2)
+                // Flat against the tick, rounded only at the outer end — the fill grows out of the
+                // target rather than floating beside it.
+                UnevenRoundedRectangle(
+                    topLeadingRadius: deviation < 0 ? 4 : 0,
+                    bottomLeadingRadius: deviation < 0 ? 4 : 0,
+                    bottomTrailingRadius: deviation > 0 ? 4 : 0,
+                    topTrailingRadius: deviation > 0 ? 4 : 0
+                )
+                .fill(color)
+                .frame(width: fillWidth, height: 9)
+                .offset(x: deviation >= 0 ? fillWidth / 2 : -fillWidth / 2)
                 Rectangle()
                     .fill(Color.white)
                     .frame(width: 2, height: 15)
@@ -84,15 +83,17 @@ struct MuscleBalanceBar: View {
 
     private var delta: some View {
         Text(deltaText)
-            .font(.system(size: 12, weight: .bold))
+            .font(.system(size: 12, weight: .bold, design: .rounded))
             .foregroundStyle(.secondary)
             .monospacedDigit()
-            .frame(width: 32, alignment: .trailing)
+            .lineLimit(1)
+            .fixedSize()
+            .frame(width: 44, alignment: .trailing)
     }
 
     private var deltaText: String {
-        if deviation == 0 { return "±0" }
-        return deviation > 0 ? "+\(deviation)" : "−\(abs(deviation))"
+        if deviation == 0 { return "±0%" }
+        return deviation > 0 ? "+\(deviation)%" : "−\(abs(deviation))%"
     }
 
     private var accessibilityLabel: Text {
@@ -109,18 +110,10 @@ struct MuscleBalanceBar: View {
 
 #Preview {
     VStack(spacing: 16) {
-        MuscleBalanceBar(
-            entry: MuscleBalanceEntry(muscleGroup: .chest, setCount: 47, actualPercent: 24, targetPercent: 16),
-            showsName: true
-        )
-        MuscleBalanceBar(
-            entry: MuscleBalanceEntry(muscleGroup: .legs, setCount: 18, actualPercent: 9, targetPercent: 20),
-            showsName: true
-        )
-        MuscleBalanceBar(
-            entry: MuscleBalanceEntry(muscleGroup: .back, setCount: 30, actualPercent: 18, targetPercent: 18),
-            showsName: true
-        )
+        MuscleBalanceBar(entry: MuscleBalanceEntry(muscleGroup: .legs, setCount: 17, actualPercent: 13, targetPercent: 20), showsName: true)
+        MuscleBalanceBar(entry: MuscleBalanceEntry(muscleGroup: .chest, setCount: 30, actualPercent: 23, targetPercent: 16), showsName: true)
+        MuscleBalanceBar(entry: MuscleBalanceEntry(muscleGroup: .back, setCount: 24, actualPercent: 18, targetPercent: 18), showsName: true)
     }
     .padding()
+    .preferredColorScheme(.dark)
 }


### PR DESCRIPTION
## What

Final muscle-balance design, converged over several mockup rounds:

**Muscle Groups overview**
- The muscle-group **occurrence donut** leads the screen (period's total sets in the centre, period name beneath), Week / Month / Year above.
- Groups split into **↓ Below target · ↑ Above target · ✓ On target** — arrows and words now describe the same thing (state), fixing the old "↓ Build up" mixed message.
- Rows are the diverging `MuscleBalanceBar`: target % above a centred white tick, the muscle-colour fill **growing out of the tick** — flat on the tick side, rounded only at the outer end — signed delta right.
- **Balance over time**: one slim normalized candle per period (week 12 / month 12 / year 6), segments fused (no gaps, no inner rounding, capped once top & bottom), single-letter month labels. **Tap a candle → donut + sections rebind** with a numeral roll and selection haptic.

**Summary tile** — back to three diverging-bar rows, below-target first, "+N more", "N of 8 on target".

**Single-muscle screen** — Target Share tile restored: share caption + state pill ("↓ Below target / ↑ Above target / ✓ On target") + the same bar; stat grid, 12-week sets chart and top exercises unchanged.

**App-wide sweep** — muscle names never render as a colour dot + white text anymore; the name itself carries the colour, bold and rounded (nav title, target-split editor rows, stale ghost-tile dot).

New shared pieces: `MuscleBalanceHistory` (period buckets), `MuscleBalanceHistoryChart` (slim candles). Two new localized keys + four section/empty-state keys across all 8 languages.

## Verification

- Built clean, **0 warnings**.
- Sim-verified on iPhone 17 Pro with seeded data: overview (donut + sections + 12-candle chart with selection), Summary tile, single-muscle hero (below- and above-target states), target-split editor, empty states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)