### PR TITLE
Add Summary Progress tab and polish the stat tiles & detail chart

### DIFF
--- a/LOGIT.xcodeproj/project.pbxproj
+++ b/LOGIT.xcodeproj/project.pbxproj
@@ -13,7 +13,6 @@
 		268525E87C3944BA9208D129 /* TrendIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D5D5995AEAE4AA8849AAF28 /* TrendIndicatorView.swift */; };
 		D1D1D1000000000000000B01 /* MetricTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1D1D1000000000000000F01 /* MetricTile.swift */; };
 		73A9CED8C934FDF36F9C4061 /* BodyMapFigure.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBBF6087BB65A5971FB5F866 /* BodyMapFigure.swift */; };
-		32F28EA03B1B20126629D2CA /* MuscleBalanceBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 619AAE029DDA528253A6AF0B /* MuscleBalanceBar.swift */; };
 		2BD2E4720FB2C657F8CA372B /* CompletionRing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C72085C4C10146858277690 /* CompletionRing.swift */; };
 		77B7E6990E4C00B75D9BC6ED /* PeriodPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA597E1519E8F6D2CBC8F9E /* PeriodPicker.swift */; };
 		E1E1E1000000000000000B12 /* ProgressIndicatorPill.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1E1E1000000000000000F12 /* ProgressIndicatorPill.swift */; };
@@ -159,6 +158,7 @@
 		801BBDCF2DF7338A00CDB1FB /* ExerciseService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBCB82DF7338A00CDB1FB /* ExerciseService.swift */; };
 		801BBDD12DF7338A00CDB1FB /* Widget+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBCDB2DF7338A00CDB1FB /* Widget+.swift */; };
 		801BBDD22DF7338A00CDB1FB /* MuscleGroupSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBD542DF7338A00CDB1FB /* MuscleGroupSelector.swift */; };
+		A1B2C3D4E5F600000007B007 /* MuscleBalanceBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F600000007F007 /* MuscleBalanceBar.swift */; };
 		801BBDD32DF7338A00CDB1FB /* SectionedFetchRequestWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBCE22DF7338A00CDB1FB /* SectionedFetchRequestWrapper.swift */; };
 		801BBDD52DF7338A00CDB1FB /* WorkoutDetailSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBD212DF7338A00CDB1FB /* WorkoutDetailSheet.swift */; };
 		801BBDD62DF7338A00CDB1FB /* TipView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBD582DF7338A00CDB1FB /* TipView.swift */; };
@@ -205,11 +205,12 @@
 		801BBE002DF7338A00CDB1FB /* String+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBCB32DF7338A00CDB1FB /* String+.swift */; };
 		801BBE012DF7338A00CDB1FB /* Database+EntityCreation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBCC32DF7338A00CDB1FB /* Database+EntityCreation.swift */; };
 		801BBE022DF7338A00CDB1FB /* OverallSetsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBD022DF7338A00CDB1FB /* OverallSetsScreen.swift */; };
+		79BB043F7BA96F3DE3739FB7 /* SummaryEmptyStates.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC42311A655A248061E11238 /* SummaryEmptyStates.swift */; };
 		1E7CF1C1E77503BD192ECE23 /* WorkoutGoalScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA376FF1C58639B7542A334 /* WorkoutGoalScreen.swift */; };
 		E18E0521AED5762B30E5FA1F /* MuscleGroupDetailScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFD9E1A9B2D266CBA7AE5F18 /* MuscleGroupDetailScreen.swift */; };
 		D0AF3C855D8D73E72DA7AF92 /* SummaryWelcomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E62F41D02C28CB089872E955 /* SummaryWelcomeView.swift */; };
 		23A5FD0EA5AC115CC0EC34E6 /* SummaryRecords.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADFEC5772AE8932AA1089603 /* SummaryRecords.swift */; };
-		79BB043F7BA96F3DE3739FB7 /* SummaryEmptyStates.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC42311A655A248061E11238 /* SummaryEmptyStates.swift */; };
+		FE01CA11AB1E5077AE000002 /* SummaryProgressTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE01CA11AB1E5077AE000001 /* SummaryProgressTab.swift */; };
 		BACD36D82914BE00C27FE040 /* MuscleTargetSplitScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80C7068F531DB65831E8FA8F /* MuscleTargetSplitScreen.swift */; };
 		07A5D2C54CA81141164E3D9D /* MuscleGroupsOverviewScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54FB7DD2DDA0DE70BD366F9C /* MuscleGroupsOverviewScreen.swift */; };
 		85D5027D8B1FA8DB36998EBC /* SummaryStatScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE557E27ADC9A2C02BE79DBE /* SummaryStatScreen.swift */; };
@@ -349,7 +350,6 @@
 		0D5D5995AEAE4AA8849AAF28 /* TrendIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrendIndicatorView.swift; sourceTree = "<group>"; };
 		D1D1D1000000000000000F01 /* MetricTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetricTile.swift; sourceTree = "<group>"; };
 		BBBF6087BB65A5971FB5F866 /* BodyMapFigure.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BodyMapFigure.swift; sourceTree = "<group>"; };
-		619AAE029DDA528253A6AF0B /* MuscleBalanceBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MuscleBalanceBar.swift; sourceTree = "<group>"; };
 		3C72085C4C10146858277690 /* CompletionRing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionRing.swift; sourceTree = "<group>"; };
 		BEA597E1519E8F6D2CBC8F9E /* PeriodPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeriodPicker.swift; sourceTree = "<group>"; };
 		E1E1E1000000000000000F12 /* ProgressIndicatorPill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressIndicatorPill.swift; sourceTree = "<group>"; };
@@ -476,11 +476,12 @@
 		801BBCFF2DF7338A00CDB1FB /* HomeNavigationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeNavigationCoordinator.swift; sourceTree = "<group>"; };
 		801BBD002DF7338A00CDB1FB /* HomeScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeScreen.swift; sourceTree = "<group>"; };
 		801BBD022DF7338A00CDB1FB /* OverallSetsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverallSetsScreen.swift; sourceTree = "<group>"; };
+		DC42311A655A248061E11238 /* SummaryEmptyStates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryEmptyStates.swift; sourceTree = "<group>"; };
 		8BA376FF1C58639B7542A334 /* WorkoutGoalScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutGoalScreen.swift; sourceTree = "<group>"; };
 		FFD9E1A9B2D266CBA7AE5F18 /* MuscleGroupDetailScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MuscleGroupDetailScreen.swift; sourceTree = "<group>"; };
 		E62F41D02C28CB089872E955 /* SummaryWelcomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryWelcomeView.swift; sourceTree = "<group>"; };
 		ADFEC5772AE8932AA1089603 /* SummaryRecords.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryRecords.swift; sourceTree = "<group>"; };
-		DC42311A655A248061E11238 /* SummaryEmptyStates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryEmptyStates.swift; sourceTree = "<group>"; };
+		FE01CA11AB1E5077AE000001 /* SummaryProgressTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryProgressTab.swift; sourceTree = "<group>"; };
 		80C7068F531DB65831E8FA8F /* MuscleTargetSplitScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MuscleTargetSplitScreen.swift; sourceTree = "<group>"; };
 		54FB7DD2DDA0DE70BD366F9C /* MuscleGroupsOverviewScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MuscleGroupsOverviewScreen.swift; sourceTree = "<group>"; };
 		DE557E27ADC9A2C02BE79DBE /* SummaryStatScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryStatScreen.swift; sourceTree = "<group>"; };
@@ -554,6 +555,7 @@
 		801BBD522DF7338A00CDB1FB /* IntegerField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegerField.swift; sourceTree = "<group>"; };
 		801BBD532DF7338A00CDB1FB /* LogitProLogo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogitProLogo.swift; sourceTree = "<group>"; };
 		801BBD542DF7338A00CDB1FB /* MuscleGroupSelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MuscleGroupSelector.swift; sourceTree = "<group>"; };
+		A1B2C3D4E5F600000007F007 /* MuscleBalanceBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MuscleBalanceBar.swift; sourceTree = "<group>"; };
 		801BBD552DF7338A00CDB1FB /* NavigationChevron.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationChevron.swift; sourceTree = "<group>"; };
 		801BBD562DF7338A00CDB1FB /* ReorderableForEach.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReorderableForEach.swift; sourceTree = "<group>"; };
 		801BBD582DF7338A00CDB1FB /* TipView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TipView.swift; sourceTree = "<group>"; };
@@ -1026,11 +1028,12 @@
 				801BBCFF2DF7338A00CDB1FB /* HomeNavigationCoordinator.swift */,
 				801BBD002DF7338A00CDB1FB /* HomeScreen.swift */,
 				801BBD022DF7338A00CDB1FB /* OverallSetsScreen.swift */,
+				DC42311A655A248061E11238 /* SummaryEmptyStates.swift */,
 				8BA376FF1C58639B7542A334 /* WorkoutGoalScreen.swift */,
 				FFD9E1A9B2D266CBA7AE5F18 /* MuscleGroupDetailScreen.swift */,
 				E62F41D02C28CB089872E955 /* SummaryWelcomeView.swift */,
 				ADFEC5772AE8932AA1089603 /* SummaryRecords.swift */,
-				DC42311A655A248061E11238 /* SummaryEmptyStates.swift */,
+				FE01CA11AB1E5077AE000001 /* SummaryProgressTab.swift */,
 				80C7068F531DB65831E8FA8F /* MuscleTargetSplitScreen.swift */,
 				54FB7DD2DDA0DE70BD366F9C /* MuscleGroupsOverviewScreen.swift */,
 				DE557E27ADC9A2C02BE79DBE /* SummaryStatScreen.swift */,
@@ -1248,6 +1251,7 @@
 				801BBD522DF7338A00CDB1FB /* IntegerField.swift */,
 				801BBD532DF7338A00CDB1FB /* LogitProLogo.swift */,
 				801BBD542DF7338A00CDB1FB /* MuscleGroupSelector.swift */,
+				A1B2C3D4E5F600000007F007 /* MuscleBalanceBar.swift */,
 				801BBD552DF7338A00CDB1FB /* NavigationChevron.swift */,
 				801BBD562DF7338A00CDB1FB /* ReorderableForEach.swift */,
 				801BBD582DF7338A00CDB1FB /* TipView.swift */,
@@ -1255,7 +1259,6 @@
 				0D5D5995AEAE4AA8849AAF28 /* TrendIndicatorView.swift */,
 				D1D1D1000000000000000F01 /* MetricTile.swift */,
 				BBBF6087BB65A5971FB5F866 /* BodyMapFigure.swift */,
-				619AAE029DDA528253A6AF0B /* MuscleBalanceBar.swift */,
 				3C72085C4C10146858277690 /* CompletionRing.swift */,
 				BEA597E1519E8F6D2CBC8F9E /* PeriodPicker.swift */,
 				E1E1E1000000000000000F12 /* ProgressIndicatorPill.swift */,
@@ -1655,7 +1658,6 @@
 				268525E87C3944BA9208D129 /* TrendIndicatorView.swift in Sources */,
 				D1D1D1000000000000000B01 /* MetricTile.swift in Sources */,
 				73A9CED8C934FDF36F9C4061 /* BodyMapFigure.swift in Sources */,
-				32F28EA03B1B20126629D2CA /* MuscleBalanceBar.swift in Sources */,
 				2BD2E4720FB2C657F8CA372B /* CompletionRing.swift in Sources */,
 				77B7E6990E4C00B75D9BC6ED /* PeriodPicker.swift in Sources */,
 				E1E1E1000000000000000B12 /* ProgressIndicatorPill.swift in Sources */,
@@ -1721,6 +1723,7 @@
 				801BBDCF2DF7338A00CDB1FB /* ExerciseService.swift in Sources */,
 				801BBDD12DF7338A00CDB1FB /* Widget+.swift in Sources */,
 				801BBDD22DF7338A00CDB1FB /* MuscleGroupSelector.swift in Sources */,
+				A1B2C3D4E5F600000007B007 /* MuscleBalanceBar.swift in Sources */,
 				801BBDD32DF7338A00CDB1FB /* SectionedFetchRequestWrapper.swift in Sources */,
 				801BBDD52DF7338A00CDB1FB /* WorkoutDetailSheet.swift in Sources */,
 				801BBDD62DF7338A00CDB1FB /* TipView.swift in Sources */,
@@ -1779,11 +1782,12 @@
 				801BBE002DF7338A00CDB1FB /* String+.swift in Sources */,
 				801BBE012DF7338A00CDB1FB /* Database+EntityCreation.swift in Sources */,
 				801BBE022DF7338A00CDB1FB /* OverallSetsScreen.swift in Sources */,
+				79BB043F7BA96F3DE3739FB7 /* SummaryEmptyStates.swift in Sources */,
 				1E7CF1C1E77503BD192ECE23 /* WorkoutGoalScreen.swift in Sources */,
 				E18E0521AED5762B30E5FA1F /* MuscleGroupDetailScreen.swift in Sources */,
 				D0AF3C855D8D73E72DA7AF92 /* SummaryWelcomeView.swift in Sources */,
 				23A5FD0EA5AC115CC0EC34E6 /* SummaryRecords.swift in Sources */,
-				79BB043F7BA96F3DE3739FB7 /* SummaryEmptyStates.swift in Sources */,
+				FE01CA11AB1E5077AE000002 /* SummaryProgressTab.swift in Sources */,
 				BACD36D82914BE00C27FE040 /* MuscleTargetSplitScreen.swift in Sources */,
 				07A5D2C54CA81141164E3D9D /* MuscleGroupsOverviewScreen.swift in Sources */,
 				85D5027D8B1FA8DB36998EBC /* SummaryStatScreen.swift in Sources */,

--- a/LOGIT/Core/Environment/de.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/de.lproj/Localizable.strings
@@ -470,6 +470,7 @@
 // MARK: - W
 
 "week" = "Woche";
+"weeks" = "Wochen";
 "weekly" = "Wöchentlich";
 "weeklyAverage" = "Wochenschnitt";
 "weeklyTarget" = "Wochenziel";
@@ -486,6 +487,20 @@
 "weekOfThe" = "Woche vom";
 "workout" = "Workout";
 "workoutGoal" = "Workout Ziel";
+
+// MARK: - Workout Goal screen
+"streakStartPrompt" = "Erreiche dein Wochenziel, um eine Serie zu starten";
+"streakFactMonth" = "Ein ganzer Monat";
+"streakFactQuarter" = "Ein ganzes Quartal";
+"streakFactHalfYear" = "Ein halbes Jahr";
+"streakFactYear" = "Ein ganzes Jahr";
+"streakFactTwoYears" = "Zwei Jahre";
+"nextMilestone" = "Nächster Meilenstein";
+"streakToGoalOne" = "Noch 1 Woche bis zum nächsten Meilenstein";
+"streakToGoalMany" = "Noch %d Wochen bis zum nächsten Meilenstein";
+"streakAtBest" = "Deine beste Serie aller Zeiten";
+"streakToBeatRecordOne" = "Noch 1 Woche bis zum Rekord";
+"streakToBeatRecordMany" = "Noch %d Wochen bis zum Rekord";
 "workoutHistory" = "Verlauf";
 "workouts" = "Workouts";
 "workoutTarget" = "Workout Ziel";
@@ -981,23 +996,45 @@
 "muscleDetailPercentOfSets" = "%d%% der Sätze";
 "weekStreakSuffix" = "Wochen-Streak";
 "yearWeeksOnTarget" = "%1$d von %2$d Wochen im Ziel";
+"currentWeekNumber" = "Woche %d";
 "bestStreakLabel" = "Best · %d Wo.";
 "monthWorkoutsCount" = "%d Workouts";
 "muscleBalanceEmptySubtitle" = "Logge ein Workout, um deine Muskelverteilung zu sehen.";
+"muscleBalanceOverTime" = "Balance im Zeitverlauf";
+"muscleBalanceGridCaption" = "Anteil an Sätzen · vs. Ziel-Split";
+"muscleBalanceOnTargetShort" = "%d von 8 im Ziel";
+"muscleBalanceOnTrack" = "Auf Kurs";
+"muscleDetailRingCaption" = "Voller Ring = im Ziel · Ziel %d %%";
+"muscleDetailShareOverTime" = "Anteil im Zeitverlauf";
+"muscleBalanceBelowTarget" = "Unter dem Ziel";
+"muscleBalanceAboveTarget" = "Über dem Ziel";
 "pinKeyLifts" = "Hefte deine wichtigsten Übungen an";
 "chooseExercises" = "Übungen auswählen";
 "pinAMeasurement" = "Maß anheften";
 "trackMeasurements" = "Verfolge deine Maße";
 "unlockWithPro" = "Mit Pro freischalten";
 
-"currentWeekNumber" = "Woche %d";
-"nextMilestone" = "Nächster Meilenstein";
-"streakFactHalfYear" = "Ein halbes Jahr";
-"streakFactMonth" = "Ein ganzer Monat";
-"streakFactQuarter" = "Ein ganzes Quartal";
-"streakFactTwoYears" = "Zwei Jahre";
-"streakFactYear" = "Ein ganzes Jahr";
-"weeks" = "Wochen";
+/* Muscle Balance — ring grouping (under / over / on target) */
+"muscleBalanceBuildUp" = "Aufbauen";
+"muscleBalanceAhead" = "Voraus";
+"muscleBalanceOnTargetSection" = "Im Ziel";
+
+/* Muscle detail — ring hero + empty state */
+"muscleDetailTargetCaption" = "Ziel %d%%";
+"muscleDetailEmptySubtitle" = "Du hast diese Muskelgruppe im gewählten Zeitraum nicht trainiert.";
+
+/* Muscle Balance — tile "+N more" hint */
+"muscleBalanceMore" = "+%d weitere";
+
+
+/* Progress tab — overall progress trend */
+"overallProgress" = "Gesamtfortschritt";
+"trendingUp" = "Aufwärtstrend";
+"trendingSteady" = "Stabil";
+"trendingDown" = "Abwärtstrend";
+"byMuscleGroup" = "Nach Muskelgruppe";
+"overallProgressBasis" = "Geschätztes 1RM · letzte 8 Wochen vs. die 8 davor";
+"overallProgressEmpty" = "Logge weiter Workouts, um deinen Gesamttrend zu sehen.";
 "streak" = "Streak";
 
 /* Muscle Balance — donut overview, sections & history chart */

--- a/LOGIT/Core/Environment/en.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/en.lproj/Localizable.strings
@@ -474,6 +474,7 @@
 // MARK: - W
 
 "week" = "Week";
+"weeks" = "Weeks";
 "weekly" = "Weekly";
 "weeklyAverage" = "Weekly Average";
 "weeklyTarget" = "Weekly Target";
@@ -490,6 +491,20 @@
 "weekOfThe" = "Week of the";
 "workout" = "Workout";
 "workoutGoal" = "Workout Goal";
+
+// MARK: - Workout Goal screen
+"streakStartPrompt" = "Hit your weekly goal to start a streak";
+"streakFactMonth" = "A full month";
+"streakFactQuarter" = "A full quarter";
+"streakFactHalfYear" = "Half a year";
+"streakFactYear" = "A full year";
+"streakFactTwoYears" = "Two years";
+"nextMilestone" = "Next Milestone";
+"streakToGoalOne" = "1 week to your next milestone";
+"streakToGoalMany" = "%d weeks to your next milestone";
+"streakAtBest" = "Your best streak yet";
+"streakToBeatRecordOne" = "1 week to beat your record";
+"streakToBeatRecordMany" = "%d weeks to beat your record";
 "workoutHistory" = "History";
 "workouts" = "Workouts";
 "workoutTarget" = "Workout target";
@@ -985,23 +1000,45 @@
 "muscleDetailPercentOfSets" = "%d%% of sets";
 "weekStreakSuffix" = "week streak";
 "yearWeeksOnTarget" = "%1$d of %2$d weeks on target";
+"currentWeekNumber" = "Week %d";
 "bestStreakLabel" = "Best · %d wks";
 "monthWorkoutsCount" = "%d workouts";
 "muscleBalanceEmptySubtitle" = "Log a workout to see your muscle split.";
+"muscleBalanceOverTime" = "Balance over time";
+"muscleBalanceGridCaption" = "% of sets · vs your target split";
+"muscleBalanceOnTargetShort" = "%d of 8 on target";
+"muscleBalanceOnTrack" = "On track";
+"muscleDetailRingCaption" = "Full ring = on target · Target %d%%";
+"muscleDetailShareOverTime" = "Share over time";
+"muscleBalanceBelowTarget" = "Below target";
+"muscleBalanceAboveTarget" = "Above target";
 "pinKeyLifts" = "Pin your key lifts";
 "chooseExercises" = "Choose exercises";
 "pinAMeasurement" = "Pin a measurement";
 "trackMeasurements" = "Track your measurements";
 "unlockWithPro" = "Unlock with Pro";
 
-"currentWeekNumber" = "Week %d";
-"nextMilestone" = "Next Milestone";
-"streakFactHalfYear" = "Half a year";
-"streakFactMonth" = "A full month";
-"streakFactQuarter" = "A full quarter";
-"streakFactTwoYears" = "Two years";
-"streakFactYear" = "A full year";
-"weeks" = "Weeks";
+/* Muscle Balance — ring grouping (under / over / on target) */
+"muscleBalanceBuildUp" = "Build up";
+"muscleBalanceAhead" = "Ahead";
+"muscleBalanceOnTargetSection" = "On target";
+
+/* Muscle detail — ring hero + empty state */
+"muscleDetailTargetCaption" = "Target %d%%";
+"muscleDetailEmptySubtitle" = "You haven't trained this muscle in the selected period.";
+
+/* Muscle Balance — tile "+N more" hint */
+"muscleBalanceMore" = "+%d more";
+
+
+/* Progress tab — overall progress trend */
+"overallProgress" = "Overall Progress";
+"trendingUp" = "Trending up";
+"trendingSteady" = "Holding steady";
+"trendingDown" = "Trending down";
+"byMuscleGroup" = "By muscle group";
+"overallProgressBasis" = "Estimated 1RM · last 8 weeks vs the 8 before";
+"overallProgressEmpty" = "Keep logging workouts to see your overall trend.";
 "streak" = "Streak";
 
 /* Muscle Balance — donut overview, sections & history chart */

--- a/LOGIT/Core/Environment/es.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/es.lproj/Localizable.strings
@@ -474,6 +474,7 @@
 // MARK: - W
 
 "week" = "Semana";
+"weeks" = "Semanas";
 "weekly" = "Semanalmente";
 "weeklyAverage" = "Promedio Semanal";
 "weeklyTarget" = "Objetivo semanal";
@@ -490,6 +491,20 @@
 "weekOfThe" = "semana de la";
 "workout" = "Workout";
 "workoutGoal" = "Objetivo de entrenamiento";
+
+// MARK: - Workout Goal screen
+"streakStartPrompt" = "Alcanza tu objetivo semanal para iniciar una racha";
+"streakFactMonth" = "Un mes completo";
+"streakFactQuarter" = "Un trimestre completo";
+"streakFactHalfYear" = "Medio año";
+"streakFactYear" = "Un año completo";
+"streakFactTwoYears" = "Dos años";
+"nextMilestone" = "Próximo hito";
+"streakToGoalOne" = "1 semana para tu próximo hito";
+"streakToGoalMany" = "%d semanas para tu próximo hito";
+"streakAtBest" = "Tu mejor racha hasta ahora";
+"streakToBeatRecordOne" = "1 semana para batir tu récord";
+"streakToBeatRecordMany" = "%d semanas para batir tu récord";
 "workoutHistory" = "Historia";
 "workouts" = "Workouts";
 "workoutTarget" = "objetivo de entrenamiento";
@@ -985,23 +1000,45 @@
 "muscleDetailPercentOfSets" = "%d%% de las series";
 "weekStreakSuffix" = "semanas seguidas";
 "yearWeeksOnTarget" = "%1$d de %2$d semanas en objetivo";
+"currentWeekNumber" = "Semana %d";
 "bestStreakLabel" = "Mejor · %d sem";
 "monthWorkoutsCount" = "%d entrenamientos";
 "muscleBalanceEmptySubtitle" = "Registra un entrenamiento para ver tu reparto muscular.";
+"muscleBalanceOverTime" = "Equilibrio a lo largo del tiempo";
+"muscleBalanceGridCaption" = "% de series · vs. tu reparto objetivo";
+"muscleBalanceOnTargetShort" = "%d de 8 en objetivo";
+"muscleBalanceOnTrack" = "En buen camino";
+"muscleDetailRingCaption" = "Anillo completo = en objetivo · Objetivo %d %%";
+"muscleDetailShareOverTime" = "Proporción en el tiempo";
+"muscleBalanceBelowTarget" = "Bajo el objetivo";
+"muscleBalanceAboveTarget" = "Sobre el objetivo";
 "pinKeyLifts" = "Fija tus ejercicios clave";
 "chooseExercises" = "Elegir ejercicios";
 "pinAMeasurement" = "Fijar una medida";
 "trackMeasurements" = "Registra tus medidas";
 "unlockWithPro" = "Desbloquear con Pro";
 
-"currentWeekNumber" = "Semana %d";
-"nextMilestone" = "Próximo hito";
-"streakFactHalfYear" = "Medio año";
-"streakFactMonth" = "Un mes completo";
-"streakFactQuarter" = "Un trimestre completo";
-"streakFactTwoYears" = "Dos años";
-"streakFactYear" = "Un año completo";
-"weeks" = "Semanas";
+/* Muscle Balance — ring grouping (under / over / on target) */
+"muscleBalanceBuildUp" = "Reforzar";
+"muscleBalanceAhead" = "Por encima";
+"muscleBalanceOnTargetSection" = "En objetivo";
+
+/* Muscle detail — ring hero + empty state */
+"muscleDetailTargetCaption" = "Objetivo %d%%";
+"muscleDetailEmptySubtitle" = "No has entrenado este músculo en el periodo seleccionado.";
+
+/* Muscle Balance — tile "+N more" hint */
+"muscleBalanceMore" = "+%d más";
+
+
+/* Progress tab — overall progress trend */
+"overallProgress" = "Progreso general";
+"trendingUp" = "Tendencia al alza";
+"trendingSteady" = "Estable";
+"trendingDown" = "Tendencia a la baja";
+"byMuscleGroup" = "Por grupo muscular";
+"overallProgressBasis" = "1RM estimado · últimas 8 semanas vs. las 8 anteriores";
+"overallProgressEmpty" = "Sigue registrando entrenamientos para ver tu tendencia general.";
 "streak" = "Racha";
 
 /* Muscle Balance — donut overview, sections & history chart */

--- a/LOGIT/Core/Environment/fr.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/fr.lproj/Localizable.strings
@@ -474,6 +474,7 @@
 // MARK: - W
 
 "week" = "Semaine";
+"weeks" = "Semaines";
 "weekly" = "Hebdomadaire";
 "weeklyAverage" = "Moyenne hebdomadaire";
 "weeklyTarget" = "Objectif hebdomadaire";
@@ -490,6 +491,20 @@
 "weekOfThe" = "Semaine du";
 "workout" = "Séance";
 "workoutGoal" = "Objectif d'entraînement";
+
+// MARK: - Workout Goal screen
+"streakStartPrompt" = "Atteins ton objectif hebdomadaire pour lancer une série";
+"streakFactMonth" = "Un mois complet";
+"streakFactQuarter" = "Un trimestre complet";
+"streakFactHalfYear" = "Une demi-année";
+"streakFactYear" = "Une année complète";
+"streakFactTwoYears" = "Deux ans";
+"nextMilestone" = "Prochain palier";
+"streakToGoalOne" = "1 semaine avant ton prochain palier";
+"streakToGoalMany" = "%d semaines avant ton prochain palier";
+"streakAtBest" = "Ta meilleure série à ce jour";
+"streakToBeatRecordOne" = "1 semaine pour battre ton record";
+"streakToBeatRecordMany" = "%d semaines pour battre ton record";
 "workoutHistory" = "Histoire";
 "workouts" = "Séances";
 "workoutTarget" = "Objectif d'entraînement";
@@ -985,23 +1000,45 @@
 "muscleDetailPercentOfSets" = "%d%% des séries";
 "weekStreakSuffix" = "semaines d'affilée";
 "yearWeeksOnTarget" = "%1$d sur %2$d semaines dans la cible";
+"currentWeekNumber" = "Semaine %d";
 "bestStreakLabel" = "Record · %d sem";
 "monthWorkoutsCount" = "%d séances";
 "muscleBalanceEmptySubtitle" = "Enregistre une séance pour voir ta répartition musculaire.";
+"muscleBalanceOverTime" = "Équilibre dans le temps";
+"muscleBalanceGridCaption" = "% des séries · vs ta répartition cible";
+"muscleBalanceOnTargetShort" = "%d sur 8 dans la cible";
+"muscleBalanceOnTrack" = "Sur la bonne voie";
+"muscleDetailRingCaption" = "Anneau plein = dans la cible · Cible %d %%";
+"muscleDetailShareOverTime" = "Part dans le temps";
+"muscleBalanceBelowTarget" = "Sous la cible";
+"muscleBalanceAboveTarget" = "Au-dessus de la cible";
 "pinKeyLifts" = "Épingle tes exercices clés";
 "chooseExercises" = "Choisir des exercices";
 "pinAMeasurement" = "Épingler une mesure";
 "trackMeasurements" = "Suis tes mesures";
 "unlockWithPro" = "Débloquer avec Pro";
 
-"currentWeekNumber" = "Semaine %d";
-"nextMilestone" = "Prochain palier";
-"streakFactHalfYear" = "Une demi-année";
-"streakFactMonth" = "Un mois complet";
-"streakFactQuarter" = "Un trimestre complet";
-"streakFactTwoYears" = "Deux ans";
-"streakFactYear" = "Une année complète";
-"weeks" = "Semaines";
+/* Muscle Balance — ring grouping (under / over / on target) */
+"muscleBalanceBuildUp" = "À renforcer";
+"muscleBalanceAhead" = "En avance";
+"muscleBalanceOnTargetSection" = "Dans la cible";
+
+/* Muscle detail — ring hero + empty state */
+"muscleDetailTargetCaption" = "Objectif %d%%";
+"muscleDetailEmptySubtitle" = "Vous n'avez pas entraîné ce muscle sur la période sélectionnée.";
+
+/* Muscle Balance — tile "+N more" hint */
+"muscleBalanceMore" = "+%d de plus";
+
+
+/* Progress tab — overall progress trend */
+"overallProgress" = "Progression globale";
+"trendingUp" = "En hausse";
+"trendingSteady" = "Stable";
+"trendingDown" = "En baisse";
+"byMuscleGroup" = "Par groupe musculaire";
+"overallProgressBasis" = "1RM estimé · 8 dernières semaines vs les 8 précédentes";
+"overallProgressEmpty" = "Continuez à enregistrer des séances pour voir votre tendance globale.";
 "streak" = "Série";
 
 /* Muscle Balance — donut overview, sections & history chart */

--- a/LOGIT/Core/Environment/it.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/it.lproj/Localizable.strings
@@ -474,6 +474,7 @@
 // MARK: - W
 
 "week" = "Settimana";
+"weeks" = "Settimane";
 "weekly" = "Settimanale";
 "weeklyAverage" = "Media settimanale";
 "weeklyTarget" = "Obiettivo settimanale";
@@ -490,6 +491,20 @@
 "weekOfThe" = "Settimana del";
 "workout" = "Workout";
 "workoutGoal" = "Obiettivo di allenamento";
+
+// MARK: - Workout Goal screen
+"streakStartPrompt" = "Raggiungi il tuo obiettivo settimanale per iniziare una serie";
+"streakFactMonth" = "Un mese intero";
+"streakFactQuarter" = "Un trimestre intero";
+"streakFactHalfYear" = "Mezzo anno";
+"streakFactYear" = "Un anno intero";
+"streakFactTwoYears" = "Due anni";
+"nextMilestone" = "Prossimo traguardo";
+"streakToGoalOne" = "1 settimana al prossimo traguardo";
+"streakToGoalMany" = "%d settimane al prossimo traguardo";
+"streakAtBest" = "La tua serie migliore di sempre";
+"streakToBeatRecordOne" = "1 settimana per battere il tuo record";
+"streakToBeatRecordMany" = "%d settimane per battere il tuo record";
 "workoutHistory" = "Storia";
 "workouts" = "Workout";
 "workoutTarget" = "Obiettivo di allenamento";
@@ -985,23 +1000,45 @@
 "muscleDetailPercentOfSets" = "%d%% delle serie";
 "weekStreakSuffix" = "settimane di fila";
 "yearWeeksOnTarget" = "%1$d di %2$d settimane a target";
+"currentWeekNumber" = "Settimana %d";
 "bestStreakLabel" = "Migliore · %d sett";
 "monthWorkoutsCount" = "%d allenamenti";
 "muscleBalanceEmptySubtitle" = "Registra un allenamento per vedere la tua ripartizione muscolare.";
+"muscleBalanceOverTime" = "Equilibrio nel tempo";
+"muscleBalanceGridCaption" = "% delle serie · vs la tua ripartizione target";
+"muscleBalanceOnTargetShort" = "%d su 8 a target";
+"muscleBalanceOnTrack" = "In linea";
+"muscleDetailRingCaption" = "Anello pieno = a target · Target %d%%";
+"muscleDetailShareOverTime" = "Quota nel tempo";
+"muscleBalanceBelowTarget" = "Sotto il target";
+"muscleBalanceAboveTarget" = "Sopra il target";
 "pinKeyLifts" = "Fissa i tuoi esercizi chiave";
 "chooseExercises" = "Scegli esercizi";
 "pinAMeasurement" = "Fissa una misura";
 "trackMeasurements" = "Monitora le tue misure";
 "unlockWithPro" = "Sblocca con Pro";
 
-"currentWeekNumber" = "Settimana %d";
-"nextMilestone" = "Prossimo traguardo";
-"streakFactHalfYear" = "Mezzo anno";
-"streakFactMonth" = "Un mese intero";
-"streakFactQuarter" = "Un trimestre intero";
-"streakFactTwoYears" = "Due anni";
-"streakFactYear" = "Un anno intero";
-"weeks" = "Settimane";
+/* Muscle Balance — ring grouping (under / over / on target) */
+"muscleBalanceBuildUp" = "Da aumentare";
+"muscleBalanceAhead" = "In eccesso";
+"muscleBalanceOnTargetSection" = "A target";
+
+/* Muscle detail — ring hero + empty state */
+"muscleDetailTargetCaption" = "Obiettivo %d%%";
+"muscleDetailEmptySubtitle" = "Non hai allenato questo muscolo nel periodo selezionato.";
+
+/* Muscle Balance — tile "+N more" hint */
+"muscleBalanceMore" = "+%d altri";
+
+
+/* Progress tab — overall progress trend */
+"overallProgress" = "Progresso generale";
+"trendingUp" = "In crescita";
+"trendingSteady" = "Stabile";
+"trendingDown" = "In calo";
+"byMuscleGroup" = "Per gruppo muscolare";
+"overallProgressBasis" = "1RM stimato · ultime 8 settimane vs le 8 precedenti";
+"overallProgressEmpty" = "Continua a registrare allenamenti per vedere il tuo andamento generale.";
 "streak" = "Serie";
 
 /* Muscle Balance — donut overview, sections & history chart */

--- a/LOGIT/Core/Environment/ja.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/ja.lproj/Localizable.strings
@@ -474,6 +474,7 @@
 // MARK: - W
 
 "week" = "週";
+"weeks" = "週";
 "weekly" = "毎週";
 "weeklyAverage" = "週平均";
 "weeklyTarget" = "週間目標";
@@ -490,6 +491,20 @@
 "weekOfThe" = "の週";
 "workout" = "ワークアウト";
 "workoutGoal" = "ワークアウトの目標";
+
+// MARK: - Workout Goal screen
+"streakStartPrompt" = "週間目標を達成してストリークを始めよう";
+"streakFactMonth" = "まる1か月";
+"streakFactQuarter" = "まる3か月";
+"streakFactHalfYear" = "半年";
+"streakFactYear" = "まる1年";
+"streakFactTwoYears" = "2年";
+"nextMilestone" = "次のマイルストーン";
+"streakToGoalOne" = "次のマイルストーンまであと1週";
+"streakToGoalMany" = "次のマイルストーンまであと%d週";
+"streakAtBest" = "自己ベストのストリーク";
+"streakToBeatRecordOne" = "記録更新まであと1週";
+"streakToBeatRecordMany" = "記録更新まであと%d週";
 "workoutHistory" = "歴史";
 "workouts" = "ワークアウト";
 "workoutTarget" = "トレーニングターゲット";
@@ -985,23 +1000,45 @@
 "muscleDetailPercentOfSets" = "セットの%d%%";
 "weekStreakSuffix" = "週連続";
 "yearWeeksOnTarget" = "%2$d週中%1$d週が目標達成";
+"currentWeekNumber" = "第%d週";
 "bestStreakLabel" = "最高 · %d週";
 "monthWorkoutsCount" = "%d回";
 "muscleBalanceEmptySubtitle" = "ワークアウトを記録すると筋肉の配分が表示されます。";
+"muscleBalanceOverTime" = "時間ごとのバランス";
+"muscleBalanceGridCaption" = "セットの割合・目標スプリット比";
+"muscleBalanceOnTargetShort" = "8つ中%dつが目標内";
+"muscleBalanceOnTrack" = "順調";
+"muscleDetailRingCaption" = "リングが満ちる＝目標達成・目標 %d%%";
+"muscleDetailShareOverTime" = "割合の推移";
+"muscleBalanceBelowTarget" = "目標未満";
+"muscleBalanceAboveTarget" = "目標超過";
 "pinKeyLifts" = "主要種目をピン留め";
 "chooseExercises" = "種目を選ぶ";
 "pinAMeasurement" = "測定値をピン留め";
 "trackMeasurements" = "測定値を記録";
 "unlockWithPro" = "Proで解除";
 
-"currentWeekNumber" = "第%d週";
-"nextMilestone" = "次のマイルストーン";
-"streakFactHalfYear" = "半年";
-"streakFactMonth" = "まる1か月";
-"streakFactQuarter" = "まる3か月";
-"streakFactTwoYears" = "2年";
-"streakFactYear" = "まる1年";
-"weeks" = "週";
+/* Muscle Balance — ring grouping (under / over / on target) */
+"muscleBalanceBuildUp" = "増やす";
+"muscleBalanceAhead" = "超過";
+"muscleBalanceOnTargetSection" = "目標どおり";
+
+/* Muscle detail — ring hero + empty state */
+"muscleDetailTargetCaption" = "目標 %d%%";
+"muscleDetailEmptySubtitle" = "選択した期間にこの部位はトレーニングしていません。";
+
+/* Muscle Balance — tile "+N more" hint */
+"muscleBalanceMore" = "他%d件";
+
+
+/* Progress tab — overall progress trend */
+"overallProgress" = "全体の進捗";
+"trendingUp" = "上昇傾向";
+"trendingSteady" = "横ばい";
+"trendingDown" = "下降傾向";
+"byMuscleGroup" = "筋群別";
+"overallProgressBasis" = "推定1RM · 直近8週間 vs その前の8週間";
+"overallProgressEmpty" = "ワークアウトを記録すると全体の傾向が表示されます。";
 "streak" = "連続記録";
 
 /* Muscle Balance — donut overview, sections & history chart */

--- a/LOGIT/Core/Environment/ko.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/ko.lproj/Localizable.strings
@@ -474,6 +474,7 @@
 // MARK: - W
 
 "week" = "주";
+"weeks" = "주";
 "weekly" = "주간";
 "weeklyAverage" = "주간 평균";
 "weeklyTarget" = "주간 목표";
@@ -490,6 +491,20 @@
 "weekOfThe" = "주";
 "workout" = "운동";
 "workoutGoal" = "운동 목표";
+
+// MARK: - Workout Goal screen
+"streakStartPrompt" = "주간 목표를 달성해 연속 기록을 시작하세요";
+"streakFactMonth" = "꼬박 한 달";
+"streakFactQuarter" = "꼬박 한 분기";
+"streakFactHalfYear" = "반년";
+"streakFactYear" = "꼬박 1년";
+"streakFactTwoYears" = "2년";
+"nextMilestone" = "다음 마일스톤";
+"streakToGoalOne" = "다음 마일스톤까지 1주";
+"streakToGoalMany" = "다음 마일스톤까지 %d주";
+"streakAtBest" = "역대 최고 연속 기록";
+"streakToBeatRecordOne" = "기록 경신까지 1주";
+"streakToBeatRecordMany" = "기록 경신까지 %d주";
 "workoutHistory" = "기록";
 "workouts" = "운동";
 "workoutTarget" = "운동 목표";
@@ -985,23 +1000,45 @@
 "muscleDetailPercentOfSets" = "세트의 %d%%";
 "weekStreakSuffix" = "주 연속";
 "yearWeeksOnTarget" = "%2$d주 중 %1$d주 목표 달성";
+"currentWeekNumber" = "%d주차";
 "bestStreakLabel" = "최고 · %d주";
 "monthWorkoutsCount" = "%d회";
 "muscleBalanceEmptySubtitle" = "운동을 기록하면 근육 분포가 표시됩니다.";
+"muscleBalanceOverTime" = "기간별 균형";
+"muscleBalanceGridCaption" = "세트 비율 · 목표 분배 대비";
+"muscleBalanceOnTargetShort" = "8개 중 %d개 목표 내";
+"muscleBalanceOnTrack" = "순조로움";
+"muscleDetailRingCaption" = "링이 가득 차면 목표 달성 · 목표 %d%%";
+"muscleDetailShareOverTime" = "비율 추이";
+"muscleBalanceBelowTarget" = "목표 미만";
+"muscleBalanceAboveTarget" = "목표 초과";
 "pinKeyLifts" = "주요 운동 고정";
 "chooseExercises" = "운동 선택";
 "pinAMeasurement" = "측정값 고정";
 "trackMeasurements" = "측정값 추적";
 "unlockWithPro" = "Pro로 잠금 해제";
 
-"currentWeekNumber" = "%d주차";
-"nextMilestone" = "다음 마일스톤";
-"streakFactHalfYear" = "반년";
-"streakFactMonth" = "꼬박 한 달";
-"streakFactQuarter" = "꼬박 한 분기";
-"streakFactTwoYears" = "2년";
-"streakFactYear" = "꼬박 1년";
-"weeks" = "주";
+/* Muscle Balance — ring grouping (under / over / on target) */
+"muscleBalanceBuildUp" = "더 늘리기";
+"muscleBalanceAhead" = "초과";
+"muscleBalanceOnTargetSection" = "목표 달성";
+
+/* Muscle detail — ring hero + empty state */
+"muscleDetailTargetCaption" = "목표 %d%%";
+"muscleDetailEmptySubtitle" = "선택한 기간에 이 부위를 운동하지 않았습니다.";
+
+/* Muscle Balance — tile "+N more" hint */
+"muscleBalanceMore" = "외 %d개";
+
+
+/* Progress tab — overall progress trend */
+"overallProgress" = "전체 진행 상황";
+"trendingUp" = "상승세";
+"trendingSteady" = "유지";
+"trendingDown" = "하락세";
+"byMuscleGroup" = "근육군별";
+"overallProgressBasis" = "추정 1RM · 최근 8주 vs 이전 8주";
+"overallProgressEmpty" = "운동을 계속 기록하면 전체 추세를 볼 수 있습니다.";
 "streak" = "연속 기록";
 
 /* Muscle Balance — donut overview, sections & history chart */

--- a/LOGIT/Core/Environment/pt-BR.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/pt-BR.lproj/Localizable.strings
@@ -474,6 +474,7 @@
 // MARK: - W
 
 "week" = "Semana";
+"weeks" = "Semanas";
 "weekly" = "Semanalmente";
 "weeklyAverage" = "Média Semanal";
 "weeklyTarget" = "Meta Semanal";
@@ -490,6 +491,20 @@
 "weekOfThe" = "Semana do";
 "workout" = "Treino";
 "workoutGoal" = "Meta de treino";
+
+// MARK: - Workout Goal screen
+"streakStartPrompt" = "Atinja sua meta semanal para iniciar uma sequência";
+"streakFactMonth" = "Um mês inteiro";
+"streakFactQuarter" = "Um trimestre inteiro";
+"streakFactHalfYear" = "Meio ano";
+"streakFactYear" = "Um ano inteiro";
+"streakFactTwoYears" = "Dois anos";
+"nextMilestone" = "Próximo marco";
+"streakToGoalOne" = "1 semana para o próximo marco";
+"streakToGoalMany" = "%d semanas para o próximo marco";
+"streakAtBest" = "Sua melhor sequência até agora";
+"streakToBeatRecordOne" = "1 semana para bater seu recorde";
+"streakToBeatRecordMany" = "%d semanas para bater seu recorde";
 "workoutHistory" = "História";
 "workouts" = "Treinos";
 "workoutTarget" = "Meta de treino";
@@ -985,23 +1000,45 @@
 "muscleDetailPercentOfSets" = "%d%% das séries";
 "weekStreakSuffix" = "semanas seguidas";
 "yearWeeksOnTarget" = "%1$d de %2$d semanas na meta";
+"currentWeekNumber" = "Semana %d";
 "bestStreakLabel" = "Melhor · %d sem";
 "monthWorkoutsCount" = "%d treinos";
 "muscleBalanceEmptySubtitle" = "Registre um treino para ver sua divisão muscular.";
+"muscleBalanceOverTime" = "Equilíbrio ao longo do tempo";
+"muscleBalanceGridCaption" = "% das séries · vs. sua divisão alvo";
+"muscleBalanceOnTargetShort" = "%d de 8 na meta";
+"muscleBalanceOnTrack" = "No caminho certo";
+"muscleDetailRingCaption" = "Anel cheio = na meta · Meta %d%%";
+"muscleDetailShareOverTime" = "Participação no tempo";
+"muscleBalanceBelowTarget" = "Abaixo da meta";
+"muscleBalanceAboveTarget" = "Acima da meta";
 "pinKeyLifts" = "Fixe seus exercícios principais";
 "chooseExercises" = "Escolher exercícios";
 "pinAMeasurement" = "Fixar uma medida";
 "trackMeasurements" = "Acompanhe suas medidas";
 "unlockWithPro" = "Desbloquear com Pro";
 
-"currentWeekNumber" = "Semana %d";
-"nextMilestone" = "Próximo marco";
-"streakFactHalfYear" = "Meio ano";
-"streakFactMonth" = "Um mês inteiro";
-"streakFactQuarter" = "Um trimestre inteiro";
-"streakFactTwoYears" = "Dois anos";
-"streakFactYear" = "Um ano inteiro";
-"weeks" = "Semanas";
+/* Muscle Balance — ring grouping (under / over / on target) */
+"muscleBalanceBuildUp" = "Aumentar";
+"muscleBalanceAhead" = "Acima";
+"muscleBalanceOnTargetSection" = "No alvo";
+
+/* Muscle detail — ring hero + empty state */
+"muscleDetailTargetCaption" = "Meta %d%%";
+"muscleDetailEmptySubtitle" = "Você não treinou este músculo no período selecionado.";
+
+/* Muscle Balance — tile "+N more" hint */
+"muscleBalanceMore" = "+%d mais";
+
+
+/* Progress tab — overall progress trend */
+"overallProgress" = "Progresso geral";
+"trendingUp" = "Em alta";
+"trendingSteady" = "Estável";
+"trendingDown" = "Em queda";
+"byMuscleGroup" = "Por grupo muscular";
+"overallProgressBasis" = "1RM estimado · últimas 8 semanas vs. as 8 anteriores";
+"overallProgressEmpty" = "Continue registrando treinos para ver sua tendência geral.";
 "streak" = "Sequência";
 
 /* Muscle Balance — donut overview, sections & history chart */

--- a/LOGIT/Features/Exercise/ExerciseDetail/Tiles/ExerciseMetricTile.swift
+++ b/LOGIT/Features/Exercise/ExerciseDetail/Tiles/ExerciseMetricTile.swift
@@ -268,9 +268,9 @@ struct ExerciseTileSparkline: View {
     /// Ignored when `bleeds` is set — the footer fills whatever height the tile hands it.
     var height: CGFloat = 56
     /// The metric-tile footer treatment: the sparkline fills the slot it's given and runs edge to
-    /// edge — no clip — with the carry-forward dash reaching the right edge and the bottom fade melting
-    /// the fill into the card border, easing IN at its left edge (just right of the trend pill). Off
-    /// for the windowed corner sparklines, which clip and fade in from the left at a fixed height.
+    /// edge — no clip, no leading fade, the carry-forward dash reaching the right edge — with only the
+    /// bottom fade melting the fill into the card border, the way the all-time line bleeds. Off for
+    /// the windowed corner sparklines, which clip and fade in from the left at a fixed height.
     var bleeds: Bool = false
 
     /// How many sessions the recent-history window shows.
@@ -328,10 +328,10 @@ struct ExerciseTileSparkline: View {
         .chartYAxis {}
 
         // The bleeding footer (metric tiles) fills the slot the tile hands it and runs edge to edge to
-        // the trailing + bottom edges — no clip — but fades IN from the left so it eases in at its left
-        // edge (just right of the trend pill). The all-time line spans the full width at a fixed height
-        // with only the bottom fade (its point is to show where the history begins and ends). The
-        // windowed corner sparklines clip and fade in from the left.
+        // the trailing + bottom edges — no clip — but fades IN from the left so it doesn't start
+        // abruptly behind the trend pill the tile overlays at its bottom-left. The all-time line spans
+        // the full width at a fixed height with only the bottom fade (its point is to show where the
+        // history begins and ends). The windowed corner sparklines clip and fade in from the left.
         if bleeds {
             chartView
                 .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/LOGIT/Features/Home/HomeScreen.swift
+++ b/LOGIT/Features/Home/HomeScreen.swift
@@ -36,6 +36,7 @@ struct HomeScreen: View {
     @State private var isShowingExercisesTip = true
     @State private var isShowingStartWorkoutSheet = false
     @State private var summaryRecords: [WorkoutProgressReport.PRRecord] = []
+    @State private var selectedTab: SummaryTab = .thisWeek
 
     // MARK: - Body
 
@@ -106,51 +107,52 @@ struct HomeScreen: View {
                                 .padding(.horizontal)
                             } else {
                             VStack(spacing: 8) {
-                                weeklyGoalHero(workouts: workouts)
-                                PeriodPicker(selection: Binding(
-                                    get: { summaryViewModel.selectedPeriod },
-                                    set: { summaryViewModel.userSelected($0) }
-                                ))
+                                SummaryTabPicker(selection: $selectedTab)
                                 .padding(.vertical, 2)
-                                if summaryViewModel.didAutoFallback {
-                                    HStack(spacing: 6) {
-                                        Image(systemName: "info.circle")
-                                        Text(summaryViewModel.selectedPeriod == .year
-                                            ? NSLocalizedString("summaryEmptyWeekHintYear", comment: "")
-                                            : NSLocalizedString("summaryEmptyWeekHintMonth", comment: ""))
+                                if selectedTab == .thisWeek {
+                                    weeklyGoalHero(workouts: workouts)
+                                    if summaryViewModel.didAutoFallback {
+                                        HStack(spacing: 6) {
+                                            Image(systemName: "info.circle")
+                                            Text(summaryViewModel.selectedPeriod == .year
+                                                ? NSLocalizedString("summaryEmptyWeekHintYear", comment: "")
+                                                : NSLocalizedString("summaryEmptyWeekHintMonth", comment: ""))
+                                        }
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                        .frame(maxWidth: .infinity, alignment: .leading)
                                     }
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
-                                    .frame(maxWidth: .infinity, alignment: .leading)
-                                }
-                                SummaryStatTileGrid(
-                                    viewModel: summaryViewModel,
-                                    workouts: workouts,
-                                    onOpenDetail: { metric in
-                                        homeNavigationCoordinator.path.append(.summaryStat(metric))
-                                    }
-                                )
-                                Button {
-                                    homeNavigationCoordinator.path.append(.muscleGroupsOverview)
-                                } label: {
-                                    MuscleBalanceTile(
-                                        workouts: summaryViewModel.filtered(workouts, to: summaryViewModel.selectedPeriod),
-                                        period: summaryViewModel.selectedPeriod
+                                    SummaryStatTileGrid(
+                                        viewModel: summaryViewModel,
+                                        workouts: workouts,
+                                        onOpenDetail: { metric in
+                                            homeNavigationCoordinator.path.append(.summaryStat(metric))
+                                        }
                                     )
-                                    .contentShape(Rectangle())
-                                }
-                                .buttonStyle(TileButtonStyle())
-                                if !summaryRecords.isEmpty {
                                     Button {
-                                        homeNavigationCoordinator.path.append(.summaryRecords(summaryViewModel.selectedPeriod))
+                                        homeNavigationCoordinator.path.append(.muscleGroupsOverview)
                                     } label: {
-                                        SummaryRecordsTile(
-                                            records: summaryRecords,
+                                        MuscleBalanceTile(
+                                            workouts: summaryViewModel.filtered(workouts, to: summaryViewModel.selectedPeriod),
                                             period: summaryViewModel.selectedPeriod
                                         )
                                         .contentShape(Rectangle())
                                     }
                                     .buttonStyle(TileButtonStyle())
+                                    if !summaryRecords.isEmpty {
+                                        Button {
+                                            homeNavigationCoordinator.path.append(.summaryRecords(summaryViewModel.selectedPeriod))
+                                        } label: {
+                                            SummaryRecordsTile(
+                                                records: summaryRecords,
+                                                period: summaryViewModel.selectedPeriod
+                                            )
+                                            .contentShape(Rectangle())
+                                        }
+                                        .buttonStyle(TileButtonStyle())
+                                    }
+                                } else {
+                                    SummaryProgressTab(workouts: workouts)
                                 }
                             }
                             .padding(.horizontal)

--- a/LOGIT/Features/Home/SummaryProgressTab.swift
+++ b/LOGIT/Features/Home/SummaryProgressTab.swift
@@ -1,0 +1,388 @@
+//
+//  SummaryProgressTab.swift
+//  LOGIT
+//
+//  Created by Lukas Kaibel on 30.06.26.
+//
+
+import CoreData
+import SwiftUI
+
+// MARK: - Summary tab
+
+/// The Summary screen's top switcher: the everyday `This Week` view vs the new `Progress` lens
+/// (recent highlights + the overall strength trend). Replaces the old Week / Month / Year period
+/// segments on the Summary — the longer windows still live on the stat detail screens.
+enum SummaryTab: String, CaseIterable, Identifiable {
+    case thisWeek, progress
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .thisWeek: return NSLocalizedString("thisWeek", comment: "")
+        case .progress: return NSLocalizedString("progress", comment: "")
+        }
+    }
+}
+
+/// The shared segmented `This Week` / `Progress` control, mirroring `PeriodPicker`'s styling.
+struct SummaryTabPicker: View {
+    @Binding var selection: SummaryTab
+
+    var body: some View {
+        Picker(NSLocalizedString("progress", comment: ""), selection: $selection) {
+            ForEach(SummaryTab.allCases) { tab in
+                Text(tab.title).tag(tab)
+            }
+        }
+        .pickerStyle(.segmented)
+        .labelsHidden()
+    }
+}
+
+// MARK: - Progress tab
+
+/// The `Progress` tab body: recent highlights on top, the overall strength-trend tile below. Computes
+/// both off the already-fetched `[Workout]` in a `.task` (no new Core Data fetches), the way the
+/// Summary's records tile does.
+struct SummaryProgressTab: View {
+    let workouts: [Workout]
+
+    @EnvironmentObject private var database: Database
+    @State private var overall: OverallProgress = .empty
+    @State private var highlights: [WorkoutProgressReport.PRRecord] = []
+
+    var body: some View {
+        VStack(spacing: 8) {
+            if !highlights.isEmpty {
+                ProgressHighlightsTile(records: highlights)
+            }
+            OverallProgressTile(progress: overall)
+        }
+        .task(id: workouts.count) {
+            overall = OverallProgress.compute(workouts: workouts)
+            highlights = SummaryRecords.records(in: recentWorkouts, database: database)
+        }
+    }
+
+    /// Workouts of the last 30 days — the window the highlights are drawn from, so the feed stays
+    /// "recent" rather than all-time.
+    private var recentWorkouts: [Workout] {
+        let cutoff = Calendar.current.date(byAdding: .day, value: -30, to: .now) ?? .now
+        return workouts.filter { !$0.isEmpty && ($0.date ?? .distantPast) >= cutoff }
+    }
+}
+
+// MARK: - Overall progress model
+
+/// The whole-training strength trend: each trained exercise's percent change in estimated 1RM over
+/// the recent block vs the equally long block before it, volume-weighted (by recent set count) into
+/// one overall figure plus a per-muscle-group breakdown. Cardio / bodyweight sets carry no e1RM and
+/// drop out; an exercise needs a usable best in BOTH blocks to count — with nothing to compare
+/// against there is no trend.
+struct OverallProgress {
+    struct GroupProgress: Identifiable {
+        let muscleGroup: MuscleGroup
+        let percentChange: Double
+        var id: String { muscleGroup.rawValue }
+    }
+
+    /// Volume-weighted mean percent change across all qualifying exercises, or nil when none qualify.
+    let overallPercentChange: Double?
+    /// Per-muscle-group weighted mean — groups with data only, sorted strongest gain first.
+    let groups: [GroupProgress]
+
+    var hasData: Bool { overallPercentChange != nil }
+
+    static let empty = OverallProgress(overallPercentChange: nil, groups: [])
+
+    /// Outlier guard so one freak set can't swing the headline.
+    private static let maxAbsPercentChange = 50.0
+
+    static func compute(workouts: [Workout], recentWeeks: Int = 8, reference: Date = .now) -> OverallProgress {
+        let calendar = Calendar.current
+        guard
+            let recentStart = calendar.date(byAdding: .weekOfYear, value: -recentWeeks, to: reference),
+            let priorStart = calendar.date(byAdding: .weekOfYear, value: -2 * recentWeeks, to: reference)
+        else { return .empty }
+
+        // Unique exercises trained across the fetched workouts.
+        var exercises: [Exercise] = []
+        var seen = Set<NSManagedObjectID>()
+        for workout in workouts where !workout.isEmpty {
+            for exercise in workout.exercises where !seen.contains(exercise.objectID) {
+                seen.insert(exercise.objectID)
+                exercises.append(exercise)
+            }
+        }
+
+        struct Change { let group: MuscleGroup; let percent: Double; let weight: Double }
+        var changes: [Change] = []
+
+        for exercise in exercises {
+            guard let group = exercise.muscleGroup else { continue }
+            var recentBest = 0
+            var priorBest = 0
+            var recentSetCount = 0
+            for set in exercise.sets {
+                guard let date = set.workout?.date else { continue }
+                let e1rm = set.estimatedOneRepMax(for: exercise)
+                guard e1rm > 0 else { continue }
+                if date >= recentStart, date <= reference {
+                    recentBest = max(recentBest, e1rm)
+                    recentSetCount += 1
+                } else if date >= priorStart, date < recentStart {
+                    priorBest = max(priorBest, e1rm)
+                }
+            }
+            guard recentBest > 0, priorBest > 0 else { continue }
+            let raw = (Double(recentBest) - Double(priorBest)) / Double(priorBest) * 100
+            let clamped = min(max(raw, -maxAbsPercentChange), maxAbsPercentChange)
+            changes.append(Change(group: group, percent: clamped, weight: Double(max(recentSetCount, 1))))
+        }
+
+        guard !changes.isEmpty else { return .empty }
+
+        let totalWeight = changes.reduce(0) { $0 + $1.weight }
+        let overall = changes.reduce(0) { $0 + $1.percent * $1.weight } / totalWeight
+
+        var byGroup: [MuscleGroup: (sum: Double, weight: Double)] = [:]
+        for change in changes {
+            let current = byGroup[change.group] ?? (0, 0)
+            byGroup[change.group] = (current.sum + change.percent * change.weight, current.weight + change.weight)
+        }
+        let groups = byGroup
+            .map { GroupProgress(muscleGroup: $0.key, percentChange: $0.value.sum / $0.value.weight) }
+            .sorted { $0.percentChange > $1.percentChange }
+
+        return OverallProgress(overallPercentChange: overall, groups: groups)
+    }
+}
+
+// MARK: - Trend arrow helpers
+
+/// Below this magnitude (in %) a trend reads as flat — a deadband so the arrow doesn't twitch.
+private let trendDeadband = 1.0
+
+private func trendIsUp(_ percent: Double) -> Bool { percent >= trendDeadband }
+private func trendIsDown(_ percent: Double) -> Bool { percent <= -trendDeadband }
+
+/// Accent for a gain; neutral grey for flat or a decline — progress green is the only colour that
+/// ever means "good", and a dip is never coloured as a warning.
+private func trendColor(_ percent: Double) -> Color {
+    trendIsUp(percent) ? .accentColor : .secondaryLabel
+}
+
+/// Continuous arrow angle in degrees (0 = flat/right, positive = up), scaled from the percent and
+/// clamped so big swings still read as "steeply up/down" without spinning past vertical.
+private func trendAngle(_ percent: Double) -> Double {
+    min(max(percent * 6, -62), 80)
+}
+
+private func signedPercent(_ percent: Double, fractionDigits: Int) -> String {
+    String(format: "%+.\(fractionDigits)f%%", percent)
+}
+
+/// A right-pointing arrow rotated to the trend angle — the shared glyph for the hero and the
+/// per-muscle rows. Positive angle rotates it up (counter-clockwise).
+private struct TrendArrow: View {
+    let percent: Double
+    let color: Color
+    let size: CGFloat
+
+    var body: some View {
+        Image(systemName: "arrow.right")
+            .font(.system(size: size, weight: .bold))
+            .foregroundStyle(color)
+            .rotationEffect(.degrees(-trendAngle(percent)))
+    }
+}
+
+// MARK: - Overall progress tile
+
+/// The Progress tab's headline tile: one continuous arrow for the whole-training trend, then a small
+/// per-muscle-group arrow in each group's colour. No detail screen yet, so no chevron.
+struct OverallProgressTile: View {
+    let progress: OverallProgress
+
+    private let columns = [GridItem(.flexible(), spacing: 16), GridItem(.flexible(), spacing: 16)]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            TileHeader(NSLocalizedString("overallProgress", comment: ""), showsChevron: false)
+                .padding([.top, .horizontal], CELL_PADDING)
+
+            if let overall = progress.overallPercentChange {
+                hero(overall)
+                    .padding(.horizontal, CELL_PADDING)
+                    .padding(.top, 12)
+
+                if !progress.groups.isEmpty {
+                    Divider()
+                        .padding(.horizontal, CELL_PADDING)
+                        .padding(.vertical, 12)
+                    muscleBreakdown
+                        .padding(.horizontal, CELL_PADDING)
+                        .padding(.bottom, CELL_PADDING)
+                } else {
+                    Spacer().frame(height: CELL_PADDING)
+                }
+            } else {
+                emptyState
+                    .padding(CELL_PADDING)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .tileStyle()
+    }
+
+    private func hero(_ overall: Double) -> some View {
+        let color = trendColor(overall)
+        return HStack(spacing: 15) {
+            ZStack {
+                Circle().fill(color.opacity(0.13)).frame(width: 60, height: 60)
+                TrendArrow(percent: overall, color: color, size: 24)
+            }
+            VStack(alignment: .leading, spacing: 4) {
+                Text(statusText(overall))
+                    .font(.title3.weight(.bold))
+                    .foregroundStyle(color)
+                Text(signedPercent(overall, fractionDigits: 1))
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(Color.label)
+                    .monospacedDigit()
+                Text(NSLocalizedString("overallProgressBasis", comment: ""))
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            Spacer(minLength: 0)
+        }
+    }
+
+    private var muscleBreakdown: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(NSLocalizedString("byMuscleGroup", comment: ""))
+                .font(.caption2.weight(.bold))
+                .textCase(.uppercase)
+                .foregroundStyle(.secondary)
+            LazyVGrid(columns: columns, alignment: .leading, spacing: 12) {
+                ForEach(progress.groups) { group in
+                    muscleRow(group)
+                }
+            }
+        }
+    }
+
+    private func muscleRow(_ group: OverallProgress.GroupProgress) -> some View {
+        let color = group.muscleGroup.color
+        let dimmed = !trendIsUp(group.percentChange)
+        return HStack(spacing: 8) {
+            TrendArrow(percent: group.percentChange, color: color, size: 13)
+                .opacity(dimmed ? 0.6 : 1)
+                .frame(width: 18)
+            Text(group.muscleGroup.description)
+                .font(.subheadline)
+                .foregroundStyle(Color.label)
+                .lineLimit(1)
+            Spacer(minLength: 4)
+            Text(signedPercent(group.percentChange, fractionDigits: 0))
+                .font(.subheadline.weight(.bold))
+                .foregroundStyle(color.opacity(dimmed ? 0.6 : 1))
+                .monospacedDigit()
+        }
+    }
+
+    private var emptyState: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "chart.line.uptrend.xyaxis")
+                .font(.title3)
+                .foregroundStyle(.secondary)
+            Text(NSLocalizedString("overallProgressEmpty", comment: ""))
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            Spacer(minLength: 0)
+        }
+    }
+
+    private func statusText(_ percent: Double) -> String {
+        if trendIsUp(percent) { return NSLocalizedString("trendingUp", comment: "") }
+        if trendIsDown(percent) { return NSLocalizedString("trendingDown", comment: "") }
+        return NSLocalizedString("trendingSteady", comment: "")
+    }
+}
+
+// MARK: - Highlights tile
+
+/// The Progress tab's highlights: the most recent personal record as a prominent hero (exercise,
+/// metric, the new value and the gain over the old best), then up to a couple more recent records as
+/// the shared `PersonalBestRow`. Hidden entirely when there are no recent records — like the Summary
+/// records tile, an empty highlights tile would be worse than none.
+struct ProgressHighlightsTile: View {
+    /// Recent, deduped records (one per exercise+metric, newest first) from `SummaryRecords.records`.
+    let records: [WorkoutProgressReport.PRRecord]
+    var maxRows: Int = 3
+
+    var body: some View {
+        if let top = records.first {
+            VStack(alignment: .leading, spacing: 0) {
+                TileHeader(NSLocalizedString("highlights", comment: ""), showsChevron: false)
+                    .padding([.top, .horizontal], CELL_PADDING)
+                hero(top)
+                    .padding(.horizontal, CELL_PADDING)
+                    .padding(.top, 12)
+                let rest = Array(records.dropFirst().prefix(max(0, maxRows - 1)))
+                if !rest.isEmpty {
+                    VStack(spacing: 8) {
+                        ForEach(rest) { PersonalBestRow(record: $0) }
+                    }
+                    .padding(.horizontal, CELL_PADDING / 2)
+                    .padding(.top, 10)
+                }
+            }
+            .padding(.bottom, CELL_PADDING / 2)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .tileStyle()
+        }
+    }
+
+    private func hero(_ record: WorkoutProgressReport.PRRecord) -> some View {
+        let color = record.exercise.muscleGroup?.color ?? .accentColor
+        let display = personalRecordDisplay(record.value, metric: record.metric)
+        let gain: Double? = record.previousBest > 0
+            ? (Double(record.value) - Double(record.previousBest)) / Double(record.previousBest) * 100
+            : nil
+        return HStack(spacing: 13) {
+            ZStack {
+                Circle().fill(color.opacity(0.15)).frame(width: 46, height: 46)
+                Image(systemName: "trophy.fill")
+                    .font(.title3)
+                    .foregroundStyle(color.gradient)
+            }
+            VStack(alignment: .leading, spacing: 3) {
+                Text(record.exercise.displayName)
+                    .font(.headline)
+                    .foregroundStyle(Color.label)
+                    .lineLimit(1)
+                Text("\(NSLocalizedString("newRecord", comment: "")) · \(record.metric.title)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            Spacer(minLength: 8)
+            VStack(alignment: .trailing, spacing: 4) {
+                UnitView(value: display.value, unit: display.unit)
+                    .foregroundStyle(color.gradient)
+                if let gain {
+                    TrendIndicatorView(
+                        percentChange: gain,
+                        positiveColor: color,
+                        positiveStyle: AnyShapeStyle(color.gradient)
+                    )
+                }
+            }
+        }
+    }
+}

--- a/LOGIT/Features/Home/SummaryStatScreen.swift
+++ b/LOGIT/Features/Home/SummaryStatScreen.swift
@@ -94,6 +94,10 @@ struct SummaryStatScreen: View {
     private var chart: some View {
         let buckets = self.buckets
         let maxValue = buckets.map(\.value).max() ?? 0
+        // At most ~4 axis labels, counted back from the current bucket so "now" is always labeled —
+        // one label per bucket sat shoulder-to-shoulder on the week view.
+        let labelStride = max(1, Int((Double(buckets.count) / 4.0).rounded(.up)))
+        let labeledDates = stride(from: buckets.count - 1, through: 0, by: -labelStride).map { buckets[$0].date }
         return Chart {
             ForEach(buckets) { bucket in
                 BarMark(
@@ -111,13 +115,18 @@ struct SummaryStatScreen: View {
         }
         .chartYScale(domain: 0 ... max(maxValue, 1))
         .chartXAxis {
-            AxisMarks(values: .stride(by: strideComponent)) { value in
+            AxisMarks(values: labeledDates) { value in
                 if let date = value.as(Date.self) {
+                    let isCurrent = period.currentRange().contains(date)
                     AxisGridLine()
                         .foregroundStyle(Color.gray.opacity(0.4))
-                    AxisValueLabel(axisLabel(for: date))
-                        .font(.caption.weight(.bold))
-                        .foregroundStyle(.secondary)
+                    // Styling lives on the Text inside the label closure — hierarchical styles on the
+                    // AxisMark itself resolve against the chart's accent on iOS 26 (labels turned lime).
+                    AxisValueLabel {
+                        Text(axisLabel(for: date))
+                            .font(.caption.weight(isCurrent ? .bold : .semibold))
+                            .foregroundStyle(isCurrent ? Color.label : Color.secondaryLabel)
+                    }
                 }
             }
         }

--- a/LOGIT/Features/Home/Tiles/SummaryStatTiles.swift
+++ b/LOGIT/Features/Home/Tiles/SummaryStatTiles.swift
@@ -14,15 +14,18 @@ import SwiftUI
 /// history bar chart with the current period highlighted. Parallel to `WorkoutStatTile` (which is
 /// hardwired to "this workout vs prior runs"), but reading the period block's window instead.
 ///
-/// Volume, sets and reps use the app accent; duration stays neutral gray — a longer week is neither
-/// better nor worse — so its trend pill and current bar read quiet, matching the mockup.
+/// The highlighted bar always uses the app accent — it marks "this week" (the current period), which
+/// matters for every metric. The trend pill, though, stays neutral gray for duration: a longer week is
+/// neither better nor worse, so only volume, sets and reps tint their pill with the accent.
 struct SummaryStatTile: View {
     let metric: WorkoutStatMetric
     let data: SummaryViewModel.StatData
     let onOpen: () -> Void
 
     private var isDuration: Bool { metric == .duration }
-    private var accentColor: Color { isDuration ? .secondary : .accentColor }
+    /// The trend pill's tint: neutral gray for duration (a longer week is neither better nor worse),
+    /// the app accent for volume / sets / reps.
+    private var pillColor: Color { isDuration ? .secondary : .accentColor }
 
     var body: some View {
         Button(action: onOpen) {
@@ -34,13 +37,15 @@ struct SummaryStatTile: View {
                 // reads as a misleading "100 % decline".
                 value: metric.formattedValue(fromRaw: data.rawValue),
                 unit: metric.unit,
-                accent: AnyShapeStyle(accentColor),
-                accentColor: accentColor,
+                accent: AnyShapeStyle(pillColor),
+                accentColor: pillColor,
                 percentChange: data.rawValue > 0 ? data.percentChange : nil,
                 requiresPro: metric.requiresPro,
                 chartBleeds: false
             ) {
-                WorkoutRunsBarChart(bars: bars, currentStyle: AnyShapeStyle(accentColor))
+                // The highlighted "this week" bar always uses the accent, even for duration — it marks
+                // the current period, not a judgement, so it reads the same as the other tiles.
+                WorkoutRunsBarChart(bars: bars, currentStyle: AnyShapeStyle(Color.accentColor))
             }
         }
         .buttonStyle(TileButtonStyle())

--- a/LOGIT/SharedUI/Charts/TileSparklineStyle.swift
+++ b/LOGIT/SharedUI/Charts/TileSparklineStyle.swift
@@ -46,9 +46,9 @@ enum TileSparklineStyle {
     static let carryForwardOpacity: CGFloat = 0.45
     /// Fraction of the width over which the leading edge fades in.
     static let leadingFadeLocation: CGFloat = 0.12
-    /// A longer leading fade for the full-bleed metric-tile line, which carries the trend pill at its
-    /// bottom-left corner: the line eases in over this span so it doesn't start abruptly at its left
-    /// edge (just to the right of the pill).
+    /// A longer leading fade for the full-bleed metric-tile line, which carries the trend pill over its
+    /// bottom-left corner: the line dissolves to transparent under the pill so it emerges to the pill's
+    /// right instead of starting abruptly behind it.
     static let bleedLeadingFadeLocation: CGFloat = 0.33
 
     /// The translucent fill under the line — a top-heavy tint. Swift Charts won't reliably fade an
@@ -129,9 +129,9 @@ func tileSparklineMarks(
             .interpolationMethod(interpolation)
             .foregroundStyle(TileSparklineStyle.areaGradient(color))
     }
-    // Extend the area flat to the chart's trailing edge, so the gradient fill bleeds all the way to
-    // the tile's right edge even though the latest dot (and the window) stop short of it — including
-    // under the dashed carry-forward line.
+    // Carry the area flat under the dashed line to the chart's trailing edge so the fill reaches the
+    // tile's right edge; the bleed mask's trailing fade then dissolves it into the edge rather than
+    // letting it end on a hard vertical cut.
     if let carryForwardArea, let last = points.last {
         AreaMark(x: .value("Date", carryForwardArea, unit: .day), y: .value("Value", last.value))
             .interpolationMethod(interpolation)
@@ -198,8 +198,9 @@ extension View {
     }
 
     /// The full-bleed metric-tile line's fade: it dissolves IN from the leading edge over a longer span
-    /// than the corner sparklines (so it eases in at its left edge, just right of the trend pill) and
-    /// OUT toward the bottom, with no clip, so the line still runs to the trailing and bottom edges.
+    /// than the corner sparklines — far enough to clear the trend pill the tile overlays at the bottom-
+    /// left — and OUT toward the bottom, with no clip, so the line still runs to the trailing and bottom
+    /// edges. The leading fade is why the line doesn't start abruptly behind the pill.
     func tileSparklineBleedFadeMask() -> some View {
         mask(
             LinearGradient(

--- a/LOGIT/SharedUI/Views/MetricTile.swift
+++ b/LOGIT/SharedUI/Views/MetricTile.swift
@@ -198,7 +198,14 @@ struct MetricTile<ChartContent: View>: View {
         case let .info(text, explanation):
             MetricTileInfoLabel(text: text, explanation: explanation)
         case .none:
-            EmptyView()
+            // Reserve one subtitle line's height so the value keeps the same fixed vertical position
+            // as tiles that do have a subtitle. Without it the value floats up into the empty slot and
+            // the chart below — which fills the leftover height — grows too tall (the Summary bars).
+            Text(" ")
+                .font(.footnote)
+                .fontWeight(.semibold)
+                .hidden()
+                .accessibilityHidden(true)
         }
     }
 


### PR DESCRIPTION
## What

Commits the currently-active Summary work and a chart fix from this session.

### Progress tab
- New `SummaryProgressTab.swift`: the `This Week` / `Progress` segmented switcher plus the Progress body — recent **Highlights** (top PR hero + rows) and the **Overall Progress** tile (whole-training estimated-1RM trend with a per-muscle-group breakdown). Wired into `HomeScreen`.

### Stat tile & chart polish
- Summary stat tiles: the highlighted "this week" bar always uses the accent (it marks the current period, not a judgement); only the trend pill stays neutral gray for duration.
- `MetricTile` reserves an empty subtitle line so the value keeps a fixed vertical position and the bleeding chart below doesn't grow too tall.
- Sparkline bleed/fade comments clarified; the leading fade clears the trend pill the tile overlays.
- **Stat detail chart x-axis** (reported this session): labels are now gray with the current period in bold white, and thinned to ~4 evenly spaced labels (anchored on the current period) so the week view no longer crams one label per bar.
- Localized the new Summary strings across all 8 languages.

## Testing
Built and ran on the iPhone 17 / 17 Pro simulators (iOS 26.0) with seeded demo data.

## Known follow-up (not in this PR)
Week/Month/Year use calendar periods, so early in a month the current week can reach into the previous month and a longer scope can show *less* than a shorter one (surfaced on the muscle-group detail screen). Tracked separately — leaning toward rolling windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)