### PR TITLE
Vertically center the Suggest a Feature row icons

### DIFF
--- a/LOGIT/Features/SettingsScreen.swift
+++ b/LOGIT/Features/SettingsScreen.swift
@@ -119,7 +119,7 @@ struct SettingsScreen: View {
         section(NSLocalizedString("feedbackAndSupport", comment: "")) {
             VStack(spacing: CELL_SPACING) {
                 Link(destination: URL(string: "mailto:\(FEEDBACK_EMAIL)?subject=Feature%20Idea")!) {
-                    HStack(alignment: .top, spacing: 12) {
+                    HStack(spacing: 12) {
                         Image(systemName: "lightbulb.fill")
                             .foregroundStyle(Color.accentColor)
                             .frame(width: 24)


### PR DESCRIPTION
## Summary
The **Suggest a Feature** row in Settings → Feedback & Support used `HStack(alignment: .top)`, which pinned the lightbulb and envelope icons to the top of the two-line text block (title + subtitle). This left the symbols visually misaligned against the cell.

Switching to the default center alignment vertically centers both symbols relative to the text.

## Change
- `LOGIT/Features/SettingsScreen.swift`: drop `alignment: .top` from the row's `HStack`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)