### PR TITLE
Fix chart selection, y-axis headroom, and scrolling across stat screens

### DIFF
--- a/LOGIT.xcodeproj/project.pbxproj
+++ b/LOGIT.xcodeproj/project.pbxproj
@@ -7,24 +7,26 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		07A5D2C54CA81141164E3D9D /* MuscleGroupsOverviewScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54FB7DD2DDA0DE70BD366F9C /* MuscleGroupsOverviewScreen.swift */; };
 		10F53DA7818380C706F42B20 /* WorkoutLiveActivityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06A7CD832F8CF2FDAB33579C /* WorkoutLiveActivityManager.swift */; };
 		18F8886F2E06B3DCB04A2002 /* LOGITWidgetExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 79D10973BCE1A0618D3256CD /* LOGITWidgetExtension.appex */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		1E7CF1C1E77503BD192ECE23 /* WorkoutGoalScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA376FF1C58639B7542A334 /* WorkoutGoalScreen.swift */; };
 		2333D8B12B944AD1A27D0E0A /* SetEntityClasses.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD50531C168D4EDFB527D76A /* SetEntityClasses.swift */; };
+		23A5FD0EA5AC115CC0EC34E6 /* SummaryRecords.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADFEC5772AE8932AA1089603 /* SummaryRecords.swift */; };
 		268525E87C3944BA9208D129 /* TrendIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D5D5995AEAE4AA8849AAF28 /* TrendIndicatorView.swift */; };
-		D1D1D1000000000000000B01 /* MetricTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1D1D1000000000000000F01 /* MetricTile.swift */; };
-		73A9CED8C934FDF36F9C4061 /* BodyMapFigure.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBBF6087BB65A5971FB5F866 /* BodyMapFigure.swift */; };
-		2BD2E4720FB2C657F8CA372B /* CompletionRing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C72085C4C10146858277690 /* CompletionRing.swift */; };
-		77B7E6990E4C00B75D9BC6ED /* PeriodPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA597E1519E8F6D2CBC8F9E /* PeriodPicker.swift */; };
-		E1E1E1000000000000000B12 /* ProgressIndicatorPill.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1E1E1000000000000000F12 /* ProgressIndicatorPill.swift */; };
-		E1E1E1000000000000000B16 /* PersonalBestRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1E1E1000000000000000F16 /* PersonalBestRow.swift */; };
-		E1E1E1000000000000000B15 /* MetricComparisonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1E1E1000000000000000F15 /* MetricComparisonView.swift */; };
 		2A384BE3816900000002 /* ExerciseSuggestionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54EE2592821500000001 /* ExerciseSuggestionService.swift */; };
+		2BD2E4720FB2C657F8CA372B /* CompletionRing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C72085C4C10146858277690 /* CompletionRing.swift */; };
+		33E50B21943F61B55A4481FC /* ChartScaling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F67610775CDB7AC5571A4B9 /* ChartScaling.swift */; };
+		34ED649B10150341352AE3D1 /* StatPeriodTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F8CD271000D75928FAE0887 /* StatPeriodTests.swift */; };
 		396ADE67CD8C1D14F7A8D82A /* LOGITWidgetExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3BDDD14FE5BF0C275AF30C5 /* LOGITWidgetExtension.swift */; };
 		435F070826CC8D1F8D7239B8 /* WorkoutDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4845CEF582EB23AB447C90B2 /* WorkoutDTO.swift */; };
+		53B547C48713887B1E5542EE /* MuscleBalanceCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0258213863A5C9812190A44D /* MuscleBalanceCalculator.swift */; };
 		5701E3D211A49E43B531E6D8 /* SnapshotHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0400C2E827A4AEAF03BACDC6 /* SnapshotHelper.swift */; };
 		57A9ABF55683DB0071E02FE6 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A72B470FE19DAE1E42233F7F /* Foundation.framework */; };
 		6A45A79A5D89B951F7726DBD /* WorkoutLiveActivitySnapshotBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F7B218CB83CEAEB494355C8 /* WorkoutLiveActivitySnapshotBuilderTests.swift */; };
+		73A9CED8C934FDF36F9C4061 /* BodyMapFigure.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBBF6087BB65A5971FB5F866 /* BodyMapFigure.swift */; };
 		773128213DE6E6FA1506597C /* WorkoutLiveActivityAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 829F12D41C231764936B6B83 /* WorkoutLiveActivityAttributes.swift */; };
+		77B7E6990E4C00B75D9BC6ED /* PeriodPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA597E1519E8F6D2CBC8F9E /* PeriodPicker.swift */; };
 		781060648530454E63B22EB3 /* WorkoutSharingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EB3B92BF7A5E9FE9E442716 /* WorkoutSharingService.swift */; };
 		7907FDEA289E99B1006AF271 /* CloudKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7907FDE9289E99B1006AF271 /* CloudKit.framework */; };
 		791347B62AE2BEB100D20BB7 /* MarkdownUI in Frameworks */ = {isa = PBXBuildFile; productRef = 791347B52AE2BEB100D20BB7 /* MarkdownUI */; };
@@ -33,9 +35,11 @@
 		794A8E602ACC2184006087EA /* athleanx_total_body_A.jpeg in Resources */ = {isa = PBXBuildFile; fileRef = 794A8E5F2ACC2184006087EA /* athleanx_total_body_A.jpeg */; };
 		795767812AE706DB0040E327 /* Camera-SwiftUI in Frameworks */ = {isa = PBXBuildFile; productRef = 795767802AE706DB0040E327 /* Camera-SwiftUI */; };
 		7959F4CF2ACD8F5B0038B222 /* WorkoutImages.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7959F4CE2ACD8F5B0038B222 /* WorkoutImages.xcassets */; };
+		79BB043F7BA96F3DE3739FB7 /* SummaryEmptyStates.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC42311A655A248061E11238 /* SummaryEmptyStates.swift */; };
 		79C07B302ABA566E000BF879 /* MeasurementEntryControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79C07B2F2ABA566E000BF879 /* MeasurementEntryControllerTests.swift */; };
 		79C8FADF2AE3F657001EA5A7 /* OpenAIKit in Frameworks */ = {isa = PBXBuildFile; productRef = 79C8FADE2AE3F657001EA5A7 /* OpenAIKit */; };
 		79FF97B72AA29E680070015E /* ExerciseServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79E849092A7EA28000C0DF95 /* ExerciseServiceTests.swift */; };
+		7E83CA2A65D6F90A809C8570 /* WeeklyGoalHeroTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF1126F67238BF3E85FCC8C8 /* WeeklyGoalHeroTile.swift */; };
 		80036CDC2EFEF98C00B7C7B4 /* GlobalSearchScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80036CDA2EFEF98C00B7C7B4 /* GlobalSearchScreen.swift */; };
 		80036CDE2EFEF9CE00B7C7B4 /* FuzzySearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80036CDD2EFEF9CE00B7C7B4 /* FuzzySearchService.swift */; };
 		80036CE12EFEFFD100B7C7B4 /* Ifrit in Frameworks */ = {isa = PBXBuildFile; productRef = 80036CE02EFEFFD100B7C7B4 /* Ifrit */; };
@@ -49,7 +53,6 @@
 		801BBD692DF7338A00CDB1FB /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBC9D2DF7338A00CDB1FB /* Constants.swift */; };
 		801BBD6A2DF7338A00CDB1FB /* MuscleGroupGradientStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBD482DF7338A00CDB1FB /* MuscleGroupGradientStyle.swift */; };
 		801BBD6B2DF7338A00CDB1FB /* ExerciseVolumeScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBCF12DF7338A00CDB1FB /* ExerciseVolumeScreen.swift */; };
-		E1E1E1000000000000000B11 /* ExerciseSetsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1E1E1000000000000000F11 /* ExerciseSetsScreen.swift */; };
 		801BBD6C2DF7338A00CDB1FB /* Template+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBCD52DF7338A00CDB1FB /* Template+.swift */; };
 		801BBD6D2DF7338A00CDB1FB /* Database+Preview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBCC62DF7338A00CDB1FB /* Database+Preview.swift */; };
 		801BBD6E2DF7338A00CDB1FB /* MeasurementEntryType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBCA12DF7338A00CDB1FB /* MeasurementEntryType.swift */; };
@@ -83,8 +86,6 @@
 		801BBD8A2DF7338A00CDB1FB /* DropSetCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBD162DF7338A00CDB1FB /* DropSetCell.swift */; };
 		801BBD8B2DF7338A00CDB1FB /* VolumeScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBD042DF7338A00CDB1FB /* VolumeScreen.swift */; };
 		801BBD8C2DF7338A00CDB1FB /* ExerciseVolumeTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBCEB2DF7338A00CDB1FB /* ExerciseVolumeTile.swift */; };
-		E1E1E1000000000000000B10 /* ExerciseSetsTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1E1E1000000000000000F10 /* ExerciseSetsTile.swift */; };
-		E1E1E1000000000000000B08 /* ExerciseMetricTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1E1E1000000000000000F08 /* ExerciseMetricTile.swift */; };
 		801BBD8D2DF7338A00CDB1FB /* WeightUnit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBCA32DF7338A00CDB1FB /* WeightUnit.swift */; };
 		801BBD8E2DF7338A00CDB1FB /* VolumeTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBCFC2DF7338A00CDB1FB /* VolumeTile.swift */; };
 		801BBD8F2DF7338A00CDB1FB /* SuperSetCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBD182DF7338A00CDB1FB /* SuperSetCell.swift */; };
@@ -95,9 +96,6 @@
 		801BBD942DF7338A00CDB1FB /* SectionHeaderStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBD4A2DF7338A00CDB1FB /* SectionHeaderStyle.swift */; };
 		801BBD952DF7338A00CDB1FB /* LOGITApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBC962DF7338A00CDB1FB /* LOGITApp.swift */; };
 		801BBD962DF7338A00CDB1FB /* OverallSetsTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBCFB2DF7338A00CDB1FB /* OverallSetsTile.swift */; };
-		A6CA17B3772D8CC88F1E0E19 /* MuscleBalanceTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 547CD2BA3A17B483651496C5 /* MuscleBalanceTile.swift */; };
-		7E83CA2A65D6F90A809C8570 /* WeeklyGoalHeroTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF1126F67238BF3E85FCC8C8 /* WeeklyGoalHeroTile.swift */; };
-		B57097634BC79614715AE3EF /* SummaryStatTiles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 336772BB4E860E3894BA7355 /* SummaryStatTiles.swift */; };
 		801BBD972DF7338A00CDB1FB /* TemplateDetailScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBD122DF7338A00CDB1FB /* TemplateDetailScreen.swift */; };
 		801BBD982DF7338A00CDB1FB /* Array+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBCAD2DF7338A00CDB1FB /* Array+.swift */; };
 		801BBD992DF7338A00CDB1FB /* OnDeleteModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBD3F2DF7338A00CDB1FB /* OnDeleteModifier.swift */; };
@@ -135,9 +133,6 @@
 		801BBDBA2DF7338A00CDB1FB /* StandardSet+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBCD32DF7338A00CDB1FB /* StandardSet+.swift */; };
 		801BBDBB2DF7338A00CDB1FB /* ExerciseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBCCB2DF7338A00CDB1FB /* ExerciseDTO.swift */; };
 		801BBDBC2DF7338A00CDB1FB /* MuscleGroupService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBD332DF7338A00CDB1FB /* MuscleGroupService.swift */; };
-		53B547C48713887B1E5542EE /* MuscleBalanceCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0258213863A5C9812190A44D /* MuscleBalanceCalculator.swift */; };
-		A1B2C3D4E5F600000001B001 /* MuscleBalanceHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F600000001F001 /* MuscleBalanceHistory.swift */; };
-		F344926EBBAE89A564139E06 /* MuscleTargetSplitStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DDAB0743896FB9245B6D5A9 /* MuscleTargetSplitStore.swift */; };
 		801BBDBD2DF7338A00CDB1FB /* Int+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBCB22DF7338A00CDB1FB /* Int+.swift */; };
 		801BBDBE2DF7338A00CDB1FB /* WidgetCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBD5B2DF7338A00CDB1FB /* WidgetCollectionView.swift */; };
 		801BBDBF2DF7338A00CDB1FB /* ExerciseEditScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBCF52DF7338A00CDB1FB /* ExerciseEditScreen.swift */; };
@@ -158,7 +153,6 @@
 		801BBDCF2DF7338A00CDB1FB /* ExerciseService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBCB82DF7338A00CDB1FB /* ExerciseService.swift */; };
 		801BBDD12DF7338A00CDB1FB /* Widget+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBCDB2DF7338A00CDB1FB /* Widget+.swift */; };
 		801BBDD22DF7338A00CDB1FB /* MuscleGroupSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBD542DF7338A00CDB1FB /* MuscleGroupSelector.swift */; };
-		A1B2C3D4E5F600000007B007 /* MuscleBalanceBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F600000007F007 /* MuscleBalanceBar.swift */; };
 		801BBDD32DF7338A00CDB1FB /* SectionedFetchRequestWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBCE22DF7338A00CDB1FB /* SectionedFetchRequestWrapper.swift */; };
 		801BBDD52DF7338A00CDB1FB /* WorkoutDetailSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBD212DF7338A00CDB1FB /* WorkoutDetailSheet.swift */; };
 		801BBDD62DF7338A00CDB1FB /* TipView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBD582DF7338A00CDB1FB /* TipView.swift */; };
@@ -174,8 +168,6 @@
 		801BBDE02DF7338A00CDB1FB /* MuscleGroupOccurancesChart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBD372DF7338A00CDB1FB /* MuscleGroupOccurancesChart.swift */; };
 		801BBDE12DF7338A00CDB1FB /* WorkoutSetGroup+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBCDF2DF7338A00CDB1FB /* WorkoutSetGroup+.swift */; };
 		801BBDE32DF7338A00CDB1FB /* MuscleGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBCA22DF7338A00CDB1FB /* MuscleGroup.swift */; };
-		AA976DD8C23A04BD91CEB858 /* MuscleTargetSplit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62318B964175E7D02FE83914 /* MuscleTargetSplit.swift */; };
-		8C2580F9D7A5C52A72312A9A /* StatPeriod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8571CBB4B50589F1F8F36F44 /* StatPeriod.swift */; };
 		801BBDE42DF7338A00CDB1FB /* NoDataPlaceholderModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBD3E2DF7338A00CDB1FB /* NoDataPlaceholderModifier.swift */; };
 		801BBDE52DF7338A00CDB1FB /* WeightConverting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBCBF2DF7338A00CDB1FB /* WeightConverting.swift */; };
 		801BBDE62DF7338A00CDB1FB /* ExerciseRepetitionsTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBCEA2DF7338A00CDB1FB /* ExerciseRepetitionsTile.swift */; };
@@ -205,16 +197,6 @@
 		801BBE002DF7338A00CDB1FB /* String+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBCB32DF7338A00CDB1FB /* String+.swift */; };
 		801BBE012DF7338A00CDB1FB /* Database+EntityCreation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBCC32DF7338A00CDB1FB /* Database+EntityCreation.swift */; };
 		801BBE022DF7338A00CDB1FB /* OverallSetsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBD022DF7338A00CDB1FB /* OverallSetsScreen.swift */; };
-		79BB043F7BA96F3DE3739FB7 /* SummaryEmptyStates.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC42311A655A248061E11238 /* SummaryEmptyStates.swift */; };
-		1E7CF1C1E77503BD192ECE23 /* WorkoutGoalScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA376FF1C58639B7542A334 /* WorkoutGoalScreen.swift */; };
-		E18E0521AED5762B30E5FA1F /* MuscleGroupDetailScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFD9E1A9B2D266CBA7AE5F18 /* MuscleGroupDetailScreen.swift */; };
-		D0AF3C855D8D73E72DA7AF92 /* SummaryWelcomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E62F41D02C28CB089872E955 /* SummaryWelcomeView.swift */; };
-		23A5FD0EA5AC115CC0EC34E6 /* SummaryRecords.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADFEC5772AE8932AA1089603 /* SummaryRecords.swift */; };
-		FE01CA11AB1E5077AE000002 /* SummaryProgressTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE01CA11AB1E5077AE000001 /* SummaryProgressTab.swift */; };
-		BACD36D82914BE00C27FE040 /* MuscleTargetSplitScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80C7068F531DB65831E8FA8F /* MuscleTargetSplitScreen.swift */; };
-		07A5D2C54CA81141164E3D9D /* MuscleGroupsOverviewScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54FB7DD2DDA0DE70BD366F9C /* MuscleGroupsOverviewScreen.swift */; };
-		85D5027D8B1FA8DB36998EBC /* SummaryStatScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE557E27ADC9A2C02BE79DBE /* SummaryStatScreen.swift */; };
-		C936BF70D80E3354D1D5BD21 /* SummaryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B422D4E53B9396026019B50 /* SummaryViewModel.swift */; };
 		801BBE032DF7338A00CDB1FB /* MeasurementView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBD072DF7338A00CDB1FB /* MeasurementView.swift */; };
 		801BBE042DF7338A00CDB1FB /* ChangeWeeklyWorkoutGoalScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBCFE2DF7338A00CDB1FB /* ChangeWeeklyWorkoutGoalScreen.swift */; };
 		801BBE052DF7338A00CDB1FB /* PrivacyPolicyScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBD2E2DF7338A00CDB1FB /* PrivacyPolicyScreen.swift */; };
@@ -243,23 +225,20 @@
 		80CBE1D52ED7AFD500DDE1C5 /* MeasurementsEditSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80CBE1D32ED7AFD500DDE1C5 /* MeasurementsEditSheet.swift */; };
 		80CBE1D62ED7AFD500DDE1C5 /* MeasurementDetailScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80CBE1D22ED7AFD500DDE1C5 /* MeasurementDetailScreen.swift */; };
 		80CBE1D72ED7AFD500DDE1C5 /* MeasurementTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80CBE1D42ED7AFD500DDE1C5 /* MeasurementTile.swift */; };
-		BF2572963E23536237AA7662 /* MeasurementWatchlistRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE91C0394869857C0E932723 /* MeasurementWatchlistRow.swift */; };
 		80NEWSHAR001 /* WorkoutActivityItemSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80NEWSHAR002 /* WorkoutActivityItemSource.swift */; };
 		80NEWTEST001 /* TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80NEWTEST002 /* TestHelpers.swift */; };
 		80NEWTEST003 /* WeightConvertingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80NEWTEST004 /* WeightConvertingTests.swift */; };
-		34ED649B10150341352AE3D1 /* StatPeriodTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F8CD271000D75928FAE0887 /* StatPeriodTests.swift */; };
 		80NEWTEST005 /* VolumeCalculatingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80NEWTEST006 /* VolumeCalculatingTests.swift */; };
 		80NEWTEST007 /* EntityExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80NEWTEST008 /* EntityExtensionTests.swift */; };
 		80NEWTEST009 /* ServicesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80NEWTEST00A /* ServicesTests.swift */; };
 		80NEWTEST00B /* WorkoutSharingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80NEWTEST00C /* WorkoutSharingTests.swift */; };
 		85709CDA5A20D6B7D9C23487 /* ExerciseMergeServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF956F5D14BBB78133BD528A /* ExerciseMergeServiceTests.swift */; };
+		85D5027D8B1FA8DB36998EBC /* SummaryStatScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE557E27ADC9A2C02BE79DBE /* SummaryStatScreen.swift */; };
 		898FDFC3AC4FF171A0E6C549 /* WorkoutLiveActivityAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 829F12D41C231764936B6B83 /* WorkoutLiveActivityAttributes.swift */; };
+		8C2580F9D7A5C52A72312A9A /* StatPeriod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8571CBB4B50589F1F8F36F44 /* StatPeriod.swift */; };
 		8C6BE79BA086E3876A56C1D7 /* SharedWithYouBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3184F4CAAB24791B6F5AC79A /* SharedWithYouBanner.swift */; };
 		8E306606440725A568FE5F1A /* ExerciseMergeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF0CFD6EDA94DA1792A2CA82 /* ExerciseMergeService.swift */; };
 		8F4A3C022E5A9B0100D4E5F2 /* SetVolumeBarChart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F4A3C012E5A9B0100D4E5F1 /* SetVolumeBarChart.swift */; };
-		A1B2C3D4E5F600000003B003 /* MuscleBalanceHistoryChart.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F600000003F003 /* MuscleBalanceHistoryChart.swift */; };
-		E1E1E1000000000000000B13 /* TileBarChartStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1E1E1000000000000000F13 /* TileBarChartStyle.swift */; };
-		E1E1E1000000000000000B14 /* TileSparklineStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1E1E1000000000000000F14 /* TileSparklineStyle.swift */; };
 		9392C43C9501E6676A02488A /* WorkoutLiveActivitySnapshotBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B6F634C95B552C305EA0055 /* WorkoutLiveActivitySnapshotBuilder.swift */; };
 		9C03B11C8A034786C5544D2E /* ScreenshotFixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = C05F3FE01CADB8E0526C799F /* ScreenshotFixtures.swift */; };
 		9D2E7A022F30AA0100C1D2E2 /* DemoWorkoutSeeder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D2E7A012F30AA0100C1D2E1 /* DemoWorkoutSeeder.swift */; };
@@ -279,19 +258,41 @@
 		A1000000000000000000001B /* logit_terms_and_conditions_ja.md in Resources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000005B /* logit_terms_and_conditions_ja.md */; };
 		A1000000000000000000001C /* logit_terms_and_conditions_ko.md in Resources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000005C /* logit_terms_and_conditions_ko.md */; };
 		A1000000000000000000001D /* logit_terms_and_conditions_it.md in Resources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000005D /* logit_terms_and_conditions_it.md */; };
+		A1B2C3D4E5F600000001B001 /* MuscleBalanceHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F600000001F001 /* MuscleBalanceHistory.swift */; };
+		A1B2C3D4E5F600000003B003 /* MuscleBalanceHistoryChart.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F600000003F003 /* MuscleBalanceHistoryChart.swift */; };
+		A1B2C3D4E5F600000007B007 /* MuscleBalanceBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F600000007F007 /* MuscleBalanceBar.swift */; };
 		A1C7F2E409AB4D11AA01FE10 /* WorkoutProgressSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1C7F2E309AB4D11AA01FE10 /* WorkoutProgressSection.swift */; };
-		E1E1E1000000000000000B09 /* WorkoutStatTiles.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1E1E1000000000000000F09 /* WorkoutStatTiles.swift */; };
-		E1E1E1000000000000000B0A /* WorkoutStatScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1E1E1000000000000000F0A /* WorkoutStatScreen.swift */; };
+		A6CA17B3772D8CC88F1E0E19 /* MuscleBalanceTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 547CD2BA3A17B483651496C5 /* MuscleBalanceTile.swift */; };
+		AA976DD8C23A04BD91CEB858 /* MuscleTargetSplit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62318B964175E7D02FE83914 /* MuscleTargetSplit.swift */; };
 		ACC49C37E1B74DFAC016299F /* ShareSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14BDE77C44D210E79936D216 /* ShareSheet.swift */; };
 		B3DC6B7D9EF58D3A51C28227 /* LOGITScreenshots.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CDACB5BDD447438F8D60BAE /* LOGITScreenshots.swift */; };
+		B57097634BC79614715AE3EF /* SummaryStatTiles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 336772BB4E860E3894BA7355 /* SummaryStatTiles.swift */; };
+		BACD36D82914BE00C27FE040 /* MuscleTargetSplitScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80C7068F531DB65831E8FA8F /* MuscleTargetSplitScreen.swift */; };
+		BF2572963E23536237AA7662 /* MeasurementWatchlistRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE91C0394869857C0E932723 /* MeasurementWatchlistRow.swift */; };
+		C936BF70D80E3354D1D5BD21 /* SummaryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B422D4E53B9396026019B50 /* SummaryViewModel.swift */; };
+		D0AF3C855D8D73E72DA7AF92 /* SummaryWelcomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E62F41D02C28CB089872E955 /* SummaryWelcomeView.swift */; };
+		D1D1D1000000000000000B01 /* MetricTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1D1D1000000000000000F01 /* MetricTile.swift */; };
+		E18E0521AED5762B30E5FA1F /* MuscleGroupDetailScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFD9E1A9B2D266CBA7AE5F18 /* MuscleGroupDetailScreen.swift */; };
 		E1E1E1000000000000000B01 /* ExerciseE1RMTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1E1E1000000000000000F01 /* ExerciseE1RMTile.swift */; };
 		E1E1E1000000000000000B02 /* ExerciseE1RMScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1E1E1000000000000000F02 /* ExerciseE1RMScreen.swift */; };
 		E1E1E1000000000000000B05 /* ExerciseSetVolumeTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1E1E1000000000000000F05 /* ExerciseSetVolumeTile.swift */; };
 		E1E1E1000000000000000B06 /* ExerciseSetVolumeScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1E1E1000000000000000F06 /* ExerciseSetVolumeScreen.swift */; };
 		E1E1E1000000000000000B07 /* AboutSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1E1E1000000000000000F07 /* AboutSection.swift */; };
+		E1E1E1000000000000000B08 /* ExerciseMetricTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1E1E1000000000000000F08 /* ExerciseMetricTile.swift */; };
+		E1E1E1000000000000000B09 /* WorkoutStatTiles.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1E1E1000000000000000F09 /* WorkoutStatTiles.swift */; };
+		E1E1E1000000000000000B0A /* WorkoutStatScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1E1E1000000000000000F0A /* WorkoutStatScreen.swift */; };
+		E1E1E1000000000000000B10 /* ExerciseSetsTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1E1E1000000000000000F10 /* ExerciseSetsTile.swift */; };
+		E1E1E1000000000000000B11 /* ExerciseSetsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1E1E1000000000000000F11 /* ExerciseSetsScreen.swift */; };
+		E1E1E1000000000000000B12 /* ProgressIndicatorPill.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1E1E1000000000000000F12 /* ProgressIndicatorPill.swift */; };
+		E1E1E1000000000000000B13 /* TileBarChartStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1E1E1000000000000000F13 /* TileBarChartStyle.swift */; };
+		E1E1E1000000000000000B14 /* TileSparklineStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1E1E1000000000000000F14 /* TileSparklineStyle.swift */; };
+		E1E1E1000000000000000B15 /* MetricComparisonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1E1E1000000000000000F15 /* MetricComparisonView.swift */; };
+		E1E1E1000000000000000B16 /* PersonalBestRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1E1E1000000000000000F16 /* PersonalBestRow.swift */; };
 		E5F79A5B29FEF4F260749E66 /* LiveActivityShowcaseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A95CC85E7895692DD1082ACD /* LiveActivityShowcaseView.swift */; };
+		F344926EBBAE89A564139E06 /* MuscleTargetSplitStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DDAB0743896FB9245B6D5A9 /* MuscleTargetSplitStore.swift */; };
 		F83E8531DDDC8C271BDF20F1 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A72B470FE19DAE1E42233F7F /* Foundation.framework */; };
 		FAC9CFA615E04E86BD814205 /* OneRepMaxCalculating.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6923C33A92504E5287236332 /* OneRepMaxCalculating.swift */; };
+		FE01CA11AB1E5077AE000002 /* SummaryProgressTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE01CA11AB1E5077AE000001 /* SummaryProgressTab.swift */; };
 		FF178CF5635C188320F0E7B4 /* WorkoutLiveActivityWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19AE937C7333501AE5BD9977 /* WorkoutLiveActivityWidget.swift */; };
 /* End PBXBuildFile section */
 
@@ -345,28 +346,30 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0258213863A5C9812190A44D /* MuscleBalanceCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MuscleBalanceCalculator.swift; sourceTree = "<group>"; };
 		0400C2E827A4AEAF03BACDC6 /* SnapshotHelper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SnapshotHelper.swift; sourceTree = "<group>"; };
 		06A7CD832F8CF2FDAB33579C /* WorkoutLiveActivityManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkoutLiveActivityManager.swift; sourceTree = "<group>"; };
 		0D5D5995AEAE4AA8849AAF28 /* TrendIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrendIndicatorView.swift; sourceTree = "<group>"; };
-		D1D1D1000000000000000F01 /* MetricTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetricTile.swift; sourceTree = "<group>"; };
-		BBBF6087BB65A5971FB5F866 /* BodyMapFigure.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BodyMapFigure.swift; sourceTree = "<group>"; };
-		3C72085C4C10146858277690 /* CompletionRing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionRing.swift; sourceTree = "<group>"; };
-		BEA597E1519E8F6D2CBC8F9E /* PeriodPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeriodPicker.swift; sourceTree = "<group>"; };
-		E1E1E1000000000000000F12 /* ProgressIndicatorPill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressIndicatorPill.swift; sourceTree = "<group>"; };
-		E1E1E1000000000000000F16 /* PersonalBestRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonalBestRow.swift; sourceTree = "<group>"; };
-		E1E1E1000000000000000F15 /* MetricComparisonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetricComparisonView.swift; sourceTree = "<group>"; };
 		0E384D0F4B54340F910F6813 /* ExerciseMergingSheet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ExerciseMergingSheet.swift; sourceTree = "<group>"; };
 		144AED8F76DE3EBB1A1752AD /* LOGITUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LOGITUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		14BDE77C44D210E79936D216 /* ShareSheet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ShareSheet.swift; sourceTree = "<group>"; };
 		19AE937C7333501AE5BD9977 /* WorkoutLiveActivityWidget.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkoutLiveActivityWidget.swift; sourceTree = "<group>"; };
 		1EB3B92BF7A5E9FE9E442716 /* WorkoutSharingService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkoutSharingService.swift; sourceTree = "<group>"; };
 		22040B8B5D5971A78B9E3A04 /* Pods_LOGIT.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_LOGIT.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		2B422D4E53B9396026019B50 /* SummaryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryViewModel.swift; sourceTree = "<group>"; };
 		3184F4CAAB24791B6F5AC79A /* SharedWithYouBanner.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SharedWithYouBanner.swift; sourceTree = "<group>"; };
+		336772BB4E860E3894BA7355 /* SummaryStatTiles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryStatTiles.swift; sourceTree = "<group>"; };
+		3C72085C4C10146858277690 /* CompletionRing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionRing.swift; sourceTree = "<group>"; };
 		3CDACB5BDD447438F8D60BAE /* LOGITScreenshots.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LOGITScreenshots.swift; sourceTree = "<group>"; };
+		3F67610775CDB7AC5571A4B9 /* ChartScaling.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ChartScaling.swift; sourceTree = "<group>"; };
 		4845CEF582EB23AB447C90B2 /* WorkoutDTO.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkoutDTO.swift; sourceTree = "<group>"; };
 		4B6F634C95B552C305EA0055 /* WorkoutLiveActivitySnapshotBuilder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkoutLiveActivitySnapshotBuilder.swift; sourceTree = "<group>"; };
+		4DDAB0743896FB9245B6D5A9 /* MuscleTargetSplitStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MuscleTargetSplitStore.swift; sourceTree = "<group>"; };
+		547CD2BA3A17B483651496C5 /* MuscleBalanceTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MuscleBalanceTile.swift; sourceTree = "<group>"; };
 		54EE2592821500000001 /* ExerciseSuggestionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseSuggestionService.swift; sourceTree = "<group>"; };
+		54FB7DD2DDA0DE70BD366F9C /* MuscleGroupsOverviewScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MuscleGroupsOverviewScreen.swift; sourceTree = "<group>"; };
 		5F7B218CB83CEAEB494355C8 /* WorkoutLiveActivitySnapshotBuilderTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkoutLiveActivitySnapshotBuilderTests.swift; sourceTree = "<group>"; };
+		62318B964175E7D02FE83914 /* MuscleTargetSplit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MuscleTargetSplit.swift; sourceTree = "<group>"; };
 		6923C33A92504E5287236332 /* OneRepMaxCalculating.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OneRepMaxCalculating.swift; sourceTree = "<group>"; };
 		7907FDE9289E99B1006AF271 /* CloudKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CloudKit.framework; path = System/Library/Frameworks/CloudKit.framework; sourceTree = SDKROOT; };
 		792A3FF22AB478F000C6A097 /* DatabaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseTests.swift; sourceTree = "<group>"; };
@@ -378,6 +381,7 @@
 		79D10973BCE1A0618D3256CD /* LOGITWidgetExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = LOGITWidgetExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		79E849072A7EA28000C0DF95 /* LOGITTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LOGITTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		79E849092A7EA28000C0DF95 /* ExerciseServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseServiceTests.swift; sourceTree = "<group>"; };
+		7F8CD271000D75928FAE0887 /* StatPeriodTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatPeriodTests.swift; sourceTree = "<group>"; };
 		80036CDA2EFEF98C00B7C7B4 /* GlobalSearchScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalSearchScreen.swift; sourceTree = "<group>"; };
 		80036CDD2EFEF9CE00B7C7B4 /* FuzzySearchService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FuzzySearchService.swift; sourceTree = "<group>"; };
 		801BBC932DF7338A00CDB1FB /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -392,8 +396,6 @@
 		801BBC9F2DF7338A00CDB1FB /* Secrets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Secrets.swift; sourceTree = "<group>"; };
 		801BBCA12DF7338A00CDB1FB /* MeasurementEntryType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeasurementEntryType.swift; sourceTree = "<group>"; };
 		801BBCA22DF7338A00CDB1FB /* MuscleGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MuscleGroup.swift; sourceTree = "<group>"; };
-		62318B964175E7D02FE83914 /* MuscleTargetSplit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MuscleTargetSplit.swift; sourceTree = "<group>"; };
-		8571CBB4B50589F1F8F36F44 /* StatPeriod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatPeriod.swift; sourceTree = "<group>"; };
 		801BBCA32DF7338A00CDB1FB /* WeightUnit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeightUnit.swift; sourceTree = "<group>"; };
 		801BBCA42DF7338A00CDB1FB /* WidgetCollectionType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetCollectionType.swift; sourceTree = "<group>"; };
 		801BBCA52DF7338A00CDB1FB /* WidgetType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetType.swift; sourceTree = "<group>"; };
@@ -454,38 +456,22 @@
 		801BBCE62DF7338A00CDB1FB /* WorkoutSetPredicateFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutSetPredicateFactory.swift; sourceTree = "<group>"; };
 		801BBCEA2DF7338A00CDB1FB /* ExerciseRepetitionsTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseRepetitionsTile.swift; sourceTree = "<group>"; };
 		801BBCEB2DF7338A00CDB1FB /* ExerciseVolumeTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseVolumeTile.swift; sourceTree = "<group>"; };
-		E1E1E1000000000000000F10 /* ExerciseSetsTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseSetsTile.swift; sourceTree = "<group>"; };
-		E1E1E1000000000000000F08 /* ExerciseMetricTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseMetricTile.swift; sourceTree = "<group>"; };
 		801BBCEC2DF7338A00CDB1FB /* ExerciseWeightTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseWeightTile.swift; sourceTree = "<group>"; };
 		801BBCEE2DF7338A00CDB1FB /* ExerciseDetailScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseDetailScreen.swift; sourceTree = "<group>"; };
 		801BBCEF2DF7338A00CDB1FB /* ExerciseHistoryScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseHistoryScreen.swift; sourceTree = "<group>"; };
 		801BBCF02DF7338A00CDB1FB /* ExerciseRepetitionsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseRepetitionsScreen.swift; sourceTree = "<group>"; };
 		801BBCF12DF7338A00CDB1FB /* ExerciseVolumeScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseVolumeScreen.swift; sourceTree = "<group>"; };
-		E1E1E1000000000000000F11 /* ExerciseSetsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseSetsScreen.swift; sourceTree = "<group>"; };
 		801BBCF22DF7338A00CDB1FB /* ExerciseWeightScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseWeightScreen.swift; sourceTree = "<group>"; };
 		801BBCF42DF7338A00CDB1FB /* ExerciseCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseCell.swift; sourceTree = "<group>"; };
 		801BBCF52DF7338A00CDB1FB /* ExerciseEditScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseEditScreen.swift; sourceTree = "<group>"; };
 		801BBCF62DF7338A00CDB1FB /* ExerciseListScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseListScreen.swift; sourceTree = "<group>"; };
 		801BBCF72DF7338A00CDB1FB /* ExerciseSelectionScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseSelectionScreen.swift; sourceTree = "<group>"; };
 		801BBCFB2DF7338A00CDB1FB /* OverallSetsTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverallSetsTile.swift; sourceTree = "<group>"; };
-		547CD2BA3A17B483651496C5 /* MuscleBalanceTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MuscleBalanceTile.swift; sourceTree = "<group>"; };
-		CF1126F67238BF3E85FCC8C8 /* WeeklyGoalHeroTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyGoalHeroTile.swift; sourceTree = "<group>"; };
-		336772BB4E860E3894BA7355 /* SummaryStatTiles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryStatTiles.swift; sourceTree = "<group>"; };
 		801BBCFC2DF7338A00CDB1FB /* VolumeTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolumeTile.swift; sourceTree = "<group>"; };
 		801BBCFE2DF7338A00CDB1FB /* ChangeWeeklyWorkoutGoalScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeWeeklyWorkoutGoalScreen.swift; sourceTree = "<group>"; };
 		801BBCFF2DF7338A00CDB1FB /* HomeNavigationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeNavigationCoordinator.swift; sourceTree = "<group>"; };
 		801BBD002DF7338A00CDB1FB /* HomeScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeScreen.swift; sourceTree = "<group>"; };
 		801BBD022DF7338A00CDB1FB /* OverallSetsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverallSetsScreen.swift; sourceTree = "<group>"; };
-		DC42311A655A248061E11238 /* SummaryEmptyStates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryEmptyStates.swift; sourceTree = "<group>"; };
-		8BA376FF1C58639B7542A334 /* WorkoutGoalScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutGoalScreen.swift; sourceTree = "<group>"; };
-		FFD9E1A9B2D266CBA7AE5F18 /* MuscleGroupDetailScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MuscleGroupDetailScreen.swift; sourceTree = "<group>"; };
-		E62F41D02C28CB089872E955 /* SummaryWelcomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryWelcomeView.swift; sourceTree = "<group>"; };
-		ADFEC5772AE8932AA1089603 /* SummaryRecords.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryRecords.swift; sourceTree = "<group>"; };
-		FE01CA11AB1E5077AE000001 /* SummaryProgressTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryProgressTab.swift; sourceTree = "<group>"; };
-		80C7068F531DB65831E8FA8F /* MuscleTargetSplitScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MuscleTargetSplitScreen.swift; sourceTree = "<group>"; };
-		54FB7DD2DDA0DE70BD366F9C /* MuscleGroupsOverviewScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MuscleGroupsOverviewScreen.swift; sourceTree = "<group>"; };
-		DE557E27ADC9A2C02BE79DBE /* SummaryStatScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryStatScreen.swift; sourceTree = "<group>"; };
-		2B422D4E53B9396026019B50 /* SummaryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryViewModel.swift; sourceTree = "<group>"; };
 		801BBD032DF7338A00CDB1FB /* TargetPerWeekDetailScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TargetPerWeekDetailScreen.swift; sourceTree = "<group>"; };
 		801BBD042DF7338A00CDB1FB /* VolumeScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolumeScreen.swift; sourceTree = "<group>"; };
 		801BBD062DF7338A00CDB1FB /* MeasurementsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeasurementsScreen.swift; sourceTree = "<group>"; };
@@ -524,9 +510,6 @@
 		801BBD302DF7338A00CDB1FB /* SettingsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsScreen.swift; sourceTree = "<group>"; };
 		801BBD312DF7338A00CDB1FB /* UpgradeToProScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpgradeToProScreen.swift; sourceTree = "<group>"; };
 		801BBD332DF7338A00CDB1FB /* MuscleGroupService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MuscleGroupService.swift; sourceTree = "<group>"; };
-		0258213863A5C9812190A44D /* MuscleBalanceCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MuscleBalanceCalculator.swift; sourceTree = "<group>"; };
-		A1B2C3D4E5F600000001F001 /* MuscleBalanceHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MuscleBalanceHistory.swift; sourceTree = "<group>"; };
-		4DDAB0743896FB9245B6D5A9 /* MuscleTargetSplitStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MuscleTargetSplitStore.swift; sourceTree = "<group>"; };
 		801BBD352DF7338A00CDB1FB /* DateBarChart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateBarChart.swift; sourceTree = "<group>"; };
 		801BBD362DF7338A00CDB1FB /* DateLineChart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateLineChart.swift; sourceTree = "<group>"; };
 		801BBD372DF7338A00CDB1FB /* MuscleGroupOccurancesChart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MuscleGroupOccurancesChart.swift; sourceTree = "<group>"; };
@@ -555,7 +538,6 @@
 		801BBD522DF7338A00CDB1FB /* IntegerField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegerField.swift; sourceTree = "<group>"; };
 		801BBD532DF7338A00CDB1FB /* LogitProLogo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogitProLogo.swift; sourceTree = "<group>"; };
 		801BBD542DF7338A00CDB1FB /* MuscleGroupSelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MuscleGroupSelector.swift; sourceTree = "<group>"; };
-		A1B2C3D4E5F600000007F007 /* MuscleBalanceBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MuscleBalanceBar.swift; sourceTree = "<group>"; };
 		801BBD552DF7338A00CDB1FB /* NavigationChevron.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationChevron.swift; sourceTree = "<group>"; };
 		801BBD562DF7338A00CDB1FB /* ReorderableForEach.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReorderableForEach.swift; sourceTree = "<group>"; };
 		801BBD582DF7338A00CDB1FB /* TipView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TipView.swift; sourceTree = "<group>"; };
@@ -587,23 +569,21 @@
 		80AA000B2F3A000100AA0001 /* WorkoutRecorderFloatingStopwatchStopButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutRecorderFloatingStopwatchStopButton.swift; sourceTree = "<group>"; };
 		80B387BA2EBA187100AD7EFC /* DecimalField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecimalField.swift; sourceTree = "<group>"; };
 		80BEEP022EF0000000000001 /* beep.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = beep.wav; sourceTree = "<group>"; };
+		80C7068F531DB65831E8FA8F /* MuscleTargetSplitScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MuscleTargetSplitScreen.swift; sourceTree = "<group>"; };
 		80CBE1D22ED7AFD500DDE1C5 /* MeasurementDetailScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeasurementDetailScreen.swift; sourceTree = "<group>"; };
 		80CBE1D32ED7AFD500DDE1C5 /* MeasurementsEditSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeasurementsEditSheet.swift; sourceTree = "<group>"; };
 		80CBE1D42ED7AFD500DDE1C5 /* MeasurementTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeasurementTile.swift; sourceTree = "<group>"; };
-		FE91C0394869857C0E932723 /* MeasurementWatchlistRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeasurementWatchlistRow.swift; sourceTree = "<group>"; };
 		80NEWSHAR002 /* WorkoutActivityItemSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutActivityItemSource.swift; sourceTree = "<group>"; };
 		80NEWTEST002 /* TestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestHelpers.swift; sourceTree = "<group>"; };
 		80NEWTEST004 /* WeightConvertingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeightConvertingTests.swift; sourceTree = "<group>"; };
-		7F8CD271000D75928FAE0887 /* StatPeriodTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatPeriodTests.swift; sourceTree = "<group>"; };
 		80NEWTEST006 /* VolumeCalculatingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolumeCalculatingTests.swift; sourceTree = "<group>"; };
 		80NEWTEST008 /* EntityExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntityExtensionTests.swift; sourceTree = "<group>"; };
 		80NEWTEST00A /* ServicesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServicesTests.swift; sourceTree = "<group>"; };
 		80NEWTEST00C /* WorkoutSharingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutSharingTests.swift; sourceTree = "<group>"; };
 		829F12D41C231764936B6B83 /* WorkoutLiveActivityAttributes.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkoutLiveActivityAttributes.swift; sourceTree = "<group>"; };
+		8571CBB4B50589F1F8F36F44 /* StatPeriod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatPeriod.swift; sourceTree = "<group>"; };
+		8BA376FF1C58639B7542A334 /* WorkoutGoalScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutGoalScreen.swift; sourceTree = "<group>"; };
 		8F4A3C012E5A9B0100D4E5F1 /* SetVolumeBarChart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetVolumeBarChart.swift; sourceTree = "<group>"; };
-		A1B2C3D4E5F600000003F003 /* MuscleBalanceHistoryChart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MuscleBalanceHistoryChart.swift; sourceTree = "<group>"; };
-		E1E1E1000000000000000F13 /* TileBarChartStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TileBarChartStyle.swift; sourceTree = "<group>"; };
-		E1E1E1000000000000000F14 /* TileSparklineStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TileSparklineStyle.swift; sourceTree = "<group>"; };
 		9D2E7A012F30AA0100C1D2E1 /* DemoWorkoutSeeder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DemoWorkoutSeeder.swift; sourceTree = "<group>"; };
 		A10000000000000000000002 /* LocalizedMarkdown.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizedMarkdown.swift; sourceTree = "<group>"; };
 		A10000000000000000000050 /* logit_privacy_policy_de.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = logit_privacy_policy_de.md; sourceTree = "<group>"; };
@@ -626,22 +606,44 @@
 		A10000000000000000000103 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Localizable.strings; sourceTree = "<group>"; };
 		A10000000000000000000104 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/Localizable.strings; sourceTree = "<group>"; };
 		A10000000000000000000105 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/Localizable.strings; sourceTree = "<group>"; };
+		A1B2C3D4E5F600000001F001 /* MuscleBalanceHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MuscleBalanceHistory.swift; sourceTree = "<group>"; };
+		A1B2C3D4E5F600000003F003 /* MuscleBalanceHistoryChart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MuscleBalanceHistoryChart.swift; sourceTree = "<group>"; };
+		A1B2C3D4E5F600000007F007 /* MuscleBalanceBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MuscleBalanceBar.swift; sourceTree = "<group>"; };
 		A1C7F2E309AB4D11AA01FE10 /* WorkoutProgressSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutProgressSection.swift; sourceTree = "<group>"; };
-		E1E1E1000000000000000F09 /* WorkoutStatTiles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutStatTiles.swift; sourceTree = "<group>"; };
-		E1E1E1000000000000000F0A /* WorkoutStatScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutStatScreen.swift; sourceTree = "<group>"; };
 		A72B470FE19DAE1E42233F7F /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		A95CC85E7895692DD1082ACD /* LiveActivityShowcaseView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LiveActivityShowcaseView.swift; sourceTree = "<group>"; };
+		ADFEC5772AE8932AA1089603 /* SummaryRecords.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryRecords.swift; sourceTree = "<group>"; };
 		AF0CFD6EDA94DA1792A2CA82 /* ExerciseMergeService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ExerciseMergeService.swift; sourceTree = "<group>"; };
 		BA2F6D7984C9394E060503E7 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		BBBF6087BB65A5971FB5F866 /* BodyMapFigure.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BodyMapFigure.swift; sourceTree = "<group>"; };
+		BEA597E1519E8F6D2CBC8F9E /* PeriodPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeriodPicker.swift; sourceTree = "<group>"; };
 		C05F3FE01CADB8E0526C799F /* ScreenshotFixtures.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ScreenshotFixtures.swift; sourceTree = "<group>"; };
 		C3BDDD14FE5BF0C275AF30C5 /* LOGITWidgetExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LOGITWidgetExtension.swift; sourceTree = "<group>"; };
+		CF1126F67238BF3E85FCC8C8 /* WeeklyGoalHeroTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyGoalHeroTile.swift; sourceTree = "<group>"; };
+		D1D1D1000000000000000F01 /* MetricTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetricTile.swift; sourceTree = "<group>"; };
+		DC42311A655A248061E11238 /* SummaryEmptyStates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryEmptyStates.swift; sourceTree = "<group>"; };
 		DD50531C168D4EDFB527D76A /* SetEntityClasses.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetEntityClasses.swift; sourceTree = "<group>"; };
+		DE557E27ADC9A2C02BE79DBE /* SummaryStatScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryStatScreen.swift; sourceTree = "<group>"; };
 		E1E1E1000000000000000F01 /* ExerciseE1RMTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseE1RMTile.swift; sourceTree = "<group>"; };
 		E1E1E1000000000000000F02 /* ExerciseE1RMScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseE1RMScreen.swift; sourceTree = "<group>"; };
 		E1E1E1000000000000000F05 /* ExerciseSetVolumeTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseSetVolumeTile.swift; sourceTree = "<group>"; };
 		E1E1E1000000000000000F06 /* ExerciseSetVolumeScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseSetVolumeScreen.swift; sourceTree = "<group>"; };
 		E1E1E1000000000000000F07 /* AboutSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutSection.swift; sourceTree = "<group>"; };
+		E1E1E1000000000000000F08 /* ExerciseMetricTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseMetricTile.swift; sourceTree = "<group>"; };
+		E1E1E1000000000000000F09 /* WorkoutStatTiles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutStatTiles.swift; sourceTree = "<group>"; };
+		E1E1E1000000000000000F0A /* WorkoutStatScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutStatScreen.swift; sourceTree = "<group>"; };
+		E1E1E1000000000000000F10 /* ExerciseSetsTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseSetsTile.swift; sourceTree = "<group>"; };
+		E1E1E1000000000000000F11 /* ExerciseSetsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseSetsScreen.swift; sourceTree = "<group>"; };
+		E1E1E1000000000000000F12 /* ProgressIndicatorPill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressIndicatorPill.swift; sourceTree = "<group>"; };
+		E1E1E1000000000000000F13 /* TileBarChartStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TileBarChartStyle.swift; sourceTree = "<group>"; };
+		E1E1E1000000000000000F14 /* TileSparklineStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TileSparklineStyle.swift; sourceTree = "<group>"; };
+		E1E1E1000000000000000F15 /* MetricComparisonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetricComparisonView.swift; sourceTree = "<group>"; };
+		E1E1E1000000000000000F16 /* PersonalBestRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonalBestRow.swift; sourceTree = "<group>"; };
+		E62F41D02C28CB089872E955 /* SummaryWelcomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryWelcomeView.swift; sourceTree = "<group>"; };
 		EF956F5D14BBB78133BD528A /* ExerciseMergeServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ExerciseMergeServiceTests.swift; sourceTree = "<group>"; };
+		FE01CA11AB1E5077AE000001 /* SummaryProgressTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryProgressTab.swift; sourceTree = "<group>"; };
+		FE91C0394869857C0E932723 /* MeasurementWatchlistRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeasurementWatchlistRow.swift; sourceTree = "<group>"; };
+		FFD9E1A9B2D266CBA7AE5F18 /* MuscleGroupDetailScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MuscleGroupDetailScreen.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1203,6 +1205,7 @@
 				A1B2C3D4E5F600000003F003 /* MuscleBalanceHistoryChart.swift */,
 				E1E1E1000000000000000F13 /* TileBarChartStyle.swift */,
 				E1E1E1000000000000000F14 /* TileSparklineStyle.swift */,
+				3F67610775CDB7AC5571A4B9 /* ChartScaling.swift */,
 			);
 			path = Charts;
 			sourceTree = "<group>";
@@ -1821,6 +1824,7 @@
 				9C03B11C8A034786C5544D2E /* ScreenshotFixtures.swift in Sources */,
 				9D2E7A022F30AA0100C1D2E2 /* DemoWorkoutSeeder.swift in Sources */,
 				E5F79A5B29FEF4F260749E66 /* LiveActivityShowcaseView.swift in Sources */,
+				33E50B21943F61B55A4481FC /* ChartScaling.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/LOGIT/Features/Exercise/ExerciseDetail/ExerciseE1RMScreen.swift
+++ b/LOGIT/Features/Exercise/ExerciseDetail/ExerciseE1RMScreen.swift
@@ -13,9 +13,6 @@ struct ExerciseE1RMScreen: View {
         case month, year
     }
 
-    private let yAxisMaxValuesKG = [10, 25, 50, 100, 150, 200, 300, 400, 500, 600, 700, 800, 900, 1000]
-    private let yAxisMaxValuesLBS = [25, 55, 110, 225, 335, 445, 665, 885, 1105, 1325, 1545, 1765, 1985, 2205]
-
     let exercise: Exercise
     let workoutSets: [WorkoutSet]
 
@@ -28,6 +25,13 @@ struct ExerciseE1RMScreen: View {
         // Determine the snapped selected set only when a selection exists; snap to the nearest datapoint (prefer visible)
         let snappedSelectedSet: WorkoutSet? = selectedDate != nil ? nearestSet(to: selectedDate, in: allDailyMaxSets) : nil
         let bestVisibleE1RM = bestE1RMInGranularity(workoutSets)
+        let yScaleCap = chartYScaleCap(
+            visibleMax: chartVisibleLineMax(
+                of: chartPoints(from: allDailyMaxSets),
+                from: chartScrollPosition,
+                to: visibleEndDate
+            )
+        )
         ScrollView {
             VStack(spacing: SECTION_SPACING) {
                 VStack {
@@ -165,7 +169,7 @@ struct ExerciseE1RMScreen: View {
                         }
                     }
                     .chartXScale(domain: xDomain(for: workoutSets))
-                    .chartYScale(domain: 0 ... chartYScaleMax(maxYValue: allTimeE1RMPR(in: workoutSets)))
+                    .chartYScale(domain: 0 ... yScaleCap)
                     .chartScrollableAxes(.horizontal)
                     .chartScrollPosition(x: $chartScrollPosition)
                     .chartScrollTargetBehavior(
@@ -175,6 +179,10 @@ struct ExerciseE1RMScreen: View {
                     )
                     .chartXSelection(value: $selectedDate)
                     .chartXVisibleDomain(length: visibleChartDomainInSeconds)
+                    // Rebuild the chart when the granularity flips: reusing the chart across visible-domain
+                    // changes leaves its scroll offset stale (the viewport shows a window months away from
+                    // chartScrollPosition), so give each granularity its own chart identity.
+                    .id(chartGranularity)
                     .chartXAxis {
                         AxisMarks(
                             position: .bottom,
@@ -190,8 +198,7 @@ struct ExerciseE1RMScreen: View {
                         }
                     }
                     .chartYAxis {
-                        let chartYScaleMax = chartYScaleMax(maxYValue: allTimeE1RMPR(in: workoutSets))
-                        AxisMarks(values: [0, chartYScaleMax / 2, chartYScaleMax])
+                        AxisMarks(values: .automatic(desiredCount: 3))
                     }
                     .emptyPlaceholder(allDailyMaxSets) {
                         Text(NSLocalizedString("noData", comment: ""))
@@ -304,16 +311,6 @@ struct ExerciseE1RMScreen: View {
         }
     }
 
-    private func allTimeE1RMPR(in workoutSets: [WorkoutSet]) -> Int {
-        convertWeightForDisplaying(
-            workoutSets
-                .map {
-                    $0.estimatedOneRepMax(for: exercise)
-                }
-                .max() ?? 0
-        )
-    }
-
     /// The header's left value and the comparison baseline: the best e1RM in the visible window
     /// *other than* the current best, falling back to the most recent day's best before the window
     /// when it holds no other value (see `exerciseOtherBestBaseline`).
@@ -326,10 +323,13 @@ struct ExerciseE1RMScreen: View {
         ) { $0.estimatedOneRepMax(for: exercise) }
     }
 
-    private func chartYScaleMax(maxYValue: Int) -> Int {
-        let values = WeightUnit.used == .kg ? yAxisMaxValuesKG : yAxisMaxValuesLBS
-        let nextBiggerYAxisMaxValue = values.filter { $0 > maxYValue }.min()
-        return nextBiggerYAxisMaxValue ?? maxYValue
+    /// The plotted daily-max series as plain (day, displayed value) points — the input for the
+    /// visible-window y-scale.
+    private func chartPoints(from sets: [WorkoutSet]) -> [(date: Date, value: Double)] {
+        sets.map { (
+            Calendar.current.startOfDay(for: $0.workout?.date ?? .now),
+            convertWeightForDisplayingDecimal($0.estimatedOneRepMax(for: exercise))
+        ) }
     }
 
     /// The fixed right-hand anchor of the header scoreboard, independent of scroll: the current best

--- a/LOGIT/Features/Exercise/ExerciseDetail/ExerciseRepetitionsScreen.swift
+++ b/LOGIT/Features/Exercise/ExerciseDetail/ExerciseRepetitionsScreen.swift
@@ -13,8 +13,6 @@ struct ExerciseRepetitionsScreen: View {
         case month, year
     }
 
-    private let yAxisMaxValues = [10, 20, 50, 100, 200]
-
     let exercise: Exercise
     let workoutSets: [WorkoutSet]
 
@@ -27,6 +25,13 @@ struct ExerciseRepetitionsScreen: View {
         // Determine the snapped selected set only when a selection exists; snap to the overall nearest datapoint
         let snappedSelectedSet: WorkoutSet? = selectedDate != nil ? nearestSet(to: selectedDate, in: allDailyMaxRepsSets) : nil
         let bestRepsInGranularity: Int? = bestRepetitionsInGranularity(in: workoutSets)
+        let yScaleCap = chartYScaleCap(
+            visibleMax: chartVisibleLineMax(
+                of: chartPoints(from: allDailyMaxRepsSets),
+                from: chartScrollPosition,
+                to: visibleEndDate
+            )
+        )
         ScrollView {
             VStack(spacing: SECTION_SPACING) {
                 VStack {
@@ -165,7 +170,7 @@ struct ExerciseRepetitionsScreen: View {
                 }
             }
             .chartXScale(domain: xDomain(for: workoutSets))
-            .chartYScale(domain: 0 ... chartYScaleMax(maxYValue: allTimeRepetitionsPR(in: workoutSets)))
+            .chartYScale(domain: 0 ... yScaleCap)
             .chartScrollableAxes(.horizontal)
             .chartScrollPosition(x: $chartScrollPosition)
             .chartScrollTargetBehavior(
@@ -175,6 +180,10 @@ struct ExerciseRepetitionsScreen: View {
             )
             .chartXSelection(value: $selectedDate)
             .chartXVisibleDomain(length: visibleChartDomainInSeconds)
+            // Rebuild the chart when the granularity flips: reusing the chart across visible-domain
+            // changes leaves its scroll offset stale (the viewport shows a window months away from
+            // chartScrollPosition), so give each granularity its own chart identity.
+            .id(chartGranularity)
             .chartXAxis {
                 AxisMarks(
                     position: .bottom,
@@ -190,8 +199,7 @@ struct ExerciseRepetitionsScreen: View {
                 }
             }
             .chartYAxis {
-                let chartYScaleMax = chartYScaleMax(maxYValue: allTimeRepetitionsPR(in: workoutSets))
-                AxisMarks(values: [0, chartYScaleMax / 2, chartYScaleMax])
+                AxisMarks(values: .automatic(desiredCount: 3))
             }
             .emptyPlaceholder(allDailyMaxRepsSets) {
                 Text(NSLocalizedString("noData", comment: ""))
@@ -308,14 +316,6 @@ struct ExerciseRepetitionsScreen: View {
         }
     }
 
-    private func allTimeRepetitionsPR(in workoutSets: [WorkoutSet]) -> Int {
-        workoutSets
-            .map {
-                $0.maximum(.repetitions, for: exercise)
-            }
-            .max() ?? 0
-    }
-
     /// The header's left value and the comparison baseline: the best reps in the visible window
     /// *other than* the current best, falling back to the most recent day's best before the window
     /// when it holds no other value (see `exerciseOtherBestBaseline`).
@@ -328,9 +328,13 @@ struct ExerciseRepetitionsScreen: View {
         ) { $0.maximum(.repetitions, for: exercise) }
     }
 
-    private func chartYScaleMax(maxYValue: Int) -> Int {
-        let nextBiggerYAxisMaxValue = yAxisMaxValues.filter { $0 > maxYValue }.min()
-        return nextBiggerYAxisMaxValue ?? maxYValue
+    /// The plotted daily-max series as plain (day, value) points — the input for the
+    /// visible-window y-scale.
+    private func chartPoints(from sets: [WorkoutSet]) -> [(date: Date, value: Double)] {
+        sets.map { (
+            Calendar.current.startOfDay(for: $0.workout?.date ?? .now),
+            Double($0.maximum(.repetitions, for: exercise))
+        ) }
     }
 
     /// The fixed right-hand anchor of the header scoreboard, independent of scroll: the current best

--- a/LOGIT/Features/Exercise/ExerciseDetail/ExerciseSetVolumeScreen.swift
+++ b/LOGIT/Features/Exercise/ExerciseDetail/ExerciseSetVolumeScreen.swift
@@ -25,6 +25,13 @@ struct ExerciseSetVolumeScreen: View {
         // Determine the snapped selected set only when a selection exists; snap to the nearest datapoint (prefer visible)
         let snappedSelectedSet: WorkoutSet? = selectedDate != nil ? nearestSet(to: selectedDate, in: allDailyMaxSets) : nil
         let bestVisibleSetVolume = bestSetVolumeInGranularity(workoutSets)
+        let yScaleCap = chartYScaleCap(
+            visibleMax: chartVisibleLineMax(
+                of: chartPoints(from: allDailyMaxSets),
+                from: chartScrollPosition,
+                to: visibleEndDate
+            )
+        )
         ScrollView {
             VStack(spacing: SECTION_SPACING) {
                 VStack {
@@ -162,7 +169,7 @@ struct ExerciseSetVolumeScreen: View {
                         }
                     }
                     .chartXScale(domain: xDomain(for: workoutSets))
-                    .chartYScale(domain: 0 ... chartYScaleMax(maxYValue: allTimeSetVolumePR(in: workoutSets)))
+                    .chartYScale(domain: 0 ... yScaleCap)
                     .chartScrollableAxes(.horizontal)
                     .chartScrollPosition(x: $chartScrollPosition)
                     .chartScrollTargetBehavior(
@@ -172,6 +179,10 @@ struct ExerciseSetVolumeScreen: View {
                     )
                     .chartXSelection(value: $selectedDate)
                     .chartXVisibleDomain(length: visibleChartDomainInSeconds)
+                    // Rebuild the chart when the granularity flips: reusing the chart across visible-domain
+                    // changes leaves its scroll offset stale (the viewport shows a window months away from
+                    // chartScrollPosition), so give each granularity its own chart identity.
+                    .id(chartGranularity)
                     .chartXAxis {
                         AxisMarks(
                             position: .bottom,
@@ -187,8 +198,7 @@ struct ExerciseSetVolumeScreen: View {
                         }
                     }
                     .chartYAxis {
-                        let chartYScaleMax = chartYScaleMax(maxYValue: allTimeSetVolumePR(in: workoutSets))
-                        AxisMarks(values: [0, chartYScaleMax / 2, chartYScaleMax])
+                        AxisMarks(values: .automatic(desiredCount: 3))
                     }
                     .emptyPlaceholder(allDailyMaxSets) {
                         Text(NSLocalizedString("noData", comment: ""))
@@ -301,16 +311,6 @@ struct ExerciseSetVolumeScreen: View {
         }
     }
 
-    private func allTimeSetVolumePR(in workoutSets: [WorkoutSet]) -> Int {
-        convertWeightForDisplaying(
-            workoutSets
-                .map {
-                    $0.volume(for: exercise)
-                }
-                .max() ?? 0
-        )
-    }
-
     /// The header's left value and the comparison baseline: the best single-set volume in the visible
     /// window *other than* the current best, falling back to the most recent day's best before the
     /// window when it holds no other value (see `exerciseOtherBestBaseline`).
@@ -323,14 +323,13 @@ struct ExerciseSetVolumeScreen: View {
         ) { $0.volume(for: exercise) }
     }
 
-    /// Set volume has no practical upper bound, so unlike the weight and e1RM screens (which pick
-    /// from a fixed list of axis caps) the cap is the PR rounded up to a clean half-magnitude step
-    /// — keeping the mid axis mark (cap / 2) a round number too.
-    private func chartYScaleMax(maxYValue: Int) -> Int {
-        guard maxYValue > 0 else { return 10 }
-        let magnitude = pow(10.0, floor(log10(Double(maxYValue))))
-        let step = magnitude / 2
-        return Int((Double(maxYValue) / step).rounded(.up) * step)
+    /// The plotted daily-max series as plain (day, displayed value) points — the input for the
+    /// visible-window y-scale.
+    private func chartPoints(from sets: [WorkoutSet]) -> [(date: Date, value: Double)] {
+        sets.map { (
+            Calendar.current.startOfDay(for: $0.workout?.date ?? .now),
+            convertWeightForDisplayingDecimal($0.volume(for: exercise))
+        ) }
     }
 
     /// The fixed right-hand anchor of the header scoreboard, independent of scroll: the current best

--- a/LOGIT/Features/Exercise/ExerciseDetail/ExerciseSetsScreen.swift
+++ b/LOGIT/Features/Exercise/ExerciseDetail/ExerciseSetsScreen.swift
@@ -26,6 +26,16 @@ struct ExerciseSetsScreen: View {
 
     var body: some View {
         let groupedWorkoutSets = Dictionary(grouping: workoutSets) { $0.workout?.date?.startOfWeek ?? .now }.sorted { $0.key < $1.key }
+        let weeklyPoints = groupedWorkoutSets.map { (date: $0.0, value: Double(setCount(for: $0.1))) }
+        let yScaleCap = chartYScaleCap(
+            visibleMax: chartVisibleMax(
+                of: weeklyPoints,
+                from: chartScrollPosition,
+                to: visibleEndDate,
+                bucketLength: 7 * 24 * 3600
+            ),
+            fallbackMax: weeklyPoints.map(\.value).max()
+        )
         let shownWeeklyAverage = averageWeekly(from: chartScrollPosition, to: visibleEndDate)
         let recentWeeklyAverage = averageWeekly(from: Exercise.currentBestWindowStart, to: .now)
         let averageTrendPercentage: Double? = {
@@ -103,6 +113,7 @@ struct ExerciseSetsScreen: View {
                     }
                 }
                 .chartXScale(domain: xDomain(for: groupedWorkoutSets.map { $0.1 }))
+                .chartYScale(domain: 0 ... yScaleCap)
                 .chartScrollableAxes(.horizontal)
                 .chartScrollPosition(x: $chartScrollPosition)
                 .chartScrollTargetBehavior(
@@ -112,6 +123,10 @@ struct ExerciseSetsScreen: View {
                 )
                 .chartXSelection(value: $selectedDate)
                 .chartXVisibleDomain(length: visibleChartDomainInSeconds)
+                // Rebuild the chart when the granularity flips: reusing the chart across visible-domain
+                // changes leaves its scroll offset stale (the viewport shows a window months away from
+                // chartScrollPosition), so give each granularity its own chart identity.
+                .id(chartGranularity)
                 .chartXAxis {
                     AxisMarks(
                         position: .bottom,
@@ -151,6 +166,18 @@ struct ExerciseSetsScreen: View {
         .onAppear {
             let firstDayOfNextWeek = Calendar.current.date(byAdding: .day, value: 1, to: .now.endOfWeek)!
             chartScrollPosition = Calendar.current.date(byAdding: .second, value: -visibleChartDomainInSeconds, to: firstDayOfNextWeek)!
+        }
+        .onChange(of: chartGranularity) {
+            // Re-initialize scroll position when switching granularity to avoid desync with visible window
+            let anchor: Date
+            switch chartGranularity {
+            case .month:
+                anchor = Calendar.current.date(byAdding: .day, value: 1, to: .now.endOfWeek)!
+            case .year:
+                // Align right edge roughly to next month for a stable yearly view
+                anchor = Calendar.current.date(byAdding: .month, value: 1, to: .now.startOfMonth)!
+            }
+            chartScrollPosition = Calendar.current.date(byAdding: .second, value: -visibleChartDomainInSeconds, to: anchor)!
         }
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {

--- a/LOGIT/Features/Exercise/ExerciseDetail/ExerciseVolumeScreen.swift
+++ b/LOGIT/Features/Exercise/ExerciseDetail/ExerciseVolumeScreen.swift
@@ -22,6 +22,16 @@ struct ExerciseVolumeScreen: View {
 
     var body: some View {
         let groupedWorkoutSets = Dictionary(grouping: workoutSets) { $0.workout?.date?.startOfWeek ?? .now }.sorted { $0.key < $1.key }
+        let weeklyPoints = groupedWorkoutSets.map { (date: $0.0, value: volume(for: $0.1)) }
+        let yScaleCap = chartYScaleCap(
+            visibleMax: chartVisibleMax(
+                of: weeklyPoints,
+                from: chartScrollPosition,
+                to: visibleEndDate,
+                bucketLength: 7 * 24 * 3600
+            ),
+            fallbackMax: weeklyPoints.map(\.value).max()
+        )
         let shownWeeklyAverage = averageWeekly(from: chartScrollPosition, to: visibleEndDate)
         let recentWeeklyAverage = averageWeekly(from: Exercise.currentBestWindowStart, to: .now)
         let averageTrendPercentage: Double? = {
@@ -106,6 +116,7 @@ struct ExerciseVolumeScreen: View {
                     }
                 }
                 .chartXScale(domain: xDomain(for: groupedWorkoutSets.map { $0.1 }))
+                .chartYScale(domain: 0 ... yScaleCap)
                 .chartScrollableAxes(.horizontal)
                 .chartScrollPosition(x: $chartScrollPosition)
                 .chartScrollTargetBehavior(
@@ -115,6 +126,10 @@ struct ExerciseVolumeScreen: View {
                 )
                 .chartXSelection(value: $selectedDate)
                 .chartXVisibleDomain(length: visibleChartDomainInSeconds)
+                // Rebuild the chart when the granularity flips: reusing the chart across visible-domain
+                // changes leaves its scroll offset stale (the viewport shows a window months away from
+                // chartScrollPosition), so give each granularity its own chart identity.
+                .id(chartGranularity)
                 .chartXAxis {
                     AxisMarks(
                         position: .bottom,
@@ -154,6 +169,18 @@ struct ExerciseVolumeScreen: View {
         .onAppear {
             let firstDayOfNextWeek = Calendar.current.date(byAdding: .day, value: 1, to: .now.endOfWeek)!
             chartScrollPosition = Calendar.current.date(byAdding: .second, value: -visibleChartDomainInSeconds, to: firstDayOfNextWeek)!
+        }
+        .onChange(of: chartGranularity) {
+            // Re-initialize scroll position when switching granularity to avoid desync with visible window
+            let anchor: Date
+            switch chartGranularity {
+            case .month:
+                anchor = Calendar.current.date(byAdding: .day, value: 1, to: .now.endOfWeek)!
+            case .year:
+                // Align right edge roughly to next month for a stable yearly view
+                anchor = Calendar.current.date(byAdding: .month, value: 1, to: .now.startOfMonth)!
+            }
+            chartScrollPosition = Calendar.current.date(byAdding: .second, value: -visibleChartDomainInSeconds, to: anchor)!
         }
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {

--- a/LOGIT/Features/Exercise/ExerciseDetail/ExerciseWeightScreen.swift
+++ b/LOGIT/Features/Exercise/ExerciseDetail/ExerciseWeightScreen.swift
@@ -13,9 +13,6 @@ struct ExerciseWeightScreen: View {
         case month, year
     }
 
-    private let yAxisMaxValuesKG = [10, 25, 50, 100, 150, 200, 300, 400, 500, 600, 700, 800, 900, 1000]
-    private let yAxisMaxValuesLBS = [25, 55, 110, 225, 335, 445, 665, 885, 1105, 1325, 1545, 1765, 1985, 2205]
-
     let exercise: Exercise
     let workoutSets: [WorkoutSet]
 
@@ -28,6 +25,13 @@ struct ExerciseWeightScreen: View {
         // Determine the snapped selected set only when a selection exists; snap to the nearest datapoint (prefer visible)
         let snappedSelectedSet: WorkoutSet? = selectedDate != nil ? nearestSet(to: selectedDate, in: allDailyMaxSets) : nil
         let bestVisibleWeight = bestWeightInGranularity(workoutSets)
+        let yScaleCap = chartYScaleCap(
+            visibleMax: chartVisibleLineMax(
+                of: chartPoints(from: allDailyMaxSets),
+                from: chartScrollPosition,
+                to: visibleEndDate
+            )
+        )
         ScrollView {
             VStack(spacing: SECTION_SPACING) {
                 VStack {
@@ -165,7 +169,7 @@ struct ExerciseWeightScreen: View {
                 }
             }
             .chartXScale(domain: xDomain(for: workoutSets))
-            .chartYScale(domain: 0 ... chartYScaleMax(maxYValue: allTimeWeightPR(in: workoutSets)))
+            .chartYScale(domain: 0 ... yScaleCap)
             .chartScrollableAxes(.horizontal)
             .chartScrollPosition(x: $chartScrollPosition)
             .chartScrollTargetBehavior(
@@ -175,6 +179,10 @@ struct ExerciseWeightScreen: View {
             )
             .chartXSelection(value: $selectedDate)
             .chartXVisibleDomain(length: visibleChartDomainInSeconds)
+            // Rebuild the chart when the granularity flips: reusing the chart across visible-domain
+            // changes leaves its scroll offset stale (the viewport shows a window months away from
+            // chartScrollPosition), so give each granularity its own chart identity.
+            .id(chartGranularity)
             .chartXAxis {
                 AxisMarks(
                     position: .bottom,
@@ -190,8 +198,7 @@ struct ExerciseWeightScreen: View {
                 }
             }
             .chartYAxis {
-                let chartYScaleMax = chartYScaleMax(maxYValue: allTimeWeightPR(in: workoutSets))
-                AxisMarks(values: [0, chartYScaleMax / 2, chartYScaleMax])
+                AxisMarks(values: .automatic(desiredCount: 3))
             }
             .emptyPlaceholder(allDailyMaxSets) {
                 Text(NSLocalizedString("noData", comment: ""))
@@ -304,16 +311,6 @@ struct ExerciseWeightScreen: View {
         }
     }
 
-    private func allTimeWeightPR(in workoutSets: [WorkoutSet]) -> Int {
-        convertWeightForDisplaying(
-            workoutSets
-                .map {
-                    $0.maximum(.weight, for: exercise)
-                }
-                .max() ?? 0
-        )
-    }
-
     /// The header's left value and the comparison baseline: the best max-weight in the visible window
     /// *other than* the current best, so the pill measures the current best against the rest of the
     /// shown period rather than itself when the peak is in view. Falls back to the most recent day's
@@ -327,10 +324,13 @@ struct ExerciseWeightScreen: View {
         ) { $0.maximum(.weight, for: exercise) }
     }
 
-    private func chartYScaleMax(maxYValue: Int) -> Int {
-        let values = WeightUnit.used == .kg ? yAxisMaxValuesKG : yAxisMaxValuesLBS
-        let nextBiggerYAxisMaxValue = values.filter { $0 > maxYValue }.min()
-        return nextBiggerYAxisMaxValue ?? maxYValue
+    /// The plotted daily-max series as plain (day, displayed value) points — the input for the
+    /// visible-window y-scale.
+    private func chartPoints(from sets: [WorkoutSet]) -> [(date: Date, value: Double)] {
+        sets.map { (
+            Calendar.current.startOfDay(for: $0.workout?.date ?? .now),
+            convertWeightForDisplayingDecimal($0.maximum(.weight, for: exercise))
+        ) }
     }
 
     /// The fixed right-hand anchor of the header scoreboard, independent of scroll: the current best

--- a/LOGIT/Features/Home/MuscleGroupDetailScreen.swift
+++ b/LOGIT/Features/Home/MuscleGroupDetailScreen.swift
@@ -14,9 +14,14 @@ import SwiftUI
 /// a 2×2 stat grid, a 12-week sets chart, and the top exercises that train it. Pro — the full
 /// per-muscle breakdown is the analytics behind the wall.
 struct MuscleGroupDetailScreen: View {
+    /// The weekly-sets chart shows 12 weeks at a time and can be panned back through history.
+    private static let twelveWeeksInSeconds = 3600 * 24 * 7 * 12
+
     let muscleGroup: MuscleGroup
 
     @State private var period: StatPeriod = .month
+    @State private var weeklyChartScrollPosition: Date = .now
+    @State private var selectedWeekDate: Date?
 
     @EnvironmentObject private var muscleGroupService: MuscleGroupService
     @EnvironmentObject private var targetSplitStore: MuscleTargetSplitStore
@@ -77,6 +82,14 @@ struct MuscleGroupDetailScreen: View {
                     .font(.system(.headline, design: .rounded, weight: .bold))
                     .foregroundStyle(color)
             }
+        }
+        .onAppear {
+            // Right edge shows the current week.
+            weeklyChartScrollPosition = Calendar.current.date(
+                byAdding: .second,
+                value: -Self.twelveWeeksInSeconds,
+                to: Date.now.endOfWeek
+            )!
         }
     }
 
@@ -185,11 +198,19 @@ struct MuscleGroupDetailScreen: View {
     private func weeklyChart(allWorkouts: [Workout]) -> some View {
         let sets = setsTraining(in: allWorkouts)
         let grouped = Dictionary(grouping: sets) { ($0.workout?.date ?? .now).startOfWeek }
-        let weeks: [(date: Date, count: Int)] = (0 ..< 12).reversed().map { weeksAgo in
-            let start = (Calendar.current.date(byAdding: .weekOfYear, value: -weeksAgo, to: .now) ?? .now).startOfWeek
-            return (start, grouped[start]?.count ?? 0)
-        }
-        let maxCount = weeks.map(\.count).max() ?? 0
+        let weeks = grouped
+            .map { (date: $0.key, count: $0.value.count) }
+            .sorted { $0.date < $1.date }
+        let points = weeks.map { (date: $0.date, value: Double($0.count)) }
+        let yScaleCap = chartYScaleCap(
+            visibleMax: chartVisibleMax(
+                of: points,
+                from: weeklyChartScrollPosition,
+                to: Calendar.current.date(byAdding: .second, value: Self.twelveWeeksInSeconds, to: weeklyChartScrollPosition)!,
+                bucketLength: 3600 * 24 * 7
+            ),
+            fallbackMax: points.map(\.value).max()
+        )
         return VStack(alignment: .leading, spacing: SECTION_HEADER_SPACING) {
             HStack {
                 Text(NSLocalizedString("weeklySets", comment: ""))
@@ -208,15 +229,68 @@ struct MuscleGroupDetailScreen: View {
                     )
                     .foregroundStyle(Calendar.current.isDate(week.date, equalTo: .now, toGranularity: .weekOfYear) ? color : Color.fill)
                     .clipShape(RoundedRectangle(cornerRadius: 3))
+                    .opacity(selectedWeekDate == nil || selectedWeekDate?.startOfWeek == week.date ? 1.0 : 0.4)
+                }
+                if let selectedWeekDate {
+                    let snapped = selectedWeekDate.startOfWeek
+                    let count = weeks.first { $0.date == snapped }?.count ?? 0
+                    RuleMark(x: .value("Selected", snapped, unit: .weekOfYear))
+                        .foregroundStyle(color.opacity(0.35))
+                        .lineStyle(StrokeStyle(lineWidth: 2))
+                        .annotation(
+                            position: .top,
+                            overflowResolution: .init(x: .fit(to: .chart), y: .fit(to: .chart))
+                        ) {
+                            VStack(alignment: .leading) {
+                                UnitView(value: "\(count)", unit: NSLocalizedString("sets", comment: ""), unitColor: .secondaryLabel)
+                                    .foregroundStyle(color.gradient)
+                                Text("\(snapped.formatted(.dateTime.day().month())) - \(snapped.endOfWeek.formatted(.dateTime.day().month()))")
+                                    .fontWeight(.bold)
+                                    .fontDesign(.rounded)
+                                    .foregroundStyle(.secondary)
+                            }
+                            .padding(.horizontal, 10)
+                            .padding(.vertical, 8)
+                            .background(RoundedRectangle(cornerRadius: 10).fill(Color.secondaryBackground))
+                        }
                 }
             }
-            .chartYScale(domain: 0 ... max(maxCount, 1))
-            .chartXAxis(.hidden)
+            .chartXScale(domain: weeklyXDomain(earliestWeek: weeks.first?.date))
+            .chartYScale(domain: 0 ... yScaleCap)
+            .chartScrollableAxes(.horizontal)
+            .chartScrollPosition(x: $weeklyChartScrollPosition)
+            .chartScrollTargetBehavior(.valueAligned(matching: DateComponents(weekday: Calendar.current.firstWeekday)))
+            .chartXSelection(value: $selectedWeekDate)
+            .chartXVisibleDomain(length: Self.twelveWeeksInSeconds)
+            .chartXAxis {
+                AxisMarks(values: .stride(by: .month)) { value in
+                    // A month tick within days of the domain's end has no room for its label —
+                    // it would clip to "…" — so the newest label only appears once its month
+                    // has properly begun.
+                    if let date = value.as(Date.self),
+                       date < Calendar.current.date(byAdding: .day, value: -10, to: Date.now.endOfWeek)! {
+                        AxisValueLabel {
+                            Text(date.formatted(.dateTime.month(.abbreviated)))
+                                .font(.caption2.weight(.semibold))
+                                .foregroundStyle(Color.secondaryLabel)
+                        }
+                    }
+                }
+            }
             .chartYAxis { AxisMarks(values: .automatic(desiredCount: 3)) }
-            .frame(height: 120)
+            .frame(height: 150)
             .padding(CELL_PADDING)
             .tileStyle()
         }
+    }
+
+    /// From the first trained week (or one full window back, whichever is earlier) to the end of
+    /// the current week.
+    private func weeklyXDomain(earliestWeek: Date?) -> ClosedRange<Date> {
+        let endDate = Date.now.endOfWeek
+        let minStartDate = Calendar.current.date(byAdding: .second, value: -Self.twelveWeeksInSeconds, to: endDate)!
+        guard let earliestWeek, earliestWeek < minStartDate else { return minStartDate ... endDate }
+        return earliestWeek ... endDate
     }
 
     // MARK: - Top exercises

--- a/LOGIT/Features/Home/OverallSetsScreen.swift
+++ b/LOGIT/Features/Home/OverallSetsScreen.swift
@@ -66,6 +66,16 @@ struct OverallSetsScreen: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
 
                     let grouped = setsGroupedByGranularity(workouts)
+                    let points = grouped.map { (date: $0.date, value: Double($0.workoutSets.count)) }
+                    let yScaleCap = chartYScaleCap(
+                        visibleMax: chartVisibleMax(
+                            of: points,
+                            from: chartScrollPosition,
+                            to: Calendar.current.date(byAdding: .second, value: visibleChartDomainInSeconds, to: chartScrollPosition)!,
+                            bucketLength: bucketLengthInSeconds
+                        ),
+                        fallbackMax: points.map(\.value).max()
+                    )
                     Chart {
                         ForEach(grouped, id: \.date) { data in
                             if data.workoutSets.count > 0 {
@@ -113,6 +123,7 @@ struct OverallSetsScreen: View {
                         }
                     }
                     .chartXScale(domain: xDomain(for: grouped.map { $0.workoutSets }))
+                    .chartYScale(domain: 0 ... yScaleCap)
                     .chartScrollableAxes(.horizontal)
                     .chartScrollPosition(x: $chartScrollPosition)
                     .chartScrollTargetBehavior(
@@ -122,6 +133,10 @@ struct OverallSetsScreen: View {
                     )
                     .chartXSelection(value: $selectedDate)
                     .chartXVisibleDomain(length: visibleChartDomainInSeconds)
+                    // Rebuild the chart when the granularity flips: reusing the chart across visible-domain
+                    // changes leaves its scroll offset stale (the viewport shows a window months away from
+                    // chartScrollPosition), so give each granularity its own chart identity.
+                    .id(chartGranularity)
                     .chartXAxis {
                         AxisMarks(
                             position: .bottom,
@@ -168,6 +183,15 @@ struct OverallSetsScreen: View {
         case .week: return 3600 * 24 * 7
         case .month: return 3600 * 24 * 35
         case .year: return 3600 * 24 * 365
+        }
+    }
+
+    /// How long one bar's bucket spans on the x-axis — a day, a week, or a month of sets.
+    private var bucketLengthInSeconds: TimeInterval {
+        switch chartGranularity {
+        case .week: return 3600 * 24
+        case .month: return 3600 * 24 * 7
+        case .year: return 3600 * 24 * 31
         }
     }
 

--- a/LOGIT/Features/Home/SummaryStatScreen.swift
+++ b/LOGIT/Features/Home/SummaryStatScreen.swift
@@ -8,16 +8,19 @@
 import Charts
 import SwiftUI
 
-/// Detail screen behind a Summary core-stat tile: the stat summed per period across recent history,
-/// scoped by the shared `PeriodPicker`. The tile shows the current period; the screen zooms out to the
-/// last several periods, the current one highlighted. One screen serves all four stats —
-/// `WorkoutStatMetric` supplies values, formatting, and the about text. Pro, like the other stat
-/// detail screens (the tile is the free hook).
+/// Detail screen behind a Summary core-stat tile: the stat summed per period across history,
+/// scoped by the shared `PeriodPicker`. The tile shows the current period; the screen zooms out to a
+/// scrollable chart of all periods — 8 weeks / 12 months / 6 years on screen, pannable back to the
+/// first workout, the current period highlighted and any bar tappable to inspect its value. One
+/// screen serves all four stats — `WorkoutStatMetric` supplies values, formatting, and the about
+/// text. Pro, like the other stat detail screens (the tile is the free hook).
 struct SummaryStatScreen: View {
     let metric: WorkoutStatMetric
     let workouts: [Workout]
 
     @State private var period: StatPeriod
+    @State private var chartScrollPosition: Date = .now
+    @State private var selectedDate: Date?
 
     init(metric: WorkoutStatMetric, workouts: [Workout], initialPeriod: StatPeriod = .week) {
         self.metric = metric
@@ -49,6 +52,15 @@ struct SummaryStatScreen: View {
                 Text(metric.title)
                     .font(.headline)
             }
+        }
+        .onAppear {
+            initializeChartScrollPosition()
+        }
+        .onChange(of: period) {
+            // A new period means a new bucket grid — drop the selection and re-anchor the window
+            // so the current period sits on the right edge again.
+            selectedDate = nil
+            initializeChartScrollPosition()
         }
     }
 
@@ -85,19 +97,25 @@ struct SummaryStatScreen: View {
     // MARK: - Chart
 
     private struct Bucket: Identifiable {
-        let id: Int
         let date: Date
+        let rawValue: Int
         let value: Double
         let isCurrent: Bool
+        var id: Date { date }
     }
 
     private var chart: some View {
         let buckets = self.buckets
-        let maxValue = buckets.map(\.value).max() ?? 0
-        // At most ~4 axis labels, counted back from the current bucket so "now" is always labeled —
-        // one label per bucket sat shoulder-to-shoulder on the week view.
-        let labelStride = max(1, Int((Double(buckets.count) / 4.0).rounded(.up)))
-        let labeledDates = stride(from: buckets.count - 1, through: 0, by: -labelStride).map { buckets[$0].date }
+        let points = buckets.map { (date: $0.date, value: $0.value) }
+        let yScaleCap = chartYScaleCap(
+            visibleMax: chartVisibleMax(
+                of: points,
+                from: chartScrollPosition,
+                to: visibleEndDate,
+                bucketLength: bucketLengthInSeconds
+            ),
+            fallbackMax: points.map(\.value).max()
+        )
         return Chart {
             ForEach(buckets) { bucket in
                 BarMark(
@@ -105,24 +123,48 @@ struct SummaryStatScreen: View {
                     y: .value(metric.title, bucket.value),
                     width: .ratio(0.6)
                 )
-                .foregroundStyle(
-                    bucket.isCurrent
-                        ? (isDuration ? Color.secondary : Color.accentColor)
-                        : Color.fill
-                )
+                .foregroundStyle(barStyle(for: bucket))
                 .clipShape(RoundedRectangle(cornerRadius: 3, style: .continuous))
+                .opacity(selectedDate == nil || isSelected(bucket) ? 1.0 : 0.4)
+            }
+            if let selectedDate {
+                let snapped = periodStart(of: selectedDate)
+                RuleMark(x: .value("Selected", snapped, unit: barUnit))
+                    .foregroundStyle(Color.label.opacity(0.35))
+                    .lineStyle(StrokeStyle(lineWidth: 2))
+                    .annotation(
+                        position: .top,
+                        overflowResolution: .init(x: .fit(to: .chart), y: .fit(to: .chart))
+                    ) {
+                        annotationCard(for: snapped)
+                    }
             }
         }
-        .chartYScale(domain: 0 ... max(maxValue, 1))
+        .chartXScale(domain: xDomain)
+        .chartYScale(domain: 0 ... yScaleCap)
+        .chartScrollableAxes(.horizontal)
+        .chartScrollPosition(x: $chartScrollPosition)
+        .chartScrollTargetBehavior(.valueAligned(matching: scrollAlignment))
+        .chartXSelection(value: $selectedDate)
+        .chartXVisibleDomain(length: visibleChartDomainInSeconds)
+        // Rebuild the chart when the period flips: reusing the chart across visible-domain
+        // changes leaves its scroll offset stale (the viewport shows a window months away from
+        // chartScrollPosition), so give each period its own chart identity.
+        .id(period)
         .chartXAxis {
-            AxisMarks(values: labeledDates) { value in
+            AxisMarks(
+                position: .bottom,
+                values: .stride(by: strideComponent, count: axisStrideCount)
+            ) { value in
                 if let date = value.as(Date.self) {
                     let isCurrent = period.currentRange().contains(date)
                     AxisGridLine()
                         .foregroundStyle(Color.gray.opacity(0.4))
                     // Styling lives on the Text inside the label closure — hierarchical styles on the
                     // AxisMark itself resolve against the chart's accent on iOS 26 (labels turned lime).
-                    AxisValueLabel {
+                    // Centered puts the label under the period's bar, keeping the newest label clear
+                    // of the plot's right edge (it clipped to "29…" when anchored on the gridline).
+                    AxisValueLabel(centered: true) {
                         Text(axisLabel(for: date))
                             .font(.caption.weight(isCurrent ? .bold : .semibold))
                             .foregroundStyle(isCurrent ? Color.label : Color.secondaryLabel)
@@ -134,6 +176,33 @@ struct SummaryStatScreen: View {
             AxisMarks(values: .automatic(desiredCount: 3))
         }
         .frame(height: 260)
+    }
+
+    /// The current period keeps the accent (grey for duration, matching its tile); a tapped past
+    /// bar lights up white; every other bar stays a quiet gray.
+    private func barStyle(for bucket: Bucket) -> Color {
+        if bucket.isCurrent { return isDuration ? Color.secondary : Color.accentColor }
+        if isSelected(bucket) { return Color.label }
+        return Color.fill
+    }
+
+    private func annotationCard(for periodStartDate: Date) -> some View {
+        let raw = buckets.first { $0.date == periodStartDate }?.rawValue ?? 0
+        return VStack(alignment: .leading) {
+            UnitView(
+                value: raw > 0 ? metric.formattedValue(fromRaw: raw) : "––",
+                unit: metric.unit,
+                unitColor: .secondaryLabel
+            )
+            .foregroundStyle(Color.label)
+            Text(annotationLabel(for: periodStartDate))
+                .fontWeight(.bold)
+                .fontDesign(.rounded)
+                .foregroundStyle(.secondary)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .background(RoundedRectangle(cornerRadius: 10).fill(Color.secondaryBackground))
     }
 
     // MARK: - Data
@@ -151,26 +220,101 @@ struct SummaryStatScreen: View {
             .reduce(0) { $0 + metric.rawValue(of: $1) }
     }
 
+    /// One bar per trained period, plus the current one so the accent bar always exists. Sparse —
+    /// the chart's scrollable domain (not this list) decides how far back the user can pan.
     private var buckets: [Bucket] {
-        let count = chartBucketCount
-        return (0 ..< count).map { index in
-            let periodsAgo = count - 1 - index
-            let range = period.range(periodsAgo: periodsAgo)
-            let raw = sum(in: range)
-            return Bucket(
-                id: index,
-                date: range.lowerBound,
-                value: metric.displayValue(fromRaw: raw),
-                isCurrent: periodsAgo == 0
-            )
+        let currentStart = periodStart(of: .now)
+        var sums: [Date: Int] = [:]
+        for workout in workouts {
+            guard let date = workout.date else { continue }
+            sums[periodStart(of: date), default: 0] += metric.rawValue(of: workout)
+        }
+        sums[currentStart] = sums[currentStart] ?? 0
+        return sums
+            .map { start, raw in
+                Bucket(
+                    date: start,
+                    rawValue: raw,
+                    value: metric.displayValue(fromRaw: raw),
+                    isCurrent: start == currentStart
+                )
+            }
+            .sorted { $0.date < $1.date }
+    }
+
+    // MARK: - Chart Window
+
+    /// 8 weeks / 12 months / 6 years on screen at a time.
+    private var visibleChartDomainInSeconds: Int {
+        switch period {
+        case .week: return 3600 * 24 * 7 * 8
+        case .month: return 3600 * 24 * 365
+        case .year: return 3600 * 24 * 365 * 6
         }
     }
 
-    private var chartBucketCount: Int {
+    private var visibleEndDate: Date {
+        Calendar.current.date(byAdding: .second, value: visibleChartDomainInSeconds, to: chartScrollPosition)!
+    }
+
+    /// How long one bar's bucket spans on the x-axis.
+    private var bucketLengthInSeconds: TimeInterval {
         switch period {
-        case .week: return 8
-        case .month: return 12
-        case .year: return 6
+        case .week: return 3600 * 24 * 7
+        case .month: return 3600 * 24 * 31
+        case .year: return 3600 * 24 * 366
+        }
+    }
+
+    /// From the first trained period (or one full window back, whichever is earlier) to the end of
+    /// the current period.
+    private var xDomain: ClosedRange<Date> {
+        let endDate = period.currentRange().upperBound
+        let minStartDate = Calendar.current.date(byAdding: .second, value: -visibleChartDomainInSeconds, to: endDate)!
+        guard let earliest = workouts.compactMap(\.date).min().map({ periodStart(of: $0) }), earliest < minStartDate
+        else { return minStartDate ... endDate }
+        return earliest ... endDate
+    }
+
+    private var scrollAlignment: DateComponents {
+        switch period {
+        case .week: return DateComponents(weekday: Calendar.current.firstWeekday)
+        case .month: return DateComponents(day: 1)
+        case .year: return DateComponents(month: 1, day: 1)
+        }
+    }
+
+    private func initializeChartScrollPosition() {
+        chartScrollPosition = Calendar.current.date(
+            byAdding: .second,
+            value: -visibleChartDomainInSeconds,
+            to: period.currentRange().upperBound
+        )!
+    }
+
+    // MARK: - Selection
+
+    private func periodStart(of date: Date) -> Date {
+        switch period {
+        case .week: return date.startOfWeek
+        case .month: return date.startOfMonth
+        case .year: return date.startOfYear
+        }
+    }
+
+    private func isSelected(_ bucket: Bucket) -> Bool {
+        guard let selectedDate else { return false }
+        return periodStart(of: selectedDate) == bucket.date
+    }
+
+    private func annotationLabel(for start: Date) -> String {
+        switch period {
+        case .week:
+            return "\(start.formatted(.dateTime.day().month())) - \(start.endOfWeek.formatted(.dateTime.day().month()))"
+        case .month:
+            return start.formatted(.dateTime.month(.abbreviated).year())
+        case .year:
+            return start.formatted(.dateTime.year())
         }
     }
 
@@ -200,9 +344,14 @@ struct SummaryStatScreen: View {
         }
     }
 
+    /// Label every other week (the 8-week view would crowd otherwise), every month, every year.
+    private var axisStrideCount: Int {
+        period == .week ? 2 : 1
+    }
+
     private func axisLabel(for date: Date) -> String {
         switch period {
-        case .week: return date.formatted(.dateTime.day().month(.abbreviated))
+        case .week: return date.formatted(.dateTime.day().month(.defaultDigits))
         case .month: return date.formatted(.dateTime.month(.narrow))
         case .year: return date.formatted(.dateTime.year())
         }

--- a/LOGIT/Features/Home/VolumeScreen.swift
+++ b/LOGIT/Features/Home/VolumeScreen.swift
@@ -23,6 +23,17 @@ struct VolumeScreen: View {
     var body: some View {
         let groupedWorkoutSets = Dictionary(grouping: workoutSets) { $0.workout?.date?.startOfWeek ?? .now }
             .sorted { $0.key < $1.key }
+        // The stacked bar's full height is the week's total volume, whichever muscle group is picked.
+        let weeklyPoints = groupedWorkoutSets.map { (date: $0.0, value: volume(for: $0.1)) }
+        let yScaleCap = chartYScaleCap(
+            visibleMax: chartVisibleMax(
+                of: weeklyPoints,
+                from: chartScrollPosition,
+                to: visibleEndDate,
+                bucketLength: 7 * 24 * 3600
+            ),
+            fallbackMax: weeklyPoints.map(\.value).max()
+        )
         ScrollView {
             VStack(spacing: SECTION_SPACING) {
                 VStack {
@@ -127,6 +138,7 @@ struct VolumeScreen: View {
                         }
                     }
                     .chartXScale(domain: xDomain(for: groupedWorkoutSets.map { $0.1 }))
+                    .chartYScale(domain: 0 ... yScaleCap)
                     .chartScrollableAxes(.horizontal)
                     .chartScrollPosition(x: $chartScrollPosition)
                     .chartScrollTargetBehavior(
@@ -136,6 +148,10 @@ struct VolumeScreen: View {
                     )
                     .chartXSelection(value: $selectedDate)
                     .chartXVisibleDomain(length: visibleChartDomainInSeconds)
+                    // Rebuild the chart when the granularity flips: reusing the chart across visible-domain
+                    // changes leaves its scroll offset stale (the viewport shows a window months away from
+                    // chartScrollPosition), so give each granularity its own chart identity.
+                    .id(chartGranularity)
                     .chartXAxis {
                         AxisMarks(
                             position: .bottom,
@@ -170,6 +186,18 @@ struct VolumeScreen: View {
             let firstDayOfNextWeek = Calendar.current.date(byAdding: .day, value: 1, to: .now.endOfWeek)!
             chartScrollPosition = Calendar.current.date(byAdding: .second, value: -visibleChartDomainInSeconds, to: firstDayOfNextWeek)!
         }
+        .onChange(of: chartGranularity) {
+            // Re-initialize scroll position when switching granularity to avoid desync with visible window
+            let anchor: Date
+            switch chartGranularity {
+            case .month:
+                anchor = Calendar.current.date(byAdding: .day, value: 1, to: .now.endOfWeek)!
+            case .year:
+                // Align right edge roughly to next month for a stable yearly view
+                anchor = Calendar.current.date(byAdding: .month, value: 1, to: .now.startOfMonth)!
+            }
+            chartScrollPosition = Calendar.current.date(byAdding: .second, value: -visibleChartDomainInSeconds, to: anchor)!
+        }
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: .principal) {
@@ -191,6 +219,10 @@ struct VolumeScreen: View {
     // MARK: - Private Helpers
 
     private var visibleChartDomainInSeconds: Int { 3600 * 24 * (chartGranularity == .month ? 35 : 365) }
+
+    private var visibleEndDate: Date {
+        Calendar.current.date(byAdding: .second, value: visibleChartDomainInSeconds, to: chartScrollPosition)!
+    }
 
     private var xUnit: Calendar.Component {
         switch chartGranularity {

--- a/LOGIT/Features/Measurement/MeasurementDetailScreen.swift
+++ b/LOGIT/Features/Measurement/MeasurementDetailScreen.swift
@@ -74,6 +74,13 @@ struct MeasurementDetailScreen: View {
     private var chartSection: some View {
         let snappedSelectedEntry = selectedDate != nil ? nearestEntry(to: selectedDate) : nil
         let latestEntry = entries.first
+        let yScaleCap = chartYScaleCap(
+            visibleMax: chartVisibleLineMax(
+                of: chartPoints,
+                from: chartScrollPosition,
+                to: visibleEndDate
+            )
+        )
 
         VStack {
             Picker("Select Chart Granularity", selection: $chartGranularity) {
@@ -209,7 +216,7 @@ struct MeasurementDetailScreen: View {
                 }
             }
             .chartXScale(domain: xDomain)
-            .chartYScale(domain: 0.0 ... chartYScaleMax)
+            .chartYScale(domain: 0.0 ... yScaleCap)
             .chartScrollableAxes(.horizontal)
             .chartScrollPosition(x: $chartScrollPosition)
             .chartScrollTargetBehavior(
@@ -219,6 +226,10 @@ struct MeasurementDetailScreen: View {
             )
             .chartXSelection(value: $selectedDate)
             .chartXVisibleDomain(length: visibleChartDomainInSeconds)
+            // Rebuild the chart when the granularity flips: reusing the chart across visible-domain
+            // changes leaves its scroll offset stale (the viewport shows a window months away from
+            // chartScrollPosition), so give each granularity its own chart identity.
+            .id(chartGranularity)
             .chartXAxis {
                 AxisMarks(
                     position: .bottom,
@@ -234,7 +245,7 @@ struct MeasurementDetailScreen: View {
                 }
             }
             .chartYAxis {
-                AxisMarks(values: [0.0, chartYScaleMax / 2.0, chartYScaleMax])
+                AxisMarks(values: .automatic(desiredCount: 3))
             }
             .emptyPlaceholder(entries) {
                 Text(NSLocalizedString("noData", comment: ""))
@@ -375,10 +386,13 @@ struct MeasurementDetailScreen: View {
         return startDate ... endDate
     }
 
-    private var chartYScaleMax: Double {
-        let maxValue = entries.map { $0.decimalValue }.max() ?? 100
-        let yAxisMaxValues: [Double] = [10, 25, 50, 100, 150, 200, 250, 300, 400, 500, 750, 1000]
-        return yAxisMaxValues.filter { $0 > maxValue }.min() ?? maxValue
+    /// The plotted series as plain (day, value) points, oldest first — the input for the
+    /// visible-window y-scale.
+    private var chartPoints: [(date: Date, value: Double)] {
+        entries.reversed().map { (
+            Calendar.current.startOfDay(for: $0.date ?? .now),
+            $0.decimalValue
+        ) }
     }
 
     private func xAxisDateString(for date: Date) -> String {

--- a/LOGIT/Features/Workout/WorkoutStatScreen.swift
+++ b/LOGIT/Features/Workout/WorkoutStatScreen.swift
@@ -219,6 +219,10 @@ struct WorkoutStatScreen: View {
         )
         .chartXSelection(value: $selectedDate)
         .chartXVisibleDomain(length: visibleChartDomainInSeconds)
+        // Rebuild the chart when the granularity flips: reusing the chart across visible-domain
+        // changes leaves its scroll offset stale (the viewport shows a window months away from
+        // chartScrollPosition), so give each granularity its own chart identity.
+        .id(chartGranularity)
         .chartXAxis {
             AxisMarks(
                 position: .bottom,
@@ -234,7 +238,7 @@ struct WorkoutStatScreen: View {
             }
         }
         .chartYAxis {
-            AxisMarks(values: [0, yScaleMax / 2, yScaleMax])
+            AxisMarks(values: .automatic(desiredCount: 3))
         }
         .emptyPlaceholder(points) {
             Text(NSLocalizedString("noData", comment: ""))
@@ -386,15 +390,18 @@ struct WorkoutStatScreen: View {
         }
     }
 
-    /// Smallest "nice" number (1/2/2.5/5 × power of ten) at or above the largest bar, so the
-    /// y-axis marks land on round values whatever unit the stat uses.
+    /// The y-axis ceiling: the tallest bar in the visible window plus ~1/5 headroom, re-fitting as
+    /// the chart scrolls; the overall max backstops windows with no bars.
     private func chartYScaleMax(for points: [StatPoint]) -> Double {
-        let maxValue = points.map(\.value).max() ?? 0
-        guard maxValue > 0 else { return 1 }
-        let magnitude = pow(10, floor(log10(maxValue)))
-        let normalized = maxValue / magnitude
-        let niceNormalized: Double = normalized <= 1 ? 1 : normalized <= 2 ? 2 : normalized <= 2.5 ? 2.5 : normalized <= 5 ? 5 : 10
-        return niceNormalized * magnitude
+        chartYScaleCap(
+            visibleMax: chartVisibleMax(
+                of: points.map { (date: $0.date, value: $0.value) },
+                from: chartScrollPosition,
+                to: visibleEndDate,
+                bucketLength: chartGranularity == .month ? 3600 * 24 : 3600 * 24 * 31
+            ),
+            fallbackMax: points.map(\.value).max()
+        )
     }
 
     // MARK: - Selection

--- a/LOGIT/SharedUI/Charts/ChartScaling.swift
+++ b/LOGIT/SharedUI/Charts/ChartScaling.swift
@@ -1,0 +1,50 @@
+//
+//  ChartScaling.swift
+//  LOGIT
+//
+//  Created by Lukas Kaibel on 04.07.26.
+//
+
+import Foundation
+
+/// Y-axis ceiling for the stat charts: the largest value currently on screen plus ~1/5 headroom,
+/// so the tallest bar or line peak never touches the top of the plot and the scale re-fits the
+/// data as the user scrolls the visible window. `fallbackMax` (typically the series' overall max)
+/// keeps the scale sane when the window holds no data at all.
+func chartYScaleCap(visibleMax: Double?, fallbackMax: Double? = nil) -> Double {
+    let reference = [visibleMax, fallbackMax].compactMap { $0 }.first { $0 > 0 } ?? 0
+    guard reference > 0 else { return 10 }
+    return reference * 1.2
+}
+
+/// The largest plotted value inside the visible window. Bars are positioned by their bucket's
+/// start date, so pass the bucket's length as `bucketLength` to also count a bar that starts
+/// before the window but reaches into it.
+func chartVisibleMax(
+    of points: [(date: Date, value: Double)],
+    from windowStart: Date,
+    to windowEnd: Date,
+    bucketLength: TimeInterval = 0
+) -> Double? {
+    points
+        .filter { $0.date >= windowStart.addingTimeInterval(-bucketLength) && $0.date <= windowEnd }
+        .map(\.value)
+        .max()
+}
+
+/// `chartVisibleMax` for line charts, where the line runs on between and beyond data points: a
+/// window with no point inside still shows the segment spanning it (or the flat run-out before the
+/// first / after the last point), so the nearest points just outside the window bound what's
+/// visible there.
+func chartVisibleLineMax(
+    of points: [(date: Date, value: Double)],
+    from windowStart: Date,
+    to windowEnd: Date
+) -> Double? {
+    if let inWindow = chartVisibleMax(of: points, from: windowStart, to: windowEnd) {
+        return inWindow
+    }
+    let before = points.filter { $0.date < windowStart }.max { $0.date < $1.date }?.value
+    let after = points.filter { $0.date > windowEnd }.min { $0.date < $1.date }?.value
+    return [before, after].compactMap { $0 }.max()
+}

--- a/LOGIT/SharedUI/Charts/SetVolumeBarChart.swift
+++ b/LOGIT/SharedUI/Charts/SetVolumeBarChart.swift
@@ -125,12 +125,21 @@ struct SetVolumeBarChart: View {
             }
         }
         .chartXScale(domain: (1 ... max(setCount, 1)).map { String($0) })
+        .chartYScale(domain: 0 ... chartYScaleCap(visibleMax: maxStackedVolume))
         .chartXSelection(value: $rawSelection)
         .chartXAxis(.hidden)
         .chartYAxis(.hidden)
     }
 
     // MARK: - Computed Properties
+
+    /// The tallest bar — a super set's bar stacks both segments — in display units.
+    private var maxStackedVolume: Double {
+        Dictionary(grouping: segments) { $0.setIndex }
+            .values
+            .map { $0.reduce(0.0) { $0 + convertWeightForDisplayingDecimal($1.volume) } }
+            .max() ?? 0
+    }
 
     /// The set the gesture currently points at, snapped to the nearest set that has volume.
     private var selectedSetIndex: Int? {


### PR DESCRIPTION
## What

A pass over every screen with a chart, fixing the three reported issues:

### 1. Selection / value inspection
- **SummaryStatScreen** (behind the Summary stat tiles) and the **muscle-group detail's Weekly Sets chart** had no selection at all — both now have the same hold-to-inspect tooltip as the other detail screens (value card + rule mark, selected bar lit up, the rest dimmed).
- The existing screens' selection was already functional (it's a press-and-hold gesture, verified working on Weight, Workout stat, Summary, and Muscle detail via mid-gesture screenshots).

### 2. Y-axis headroom from the *visible* window
- New shared helpers in `ChartScaling.swift`: the y-domain now tops out at the **largest currently-visible value × 1.2** (≈1/5 of the chart above the tallest bar / line peak), recomputed live as the chart scrolls or the granularity changes.
- Replaces the old fixed axis buckets (weight/e1RM/reps/measurement) and all-time nice-caps (workout stat, set volume) that either wasted half the plot or let bars touch the ceiling. Line charts count the run-in/run-out of the line for empty windows; bar charts fall back to the series max.
- Y-axes switched to `.automatic(desiredCount: 3)` so gridline labels stay round for any domain.
- The workout detail's per-set volume chart and the Summary/Muscle detail charts (which had zero headroom) get the same treatment.

### 3. Scrolling
- **SummaryStatScreen** and the **Weekly Sets chart** are now horizontally scrollable through full history (8 weeks / 12 months / 6 years, resp. 12 weeks, per window), value-aligned, right edge anchored on the current period.
- ExerciseSetsScreen, ExerciseVolumeScreen, and the home VolumeScreen were missing the granularity-switch scroll reset their sibling screens had — added.
- Root cause of "scrolling feels broken": changing `chartXVisibleDomain` (month ↔ year) leaves the chart's scroll offset stale even after resetting `chartScrollPosition` — the viewport showed a window months away from the header. All granularity-switching charts are now rebuilt via `.id(chartGranularity)`, which fixes the round-trip (verified: month → year → month lands back on the current window).

Also: Summary axis labels are centered under their bars (the newest label used to clip to "…" at the plot edge), and the muscle weekly chart suppresses a month label that would clip at the window's edge.

## Verification

- Verified in the iPhone 17 Pro (iOS 26) simulator with seeded fixtures via temporary XCUITest screenshot runs: initial state, scrolled-back state (y-scale re-fits), granularity round-trip, and mid-gesture selection tooltips on the Summary, Weight, Sets, Measurement, Muscle detail, and Workout stat screens.
- Full `LOGITTests` unit suite passes (322 tests).
- No user-facing strings added or changed, so no localization updates needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)