### PR TITLE
Add default workout templates with localized descriptions

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -128,7 +128,10 @@ that are committed to the repo.
   copy or screenshots, update every matching `fastlane/metadata/<locale>` and
   `fastlane/screenshots/<locale>` file. If the change touches default
   exercises, localize both the `_default.exercise.*` names and the localized
-  instruction arrays in `LOGIT/Resources/default_exercises.json`.
+  instruction arrays in `LOGIT/Resources/default_exercises.json`. Default
+  templates (`LOGIT/Resources/default_templates.json`) keep their structure in
+  the JSON but localize their `_default.template.*` names and descriptions in
+  every `Localizable.strings` file.
 - Keep translations close to the English length where possible, but do not make
   them awkward. Use natural Apple-style platform wording, preserve product
   terms such as iCloud, App Store, Live Activity, Dynamic Island, and LOGIT Pro,

--- a/LOGIT.xcodeproj/project.pbxproj
+++ b/LOGIT.xcodeproj/project.pbxproj
@@ -196,7 +196,10 @@
 		806DE6202E1DD10A008E162F /* ChronographView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 806DE61F2E1DD106008E162F /* ChronographView.swift */; };
 		806F87E52ED0D7E7001E8B8B /* Logit.icon in Resources */ = {isa = PBXBuildFile; fileRef = 806F87E42ED0D7E7001E8B8B /* Logit.icon */; };
 		8085497B2EE9A34400761706 /* DefaultExerciseService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8085497A2EE9A34400761706 /* DefaultExerciseService.swift */; };
+		80AA10032F5CAA0200AA1003 /* DefaultTemplateService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80AA10042F5CAA0200AA1004 /* DefaultTemplateService.swift */; };
+		80AA10012F5CAA0200AA1001 /* DeterministicUUID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80AA10022F5CAA0200AA1002 /* DeterministicUUID.swift */; };
 		8085497F2EE9A37C00761706 /* default_exercises.json in Resources */ = {isa = PBXBuildFile; fileRef = 8085497D2EE9A37C00761706 /* default_exercises.json */; };
+		80AA10052F5CAA0200AA1005 /* default_templates.json in Resources */ = {isa = PBXBuildFile; fileRef = 80AA10062F5CAA0200AA1006 /* default_templates.json */; };
 		80A1D97B2EDC91B2004EE258 /* PinnedExerciseTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80A1D97A2EDC91B2004EE258 /* PinnedExerciseTile.swift */; };
 		80A1D97C2EDC91B2004EE258 /* ExercisesPinEditSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80A1D9792EDC91B2004EE258 /* ExercisesPinEditSheet.swift */; };
 		80A7A0D12F2E6C5C00112233 /* logit_terms_and_conditions.md in Resources */ = {isa = PBXBuildFile; fileRef = 80A7A0D02F2E6C5C00112233 /* logit_terms_and_conditions.md */; };
@@ -532,13 +535,17 @@
 		806DE61F2E1DD106008E162F /* ChronographView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChronographView.swift; sourceTree = "<group>"; };
 		806F87E42ED0D7E7001E8B8B /* Logit.icon */ = {isa = PBXFileReference; lastKnownFileType = folder.iconcomposer.icon; path = Logit.icon; sourceTree = "<group>"; };
 		8085497A2EE9A34400761706 /* DefaultExerciseService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultExerciseService.swift; sourceTree = "<group>"; };
+		80AA10042F5CAA0200AA1004 /* DefaultTemplateService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultTemplateService.swift; sourceTree = "<group>"; };
+		80AA10022F5CAA0200AA1002 /* DeterministicUUID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeterministicUUID.swift; sourceTree = "<group>"; };
 		8085497D2EE9A37C00761706 /* default_exercises.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = default_exercises.json; sourceTree = "<group>"; };
+		80AA10062F5CAA0200AA1006 /* default_templates.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = default_templates.json; sourceTree = "<group>"; };
 		80A1D9792EDC91B2004EE258 /* ExercisesPinEditSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExercisesPinEditSheet.swift; sourceTree = "<group>"; };
 		80A1D97A2EDC91B2004EE258 /* PinnedExerciseTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinnedExerciseTile.swift; sourceTree = "<group>"; };
 		80A7A0D02F2E6C5C00112233 /* logit_terms_and_conditions.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = logit_terms_and_conditions.md; sourceTree = "<group>"; };
 		80AA00012F3A000100AA0001 /* RestDurationPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestDurationPicker.swift; sourceTree = "<group>"; };
 		80AA00032F3A000100AA0001 /* RestTimerBetweenSetsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestTimerBetweenSetsView.swift; sourceTree = "<group>"; };
 		80AA00052F3A000100AA0001 /* LOGIT 6.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "LOGIT 6.0.xcdatamodel"; sourceTree = "<group>"; };
+		80AA00072F5CAA0100AA0007 /* LOGIT 7.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "LOGIT 7.0.xcdatamodel"; sourceTree = "<group>"; };
 		80AA00072F3A000100AA0001 /* RestDurationEditorSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestDurationEditorSheet.swift; sourceTree = "<group>"; };
 		80AA00092F3A000100AA0001 /* WorkoutRecorderFloatingTimerButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutRecorderFloatingTimerButton.swift; sourceTree = "<group>"; };
 		80AA000B2F3A000100AA0001 /* WorkoutRecorderFloatingStopwatchStopButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutRecorderFloatingStopwatchStopButton.swift; sourceTree = "<group>"; };
@@ -1151,6 +1158,8 @@
 			children = (
 				80036CDD2EFEF9CE00B7C7B4 /* FuzzySearchService.swift */,
 				8085497A2EE9A34400761706 /* DefaultExerciseService.swift */,
+				80AA10042F5CAA0200AA1004 /* DefaultTemplateService.swift */,
+				80AA10022F5CAA0200AA1002 /* DeterministicUUID.swift */,
 				801BBD332DF7338A00CDB1FB /* MuscleGroupService.swift */,
 				0258213863A5C9812190A44D /* MuscleBalanceCalculator.swift */,
 				A1B2C3D4E5F600000001F001 /* MuscleBalanceHistory.swift */,
@@ -1304,6 +1313,7 @@
 			isa = PBXGroup;
 			children = (
 				8085497D2EE9A37C00761706 /* default_exercises.json */,
+				80AA10062F5CAA0200AA1006 /* default_templates.json */,
 			);
 			path = Resources;
 			sourceTree = "<group>";
@@ -1491,6 +1501,7 @@
 				801BBD652DF7338A00CDB1FB /* timer.wav in Resources */,
 				801BBD662DF7338A00CDB1FB /* Localizable.strings in Resources */,
 				8085497F2EE9A37C00761706 /* default_exercises.json in Resources */,
+				80AA10052F5CAA0200AA1005 /* default_templates.json in Resources */,
 				801BBD672DF7338A00CDB1FB /* Assets.xcassets in Resources */,
 				801BBD682DF7338A00CDB1FB /* logit_privacy_policy.md in Resources */,
 				80A7A0D12F2E6C5C00112233 /* logit_terms_and_conditions.md in Resources */,
@@ -1658,6 +1669,8 @@
 				801BBDBA2DF7338A00CDB1FB /* StandardSet+.swift in Sources */,
 				801BBDBB2DF7338A00CDB1FB /* ExerciseDTO.swift in Sources */,
 				8085497B2EE9A34400761706 /* DefaultExerciseService.swift in Sources */,
+				80AA10032F5CAA0200AA1003 /* DefaultTemplateService.swift in Sources */,
+				80AA10012F5CAA0200AA1001 /* DeterministicUUID.swift in Sources */,
 				801BBDBC2DF7338A00CDB1FB /* MuscleGroupService.swift in Sources */,
 				53B547C48713887B1E5542EE /* MuscleBalanceCalculator.swift in Sources */,
 				A1B2C3D4E5F600000001B001 /* MuscleBalanceHistory.swift in Sources */,
@@ -2270,6 +2283,7 @@
 		801BBCC92DF7338A00CDB1FB /* LOGIT.xcdatamodeld */ = {
 			isa = XCVersionGroup;
 			children = (
+				80AA00072F5CAA0100AA0007 /* LOGIT 7.0.xcdatamodel */,
 				80AA00052F3A000100AA0001 /* LOGIT 6.0.xcdatamodel */,
 				8054E6B02F1CC5F9003F150D /* LOGIT 5.0.xcdatamodel */,
 				8034A7EC2E83073700834A32 /* LOGIT 4.0.xcdatamodel */,
@@ -2277,7 +2291,7 @@
 				801BBD602DF7338A00CDB1FB /* LOGIT 3.0.xcdatamodel */,
 				801BBD612DF7338A00CDB1FB /* WorkoutDiary.xcdatamodel */,
 			);
-			currentVersion = 80AA00052F3A000100AA0001 /* LOGIT 6.0.xcdatamodel */;
+			currentVersion = 80AA00072F5CAA0100AA0007 /* LOGIT 7.0.xcdatamodel */;
 			path = LOGIT.xcdatamodeld;
 			sourceTree = "<group>";
 			versionGroupType = wrapper.xcdatamodel;

--- a/LOGIT/App/LOGITApp.swift
+++ b/LOGIT/App/LOGITApp.swift
@@ -31,6 +31,7 @@ struct LOGIT: App {
     @StateObject private var homeNavigationCoordinator = HomeNavigationCoordinator()
     @StateObject private var chronograph: Chronograph
     @StateObject private var defaultExerciseService: DefaultExerciseService
+    @StateObject private var defaultTemplateService: DefaultTemplateService
     @StateObject private var exerciseSuggestionService: ExerciseSuggestionService
 
     @State private var selectedTab: TabType = .home
@@ -79,6 +80,7 @@ struct LOGIT: App {
         _muscleGroupService = StateObject(wrappedValue: MuscleGroupService())
         _homeNavigationCoordinator = StateObject(wrappedValue: HomeNavigationCoordinator())
         _defaultExerciseService = StateObject(wrappedValue: DefaultExerciseService(database: database))
+        _defaultTemplateService = StateObject(wrappedValue: DefaultTemplateService(database: database))
         _exerciseSuggestionService = StateObject(wrappedValue: ExerciseSuggestionService(database: database))
 
         UserDefaults.standard.register(defaults: [
@@ -164,6 +166,11 @@ struct LOGIT: App {
                         isShowingWelcome = true
                     }
                     defaultExerciseService.loadDefaultExercisesIfNeeded()
+                    // Skipped for fastlane screenshot runs so the curated fixture data stays
+                    // exactly what the marketing screenshots expect.
+                    if !ScreenshotFixtures.isEnabled {
+                        defaultTemplateService.loadDefaultTemplatesIfNeeded()
+                    }
                     #if DEBUG
                     DemoWorkoutSeeder.seedIfRequested(database: database)
                     #endif

--- a/LOGIT/Core/Environment/de.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/de.lproj/Localizable.strings
@@ -718,6 +718,19 @@
 "_default.exercise.ringPushups" = "Ring Liegestütze";
 "_default.exercise.ringRows" = "Ring Rudern";
 
+// MARK: - Default Template Names & Descriptions
+
+"_default.template.fullBodyA" = "Ganzkörper A";
+"_default.template.fullBodyA.description" = "Kniebeugen, Drücken und Rudern – das klassische Einsteiger-Workout. Wechsle an 2–3 nicht aufeinanderfolgenden Tagen pro Woche mit Ganzkörper B ab und steigere das Gewicht leicht, sobald alle Sätze gut machbar sind.";
+"_default.template.fullBodyB" = "Ganzkörper B";
+"_default.template.fullBodyB.description" = "Das Gegenstück zu Ganzkörper A – mit Kreuzheben, Schulterdrücken und Latzug. Im Wechsel ergeben beide eine einfache, ausgewogene Routine.";
+"_default.template.pushDay" = "Push-Tag";
+"_default.template.pushDay.description" = "Brust, Schultern und Trizeps – alles, was drückt. Teil des klassischen Push/Pull/Beine-Splits, zusammen mit Pull-Tag und Beintag.";
+"_default.template.pullDay" = "Pull-Tag";
+"_default.template.pullDay.description" = "Rücken und Bizeps – alles, was zieht. Teil des klassischen Push/Pull/Beine-Splits, zusammen mit Push-Tag und Beintag.";
+"_default.template.legDay" = "Beintag";
+"_default.template.legDay.description" = "Quadrizeps, Beinbeuger, Gesäß und Waden. Teil des klassischen Push/Pull/Beine-Splits, zusammen mit Push-Tag und Pull-Tag.";
+
 // MARK: - Volume Highlights
 "avgMoreVolumePerWorkoutThisMonthThanLastMonth" = "Du bewegst im Durchschnitt mehr Volumen pro Workout diesen Monat als letzten Monat.";
 "avgLessVolumePerWorkoutThisMonthThanLastMonth" = "Du bewegst im Durchschnitt weniger Volumen pro Workout diesen Monat als letzten Monat.";

--- a/LOGIT/Core/Environment/en.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/en.lproj/Localizable.strings
@@ -722,6 +722,19 @@
 "_default.exercise.ringPushups" = "Ring Push-ups";
 "_default.exercise.ringRows" = "Ring Rows";
 
+// MARK: - Default Template Names & Descriptions
+
+"_default.template.fullBodyA" = "Full Body A";
+"_default.template.fullBodyA.description" = "Squat, press and row — the classic starter workout. Alternate with Full Body B on 2–3 non-consecutive days per week, and add a little weight once all sets feel manageable.";
+"_default.template.fullBodyB" = "Full Body B";
+"_default.template.fullBodyB.description" = "The partner workout to Full Body A, built around the deadlift, shoulder press and pulldown. Alternate the two for a simple, balanced routine.";
+"_default.template.pushDay" = "Push Day";
+"_default.template.pushDay.description" = "Chest, shoulders and triceps — everything that pushes. Part of the classic push/pull/legs split, together with Pull Day and Leg Day.";
+"_default.template.pullDay" = "Pull Day";
+"_default.template.pullDay.description" = "Back and biceps — everything that pulls. Part of the classic push/pull/legs split, together with Push Day and Leg Day.";
+"_default.template.legDay" = "Leg Day";
+"_default.template.legDay.description" = "Quads, hamstrings, glutes and calves. Part of the classic push/pull/legs split, together with Push Day and Pull Day.";
+
 // MARK: - Volume Highlights
 "avgMoreVolumePerWorkoutThisMonthThanLastMonth" = "You're averaging more volume per workout this month than last month.";
 "avgLessVolumePerWorkoutThisMonthThanLastMonth" = "You're averaging less volume per workout this month than last month.";

--- a/LOGIT/Core/Environment/es.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/es.lproj/Localizable.strings
@@ -722,6 +722,19 @@
 "_default.exercise.ringPushups" = "Flexiones de anillo";
 "_default.exercise.ringRows" = "Filas de anillos";
 
+// MARK: - Default Template Names & Descriptions
+
+"_default.template.fullBodyA" = "Cuerpo completo A";
+"_default.template.fullBodyA.description" = "Sentadilla, press y remo: el entrenamiento clásico para empezar. Altérnalo con Cuerpo completo B 2–3 días no consecutivos por semana y sube un poco el peso cuando todas las series te resulten manejables.";
+"_default.template.fullBodyB" = "Cuerpo completo B";
+"_default.template.fullBodyB.description" = "El complemento de Cuerpo completo A, con peso muerto, press de hombros y jalón. Alterna ambos para una rutina sencilla y equilibrada.";
+"_default.template.pushDay" = "Día de empuje";
+"_default.template.pushDay.description" = "Pecho, hombros y tríceps: todo lo que empuja. Parte del clásico split de empuje/tirón/pierna, junto con Día de tirón y Día de pierna.";
+"_default.template.pullDay" = "Día de tirón";
+"_default.template.pullDay.description" = "Espalda y bíceps: todo lo que tira. Parte del clásico split de empuje/tirón/pierna, junto con Día de empuje y Día de pierna.";
+"_default.template.legDay" = "Día de pierna";
+"_default.template.legDay.description" = "Cuádriceps, femorales, glúteos y gemelos. Parte del clásico split de empuje/tirón/pierna, junto con Día de empuje y Día de tirón.";
+
 // MARK: - Volume Highlights
 "avgMoreVolumePerWorkoutThisMonthThanLastMonth" = "Estás promediando más volumen por entrenamiento este mes que el mes pasado.";
 "avgLessVolumePerWorkoutThisMonthThanLastMonth" = "Estás promediando menos volumen por entrenamiento este mes que el mes pasado.";

--- a/LOGIT/Core/Environment/fr.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/fr.lproj/Localizable.strings
@@ -722,6 +722,19 @@
 "_default.exercise.ringPushups" = "Pompes à anneaux";
 "_default.exercise.ringRows" = "Rangées d'anneaux";
 
+// MARK: - Default Template Names & Descriptions
+
+"_default.template.fullBodyA" = "Full Body A";
+"_default.template.fullBodyA.description" = "Squat, développé et rowing : la séance classique pour débuter. Alternez avec Full Body B 2 à 3 jours non consécutifs par semaine, et ajoutez un peu de poids dès que toutes les séries passent bien.";
+"_default.template.fullBodyB" = "Full Body B";
+"_default.template.fullBodyB.description" = "Le pendant de Full Body A, autour du soulevé de terre, du développé épaules et du tirage. Alternez les deux pour une routine simple et équilibrée.";
+"_default.template.pushDay" = "Séance Push";
+"_default.template.pushDay.description" = "Pectoraux, épaules et triceps : tout ce qui pousse. Élément du classique split push/pull/jambes, avec la Séance Pull et la Séance Jambes.";
+"_default.template.pullDay" = "Séance Pull";
+"_default.template.pullDay.description" = "Dos et biceps : tout ce qui tire. Élément du classique split push/pull/jambes, avec la Séance Push et la Séance Jambes.";
+"_default.template.legDay" = "Séance Jambes";
+"_default.template.legDay.description" = "Quadriceps, ischio-jambiers, fessiers et mollets. Élément du classique split push/pull/jambes, avec la Séance Push et la Séance Pull.";
+
 // MARK: - Volume Highlights
 "avgMoreVolumePerWorkoutThisMonthThanLastMonth" = "Vous réalisez en moyenne plus de volume par entraînement ce mois-ci que le mois dernier.";
 "avgLessVolumePerWorkoutThisMonthThanLastMonth" = "Vous réalisez en moyenne moins de volume par entraînement ce mois-ci que le mois dernier.";

--- a/LOGIT/Core/Environment/it.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/it.lproj/Localizable.strings
@@ -722,6 +722,19 @@
 "_default.exercise.ringPushups" = "Push-up ad anello";
 "_default.exercise.ringRows" = "Righe ad anello";
 
+// MARK: - Default Template Names & Descriptions
+
+"_default.template.fullBodyA" = "Full Body A";
+"_default.template.fullBodyA.description" = "Squat, distensioni e rematore: il classico allenamento per iniziare. Alternalo con Full Body B in 2–3 giorni non consecutivi a settimana e aumenta un po' il peso quando tutte le serie risultano gestibili.";
+"_default.template.fullBodyB" = "Full Body B";
+"_default.template.fullBodyB.description" = "Il complemento di Full Body A, con stacco, distensioni per le spalle e lat machine. Alternali per una routine semplice ed equilibrata.";
+"_default.template.pushDay" = "Giorno Push";
+"_default.template.pushDay.description" = "Petto, spalle e tricipiti: tutto ciò che spinge. Parte del classico split push/pull/gambe, insieme a Giorno Pull e Giorno Gambe.";
+"_default.template.pullDay" = "Giorno Pull";
+"_default.template.pullDay.description" = "Schiena e bicipiti: tutto ciò che tira. Parte del classico split push/pull/gambe, insieme a Giorno Push e Giorno Gambe.";
+"_default.template.legDay" = "Giorno Gambe";
+"_default.template.legDay.description" = "Quadricipiti, femorali, glutei e polpacci. Parte del classico split push/pull/gambe, insieme a Giorno Push e Giorno Pull.";
+
 // MARK: - Volume Highlights
 "avgMoreVolumePerWorkoutThisMonthThanLastMonth" = "Stai registrando in media più volume per allenamento questo mese rispetto al mese scorso.";
 "avgLessVolumePerWorkoutThisMonthThanLastMonth" = "Questo mese stai registrando un volume medio per allenamento inferiore rispetto al mese scorso.";

--- a/LOGIT/Core/Environment/ja.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/ja.lproj/Localizable.strings
@@ -722,6 +722,19 @@
 "_default.exercise.ringPushups" = "リングプッシュアップ";
 "_default.exercise.ringRows" = "リングロウ";
 
+// MARK: - Default Template Names & Descriptions
+
+"_default.template.fullBodyA" = "全身トレーニング A";
+"_default.template.fullBodyA.description" = "スクワット、プレス、ロウイングを組み合わせた定番の入門ワークアウト。全身トレーニング B と交互に、週2〜3回(連続しない日)で行い、全セットを余裕でこなせるようになったら少しずつ重量を増やしましょう。";
+"_default.template.fullBodyB" = "全身トレーニング B";
+"_default.template.fullBodyB.description" = "全身トレーニング A と対になるワークアウト。デッドリフト、ショルダープレス、ラットプルダウンが中心です。2つを交互に行えば、シンプルでバランスの良いルーティンになります。";
+"_default.template.pushDay" = "プッシュデイ";
+"_default.template.pushDay.description" = "胸・肩・上腕三頭筋など「押す」筋肉を鍛える日。プルデイ、レッグデイと組み合わせる定番のプッシュ/プル/レッグ分割法の一部です。";
+"_default.template.pullDay" = "プルデイ";
+"_default.template.pullDay.description" = "背中と上腕二頭筋など「引く」筋肉を鍛える日。プッシュデイ、レッグデイと組み合わせる定番のプッシュ/プル/レッグ分割法の一部です。";
+"_default.template.legDay" = "レッグデイ";
+"_default.template.legDay.description" = "大腿四頭筋、ハムストリングス、臀筋、ふくらはぎを鍛える日。プッシュデイ、プルデイと組み合わせる定番の分割法の一部です。";
+
 // MARK: - Volume Highlights
 "avgMoreVolumePerWorkoutThisMonthThanLastMonth" = "今月は先月よりもワークアウトごとの平均ボリュームが増えています。";
 "avgLessVolumePerWorkoutThisMonthThanLastMonth" = "今月は先月よりもワークアウトごとの平均ボリュームが減少しています。";

--- a/LOGIT/Core/Environment/ko.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/ko.lproj/Localizable.strings
@@ -722,6 +722,19 @@
 "_default.exercise.ringPushups" = "링 푸쉬업";
 "_default.exercise.ringRows" = "링 로우";
 
+// MARK: - Default Template Names & Descriptions
+
+"_default.template.fullBodyA" = "전신 운동 A";
+"_default.template.fullBodyA.description" = "스쿼트, 프레스, 로우로 구성된 클래식 입문 루틴입니다. 전신 운동 B와 번갈아 가며 주 2~3회(연속되지 않는 날) 진행하고, 모든 세트가 수월해지면 무게를 조금씩 올려 보세요.";
+"_default.template.fullBodyB" = "전신 운동 B";
+"_default.template.fullBodyB.description" = "전신 운동 A와 짝을 이루는 루틴으로 데드리프트, 숄더 프레스, 랫 풀다운이 중심입니다. 두 루틴을 번갈아 하면 간단하고 균형 잡힌 프로그램이 됩니다.";
+"_default.template.pushDay" = "푸시 데이";
+"_default.template.pushDay.description" = "가슴, 어깨, 삼두 등 미는 근육을 단련하는 날입니다. 풀 데이, 레그 데이와 함께 하는 클래식 푸시/풀/레그 분할의 일부입니다.";
+"_default.template.pullDay" = "풀 데이";
+"_default.template.pullDay.description" = "등과 이두 등 당기는 근육을 단련하는 날입니다. 푸시 데이, 레그 데이와 함께 하는 클래식 푸시/풀/레그 분할의 일부입니다.";
+"_default.template.legDay" = "레그 데이";
+"_default.template.legDay.description" = "대퇴사두, 햄스트링, 둔근, 종아리를 단련하는 날입니다. 푸시 데이, 풀 데이와 함께 하는 클래식 분할의 일부입니다.";
+
 // MARK: - Volume Highlights
 "avgMoreVolumePerWorkoutThisMonthThanLastMonth" = "이번 달에는 지난 달보다 평균적으로 더 많은 운동량을 기록하고 있습니다.";
 "avgLessVolumePerWorkoutThisMonthThanLastMonth" = "이번 달에는 지난 달보다 평균 운동량의 양이 적습니다.";

--- a/LOGIT/Core/Environment/pt-BR.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/pt-BR.lproj/Localizable.strings
@@ -722,6 +722,19 @@
 "_default.exercise.ringPushups" = "Flexões de anel";
 "_default.exercise.ringRows" = "Linhas de anel";
 
+// MARK: - Default Template Names & Descriptions
+
+"_default.template.fullBodyA" = "Full Body A";
+"_default.template.fullBodyA.description" = "Agachamento, supino e remada: o treino clássico para começar. Alterne com o Full Body B em 2–3 dias não consecutivos por semana e aumente um pouco a carga quando todas as séries ficarem confortáveis.";
+"_default.template.fullBodyB" = "Full Body B";
+"_default.template.fullBodyB.description" = "O par do Full Body A, com levantamento terra, desenvolvimento de ombros e puxada. Alterne os dois para uma rotina simples e equilibrada.";
+"_default.template.pushDay" = "Treino Push";
+"_default.template.pushDay.description" = "Peito, ombros e tríceps: tudo que empurra. Parte do clássico split push/pull/pernas, junto com o Treino Pull e o Treino de Pernas.";
+"_default.template.pullDay" = "Treino Pull";
+"_default.template.pullDay.description" = "Costas e bíceps: tudo que puxa. Parte do clássico split push/pull/pernas, junto com o Treino Push e o Treino de Pernas.";
+"_default.template.legDay" = "Treino de Pernas";
+"_default.template.legDay.description" = "Quadríceps, posteriores, glúteos e panturrilhas. Parte do clássico split push/pull/pernas, junto com o Treino Push e o Treino Pull.";
+
 // MARK: - Volume Highlights
 "avgMoreVolumePerWorkoutThisMonthThanLastMonth" = "Você está obtendo em média mais volume por treino neste mês do que no mês passado.";
 "avgLessVolumePerWorkoutThisMonthThanLastMonth" = "Você está obtendo em média menos volume por treino este mês do que no mês passado.";

--- a/LOGIT/Data/DTOs/TemplateDTO.swift
+++ b/LOGIT/Data/DTOs/TemplateDTO.swift
@@ -13,23 +13,29 @@ struct TemplateDTO: Codable {
     
     let formatVersion: Int?
     let name: String
+    /// Optional template description (added in app version 7 files; absent in older ones)
+    let description: String?
     let setGroups: [TemplateSetGroupDTO]
-    
+
     /// App Store URL for users who don't have the app installed
     let appStoreURL: String?
-    
-    /// Initialize from a Core Data Template entity for sharing
+
+    /// Initialize from a Core Data Template entity for sharing.
+    /// Exports the resolved (localized) name and description, not `_default.` keys, so
+    /// receivers on older app versions still see readable text.
     init(from template: Template) {
         self.formatVersion = Self.formatVersion
-        self.name = template.name ?? ""
+        self.name = template.resolvedName ?? ""
+        self.description = template.displayDescription
         self.setGroups = template.setGroups.map { TemplateSetGroupDTO(from: $0) }
         self.appStoreURL = "https://apps.apple.com/app/logit-track-your-workouts/id6444813640"
     }
-    
+
     /// Initialize for decoding (used by AI generation and import)
-    init(name: String, setGroups: [TemplateSetGroupDTO], formatVersion: Int? = nil, appStoreURL: String? = nil) {
+    init(name: String, setGroups: [TemplateSetGroupDTO], formatVersion: Int? = nil, appStoreURL: String? = nil, description: String? = nil) {
         self.formatVersion = formatVersion
         self.name = name
+        self.description = description
         self.setGroups = setGroups
         self.appStoreURL = appStoreURL
     }

--- a/LOGIT/Data/Database/Database+EntityCreation.swift
+++ b/LOGIT/Data/Database/Database+EntityCreation.swift
@@ -143,6 +143,7 @@ extension Database {
         setGroups: [TemplateSetGroup] = [TemplateSetGroup]()
     ) -> Template {
         let template = Template(context: context)
+        template.id = UUID()
         template.name = name
         template.creationDate = Date.now
         template.setGroups = setGroups

--- a/LOGIT/Data/Database/LOGIT.xcdatamodeld/.xccurrentversion
+++ b/LOGIT/Data/Database/LOGIT.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>LOGIT 6.0.xcdatamodel</string>
+	<string>LOGIT 7.0.xcdatamodel</string>
 </dict>
 </plist>

--- a/LOGIT/Data/Database/LOGIT.xcdatamodeld/LOGIT 7.0.xcdatamodel/contents
+++ b/LOGIT/Data/Database/LOGIT.xcdatamodeld/LOGIT 7.0.xcdatamodel/contents
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="24299" systemVersion="25B78" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithCloudKit="YES" userDefinedModelVersionIdentifier="">
+    <entity name="DropSet" representedClassName="DropSet" parentEntity="WorkoutSet" syncable="YES" codeGenerationType="category">
+        <attribute name="repetitions" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[Int64]"/>
+        <attribute name="weights" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[Int64]"/>
+    </entity>
+    <entity name="Exercise" representedClassName="Exercise" syncable="YES" codeGenerationType="class">
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="instructions" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromDataTransformerName" customClassName="[String]"/>
+        <attribute name="muscleGroupString" optional="YES" attributeType="String" customClassName="MuscleGroup"/>
+        <attribute name="name" optional="YES" attributeType="String" elementID="name"/>
+        <attribute name="setGroupOrder" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromDataTransformerName" customClassName="[UUID]"/>
+        <attribute name="templateSetGroupOrder" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromDataTransformerName" customClassName="[UUID]"/>
+        <relationship name="setGroups_" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="WorkoutSetGroup" inverseName="exercises_" inverseEntity="WorkoutSetGroup"/>
+        <relationship name="templateSetGroups_" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="TemplateSetGroup" inverseName="exercises_" inverseEntity="TemplateSetGroup"/>
+    </entity>
+    <entity name="MeasurementEntry" representedClassName="MeasurementEntry" syncable="YES" codeGenerationType="class">
+        <attribute name="date" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="type_" optional="YES" attributeType="String"/>
+        <attribute name="value_" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+    </entity>
+    <entity name="StandardSet" representedClassName="StandardSet" parentEntity="WorkoutSet" syncable="YES" codeGenerationType="category">
+        <attribute name="repetitions" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="weight" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+    </entity>
+    <entity name="SuperSet" representedClassName="SuperSet" parentEntity="WorkoutSet" syncable="YES" codeGenerationType="category">
+        <attribute name="repetitionsFirstExercise" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="repetitionsSecondExercise" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="weightFirstExercise" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="weightSecondExercise" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+    </entity>
+    <entity name="Template" representedClassName="Template" syncable="YES" codeGenerationType="class">
+        <attribute name="creationDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="descriptionText" optional="YES" attributeType="String"/>
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="templateSetGroupOrder" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromDataTransformerName" customClassName="[UUID]"/>
+        <relationship name="setGroups_" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="TemplateSetGroup" inverseName="workout" inverseEntity="TemplateSetGroup"/>
+        <relationship name="workouts_" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Workout" inverseName="template" inverseEntity="Workout"/>
+    </entity>
+    <entity name="TemplateDropSet" representedClassName="TemplateDropSet" parentEntity="TemplateSet" syncable="YES" codeGenerationType="category">
+        <attribute name="repetitions" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[Int64]"/>
+        <attribute name="weights" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[Int64]"/>
+    </entity>
+    <entity name="TemplateSet" representedClassName="TemplateSet" isAbstract="YES" syncable="YES" codeGenerationType="class">
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="restDuration" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="setGroup" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="TemplateSetGroup" inverseName="sets_" inverseEntity="TemplateSetGroup"/>
+    </entity>
+    <entity name="TemplateSetGroup" representedClassName="TemplateSetGroup" syncable="YES" codeGenerationType="class">
+        <attribute name="exerciseOrder" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromDataTransformerName" customClassName="[UUID]"/>
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="setOrder" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromDataTransformerName" customClassName="[UUID]"/>
+        <relationship name="exercises_" optional="YES" toMany="YES" maxCount="2" deletionRule="Nullify" destinationEntity="Exercise" inverseName="templateSetGroups_" inverseEntity="Exercise"/>
+        <relationship name="sets_" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="TemplateSet" inverseName="setGroup" inverseEntity="TemplateSet"/>
+        <relationship name="workout" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Template" inverseName="setGroups_" inverseEntity="Template"/>
+    </entity>
+    <entity name="TemplateStandardSet" representedClassName="TemplateStandardSet" parentEntity="TemplateSet" syncable="YES" codeGenerationType="category">
+        <attribute name="repetitions" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="weight" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+    </entity>
+    <entity name="TemplateSuperSet" representedClassName="TemplateSuperSet" parentEntity="TemplateSet" syncable="YES" codeGenerationType="category">
+        <attribute name="repetitionsFirstExercise" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="repetitionsSecondExercise" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="weightFirstExercise" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="weightSecondExercise" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+    </entity>
+    <entity name="Widget" representedClassName="Widget" syncable="YES" codeGenerationType="class">
+        <attribute name="id" optional="YES" attributeType="String"/>
+        <attribute name="isAdded" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <relationship name="collection" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="WidgetCollection" inverseName="items_" inverseEntity="WidgetCollection"/>
+    </entity>
+    <entity name="WidgetCollection" representedClassName="WidgetCollection" syncable="YES" codeGenerationType="class">
+        <attribute name="id" optional="YES" attributeType="String"/>
+        <attribute name="itemOrder" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromDataTransformerName" customClassName="[String]"/>
+        <relationship name="items_" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Widget" inverseName="collection" inverseEntity="Widget"/>
+    </entity>
+    <entity name="Workout" representedClassName="Workout" syncable="YES" codeGenerationType="class">
+        <attribute name="date" optional="YES" attributeType="Date" defaultDateTimeInterval="646345140" usesScalarValueType="NO"/>
+        <attribute name="endDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="isCurrentWorkout" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" defaultValueString=""/>
+        <attribute name="setGroupOrder" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromDataTransformerName" customClassName="[UUID]"/>
+        <relationship name="setGroups_" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="WorkoutSetGroup" inverseName="workout" inverseEntity="WorkoutSetGroup"/>
+        <relationship name="template" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Template" inverseName="workouts_" inverseEntity="Template"/>
+    </entity>
+    <entity name="WorkoutSet" representedClassName="WorkoutSet" isAbstract="YES" syncable="YES" codeGenerationType="class">
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="restDuration" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="setGroup" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="WorkoutSetGroup" inverseName="sets_" inverseEntity="WorkoutSetGroup"/>
+    </entity>
+    <entity name="WorkoutSetGroup" representedClassName="WorkoutSetGroup" syncable="YES" codeGenerationType="class">
+        <attribute name="exerciseOrder" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromDataTransformerName" customClassName="[UUID]"/>
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="note" optional="YES" attributeType="String"/>
+        <attribute name="setOrder" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromDataTransformerName" customClassName="[UUID]"/>
+        <relationship name="exercises_" optional="YES" toMany="YES" maxCount="2" deletionRule="Nullify" destinationEntity="Exercise" inverseName="setGroups_" inverseEntity="Exercise"/>
+        <relationship name="sets_" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="WorkoutSet" inverseName="setGroup" inverseEntity="WorkoutSet"/>
+        <relationship name="workout" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Workout" inverseName="setGroups_" inverseEntity="Workout"/>
+    </entity>
+</model>

--- a/LOGIT/Data/EntityExtensions/Template+.swift
+++ b/LOGIT/Data/EntityExtensions/Template+.swift
@@ -13,7 +13,7 @@ import Ifrit
 extension Template {
     var searchProperties: [FuseProp] {
         var props: [FuseProp] = []
-        if let name = name {
+        if let name = resolvedName {
             props.append(FuseProp(name, weight: 1.0))
         }
         let exerciseNames = exercises.compactMap { $0.displayName }.joined(separator: " ")
@@ -27,6 +27,35 @@ extension Template {
 // MARK: - Template Extension
 
 extension Template {
+    /// `name` with `_default.` localization keys resolved (bundled templates store the key, not
+    /// a language-specific string, so every device shows its own language). Preserves nil and
+    /// empty names — use this wherever `template.name` used to be read directly.
+    var resolvedName: String? {
+        guard let name = name else { return nil }
+        return name.hasPrefix("_default.") ? NSLocalizedString(name, comment: "") : name
+    }
+
+    /// The name to render in cells and headers, mirroring `Exercise.displayName`.
+    var displayName: String {
+        guard let resolvedName = resolvedName, !resolvedName.isEmpty else {
+            return NSLocalizedString("noName", comment: "")
+        }
+        return resolvedName
+    }
+
+    var isDefaultTemplate: Bool {
+        name?.hasPrefix("_default.") ?? false
+    }
+
+    /// Localized description for display, or nil when there is none. Bundled templates store a
+    /// `_default.` localization key in `descriptionText`; user descriptions are literal text.
+    var displayDescription: String? {
+        guard let descriptionText = descriptionText, !descriptionText.isEmpty else { return nil }
+        return descriptionText.hasPrefix("_default.")
+            ? NSLocalizedString(descriptionText, comment: "")
+            : descriptionText
+    }
+
     var workouts: [Workout] {
         get {
             (workouts_?.allObjects as? [Workout] ?? .emptyList)

--- a/LOGIT/Features/Template/Cells/TemplateCell.swift
+++ b/LOGIT/Features/Template/Cells/TemplateCell.swift
@@ -37,11 +37,17 @@ struct TemplateCell: View {
                     Text(NSLocalizedString("template", comment: "").uppercased())
                         .font(.footnote.weight(.medium))
                         .foregroundStyle(.secondary)
-                    Text(template.name ?? NSLocalizedString("noName", comment: ""))
+                    Text(template.displayName)
                         .fontWeight(.bold)
                         .foregroundColor(.primary)
                         .lineLimit(1)
                 }
+            }
+            if let description = template.displayDescription {
+                Text(description)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/LOGIT/Features/Template/TemplateDetailScreen.swift
+++ b/LOGIT/Features/Template/TemplateDetailScreen.swift
@@ -124,7 +124,7 @@ struct TemplateDetailScreen: View {
             }
         }
         .sheet(item: $templateShareFileURL) { url in
-            ShareSheet(activityItems: [WorkoutActivityItemSource(fileURL: url, title: template.name ?? NSLocalizedString("template", comment: ""))])
+            ShareSheet(activityItems: [WorkoutActivityItemSource(fileURL: url, title: template.resolvedName ?? NSLocalizedString("template", comment: ""))])
                 .onDisappear {
                     do {
                         try FileManager.default.removeItem(at: url)
@@ -151,9 +151,15 @@ struct TemplateDetailScreen: View {
         VStack(alignment: .leading) {
             Text(NSLocalizedString("template", comment: ""))
                 .screenHeaderTertiaryStyle()
-            Text(template.name ?? "")
+            Text(template.resolvedName ?? "")
                 .screenHeaderStyle()
                 .lineLimit(2)
+            if let description = template.displayDescription {
+                Text(description)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .padding(.top, 2)
+            }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
     }

--- a/LOGIT/Features/Template/TemplateEditorScreen.swift
+++ b/LOGIT/Features/Template/TemplateEditorScreen.swift
@@ -305,7 +305,10 @@ struct TemplateEditorScreen: View {
     // MARK: - Computed Properties
 
     private var templateName: Binding<String> {
-        Binding(get: { template.name ?? "" }, set: { template.name = $0 })
+        // Resolve `_default.` keys so bundled templates show their localized name here. Once
+        // the user types, the literal text is stored and the template stops being localized —
+        // renaming makes it theirs.
+        Binding(get: { template.resolvedName ?? "" }, set: { template.name = $0 })
     }
 
     /// The template set whose rep/weight field currently holds focus, derived from the keyboard

--- a/LOGIT/Features/Template/TemplateListScreen.swift
+++ b/LOGIT/Features/Template/TemplateListScreen.swift
@@ -39,10 +39,10 @@ struct TemplateListScreen: View {
         ) { allTemplates in
             let templates = FuzzySearchService.shared.searchTemplates(searchedText, in: allTemplates)
             let sortedTemplates = searchedText.isEmpty
-                ? templates.sorted { ($0.name ?? "").localizedCompare($1.name ?? "") == .orderedAscending }
+                ? templates.sorted { ($0.resolvedName ?? "").localizedCompare($1.resolvedName ?? "") == .orderedAscending }
                 : templates // Keep fuzzy search order when searching
             let groupedTemplates = Dictionary(grouping: sortedTemplates, by: {
-                String($0.name?.prefix(1) ?? "")
+                String(($0.resolvedName ?? "").prefix(1))
             }).sorted { $0.key < $1.key }
             let isSearching = !searchedText.isEmpty
             ScrollView {

--- a/LOGIT/Features/Workout/WorkoutRecorder/WorkoutRecorder.swift
+++ b/LOGIT/Features/Workout/WorkoutRecorder/WorkoutRecorder.swift
@@ -48,7 +48,7 @@ final class WorkoutRecorder: ObservableObject {
         workout?.isCurrentWorkout = true
         if let template = template {
             template.workouts.append(workout!)
-            workout!.name = template.name
+            workout!.name = template.resolvedName
             for templateSetGroup in template.setGroups {
                 let setGroup = database.newWorkoutSetGroup(
                     createFirstSetAutomatically: false,

--- a/LOGIT/Resources/default_templates.json
+++ b/LOGIT/Resources/default_templates.json
@@ -1,0 +1,65 @@
+{
+  "version": 1,
+  "templates": [
+    {
+      "id": "default_template_001",
+      "nameKey": "_default.template.fullBodyA",
+      "descriptionKey": "_default.template.fullBodyA.description",
+      "setGroups": [
+        { "exerciseId": "default_023", "sets": 3, "repetitions": 8, "restDuration": 120 },
+        { "exerciseId": "default_002", "sets": 3, "repetitions": 8, "restDuration": 120 },
+        { "exerciseId": "default_015", "sets": 3, "repetitions": 8, "restDuration": 120 },
+        { "exerciseId": "default_057", "sets": 3, "repetitions": 12, "restDuration": 60 },
+        { "exerciseId": "default_065", "sets": 3, "repetitions": 15, "restDuration": 60 }
+      ]
+    },
+    {
+      "id": "default_template_002",
+      "nameKey": "_default.template.fullBodyB",
+      "descriptionKey": "_default.template.fullBodyB.description",
+      "setGroups": [
+        { "exerciseId": "default_021", "sets": 3, "repetitions": 8, "restDuration": 120 },
+        { "exerciseId": "default_041", "sets": 3, "repetitions": 8, "restDuration": 90 },
+        { "exerciseId": "default_014", "sets": 3, "repetitions": 10, "restDuration": 90 },
+        { "exerciseId": "default_049", "sets": 3, "repetitions": 12, "restDuration": 60 },
+        { "exerciseId": "default_067", "sets": 3, "repetitions": 12, "restDuration": 60 }
+      ]
+    },
+    {
+      "id": "default_template_003",
+      "nameKey": "_default.template.pushDay",
+      "descriptionKey": "_default.template.pushDay.description",
+      "setGroups": [
+        { "exerciseId": "default_002", "sets": 3, "repetitions": 8, "restDuration": 120 },
+        { "exerciseId": "default_005", "sets": 3, "repetitions": 10, "restDuration": 90 },
+        { "exerciseId": "default_041", "sets": 3, "repetitions": 10, "restDuration": 90 },
+        { "exerciseId": "default_043", "sets": 3, "repetitions": 12, "restDuration": 60 },
+        { "exerciseId": "default_049", "sets": 3, "repetitions": 12, "restDuration": 60 }
+      ]
+    },
+    {
+      "id": "default_template_004",
+      "nameKey": "_default.template.pullDay",
+      "descriptionKey": "_default.template.pullDay.description",
+      "setGroups": [
+        { "exerciseId": "default_014", "sets": 3, "repetitions": 10, "restDuration": 90 },
+        { "exerciseId": "default_015", "sets": 3, "repetitions": 8, "restDuration": 120 },
+        { "exerciseId": "default_017", "sets": 3, "repetitions": 10, "restDuration": 90 },
+        { "exerciseId": "default_022", "sets": 3, "repetitions": 15, "restDuration": 60 },
+        { "exerciseId": "default_056", "sets": 3, "repetitions": 12, "restDuration": 60 }
+      ]
+    },
+    {
+      "id": "default_template_005",
+      "nameKey": "_default.template.legDay",
+      "descriptionKey": "_default.template.legDay.description",
+      "setGroups": [
+        { "exerciseId": "default_023", "sets": 3, "repetitions": 8, "restDuration": 120 },
+        { "exerciseId": "default_025", "sets": 3, "repetitions": 10, "restDuration": 90 },
+        { "exerciseId": "default_030", "sets": 3, "repetitions": 12, "restDuration": 60 },
+        { "exerciseId": "default_029", "sets": 3, "repetitions": 12, "restDuration": 60 },
+        { "exerciseId": "default_031", "sets": 3, "repetitions": 15, "restDuration": 60 }
+      ]
+    }
+  ]
+}

--- a/LOGIT/Services/DefaultExerciseService.swift
+++ b/LOGIT/Services/DefaultExerciseService.swift
@@ -42,12 +42,13 @@ struct DefaultExercise: Codable {
 
 class DefaultExerciseService: ObservableObject {
     private let database: Database
-    private let defaults = UserDefaults.standard
+    private let defaults: UserDefaults
     private let lastLoadedVersionKey = "lastLoadedDefaultExercisesVersion"
     private let lastLoadedLocaleKey = "lastLoadedDefaultExercisesLocale"
-    
-    init(database: Database) {
+
+    init(database: Database, defaults: UserDefaults = .standard) {
         self.database = database
+        self.defaults = defaults
     }
     
     func loadDefaultExercisesIfNeeded() {
@@ -94,37 +95,9 @@ class DefaultExerciseService: ObservableObject {
     }
     
     private func generateUUID(from defaultId: String) -> UUID {
-        // Create deterministic UUID from default ID
-        // Use MD5 hash to generate UUID v3-style identifier
-        let namespace = "com.logit.defaultexercise"
-        let input = namespace + defaultId
-        
-        guard let data = input.data(using: .utf8) else {
-            return UUID()
-        }
-        
-        // Simple hash-based UUID generation
-        var hash = data.withUnsafeBytes { bytes -> [UInt8] in
-            var result = [UInt8](repeating: 0, count: 16)
-            for (index, byte) in bytes.enumerated() {
-                result[index % 16] ^= byte
-            }
-            return result
-        }
-        
-        // Set version (3) and variant bits for UUID
-        hash[6] = (hash[6] & 0x0F) | 0x30
-        hash[8] = (hash[8] & 0x3F) | 0x80
-        
-        let uuidString = String(format: "%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",
-                               hash[0], hash[1], hash[2], hash[3],
-                               hash[4], hash[5], hash[6], hash[7],
-                               hash[8], hash[9], hash[10], hash[11],
-                               hash[12], hash[13], hash[14], hash[15])
-        
-        return UUID(uuidString: uuidString) ?? UUID()
+        DeterministicUUID.make(namespace: "com.logit.defaultexercise", id: defaultId)
     }
-    
+
     private func fetchExerciseByDefaultId(_ defaultId: String) -> Exercise? {
         let uuid = generateUUID(from: defaultId)
         

--- a/LOGIT/Services/DefaultTemplateService.swift
+++ b/LOGIT/Services/DefaultTemplateService.swift
@@ -1,0 +1,154 @@
+//
+//  DefaultTemplateService.swift
+//  LOGIT
+//
+
+import Combine
+import CoreData
+import Foundation
+import OSLog
+
+struct DefaultTemplateData: Codable {
+    let version: Int
+    let templates: [DefaultTemplate]
+}
+
+struct DefaultTemplate: Codable {
+    let id: String
+    let nameKey: String
+    let descriptionKey: String
+    let setGroups: [DefaultTemplateSetGroup]
+}
+
+struct DefaultTemplateSetGroup: Codable {
+    let exerciseId: String
+    let sets: Int
+    let repetitions: Int
+    let restDuration: Int
+}
+
+/// Seeds the bundled starter templates (push/pull/legs, full body) so first-time users have
+/// ready-made workouts to pick from.
+///
+/// Unlike `DefaultExerciseService`, which re-applies the bundled data on every version bump,
+/// templates are starting points the user is expected to edit — so each template is created at
+/// most once. `seededTemplateIdsKey` remembers every id that was ever seeded: a template the
+/// user deleted stays deleted, and one the user edited or renamed is never touched again. A
+/// future JSON version bump therefore only adds templates that are new to the file.
+class DefaultTemplateService: ObservableObject {
+    private let database: Database
+    private let defaults: UserDefaults
+    private let lastLoadedVersionKey = "lastLoadedDefaultTemplatesVersion"
+    private let seededTemplateIdsKey = "seededDefaultTemplateIds"
+
+    init(database: Database, defaults: UserDefaults = .standard) {
+        self.database = database
+        self.defaults = defaults
+    }
+
+    /// Must run after `DefaultExerciseService.loadDefaultExercisesIfNeeded()` — the templates
+    /// reference default exercises by id and a template is skipped when one is missing.
+    func loadDefaultTemplatesIfNeeded() {
+        backfillMissingTemplateIds()
+
+        guard let url = Bundle.main.url(forResource: "default_templates", withExtension: "json"),
+              let data = try? Data(contentsOf: url),
+              let templateData = try? JSONDecoder().decode(DefaultTemplateData.self, from: data) else {
+            os_log("DefaultTemplateService: Failed to load default templates JSON", type: .error)
+            return
+        }
+
+        guard templateData.version > defaults.integer(forKey: lastLoadedVersionKey) else { return }
+
+        var seededIds = defaults.stringArray(forKey: seededTemplateIdsKey) ?? []
+        var didSeedAll = true
+        for template in templateData.templates {
+            guard !seededIds.contains(template.id) else { continue }
+            if fetchTemplateByDefaultId(template.id) != nil {
+                // Already present without a local seeding record — e.g. synced in from
+                // another device. Record it so it can't be seeded twice.
+                seededIds.append(template.id)
+                continue
+            }
+            if createDefaultTemplate(template) {
+                seededIds.append(template.id)
+            } else {
+                didSeedAll = false
+            }
+        }
+
+        defaults.set(seededIds, forKey: seededTemplateIdsKey)
+        // Only advance the version once every template made it in, so a template that was
+        // skipped (its exercises weren't seeded yet) gets another chance on the next launch.
+        if didSeedAll {
+            defaults.set(templateData.version, forKey: lastLoadedVersionKey)
+        }
+        database.save()
+        os_log("DefaultTemplateService: Loaded default templates version %d", type: .info, templateData.version)
+    }
+
+    /// The `id` attribute arrived with model version 7, so templates created before it carry
+    /// nil. Everything else identifies templates by objectID, but nil ids would make future
+    /// id-based features (sharing, dedup) silently misbehave — assign one wherever it's missing.
+    private func backfillMissingTemplateIds() {
+        let request = Template.fetchRequest()
+        request.predicate = NSPredicate(format: "id == nil")
+        guard let templates = try? database.context.fetch(request), !templates.isEmpty else { return }
+        for template in templates {
+            template.id = UUID()
+        }
+        database.save()
+    }
+
+    /// Creates the template with all set groups, or leaves the store untouched and returns
+    /// false when a referenced exercise is missing — half a template is worse than none.
+    private func createDefaultTemplate(_ templateData: DefaultTemplate) -> Bool {
+        var exercises = [Exercise]()
+        for setGroupData in templateData.setGroups {
+            guard let exercise = fetchExerciseByDefaultId(setGroupData.exerciseId) else {
+                os_log(
+                    "DefaultTemplateService: Missing default exercise %{public}@ — skipping template %{public}@",
+                    type: .error, setGroupData.exerciseId, templateData.id
+                )
+                return false
+            }
+            exercises.append(exercise)
+        }
+
+        let template = database.newTemplate(name: templateData.nameKey)
+        template.id = DeterministicUUID.make(namespace: "com.logit.defaulttemplate", id: templateData.id)
+        template.descriptionText = templateData.descriptionKey
+        for (setGroupData, exercise) in zip(templateData.setGroups, exercises) {
+            let setGroup = database.newTemplateSetGroup(
+                createFirstSetAutomatically: false,
+                exercise: exercise,
+                template: template
+            )
+            for _ in 0..<setGroupData.sets {
+                database.newTemplateStandardSet(
+                    repetitions: setGroupData.repetitions,
+                    weight: 0,
+                    restDuration: setGroupData.restDuration,
+                    setGroup: setGroup
+                )
+            }
+        }
+        return true
+    }
+
+    private func fetchTemplateByDefaultId(_ defaultId: String) -> Template? {
+        let uuid = DeterministicUUID.make(namespace: "com.logit.defaulttemplate", id: defaultId)
+        let request = Template.fetchRequest()
+        request.predicate = NSPredicate(format: "id == %@", uuid as CVarArg)
+        request.fetchLimit = 1
+        return (try? database.context.fetch(request))?.first
+    }
+
+    private func fetchExerciseByDefaultId(_ defaultId: String) -> Exercise? {
+        let uuid = DeterministicUUID.make(namespace: "com.logit.defaultexercise", id: defaultId)
+        let request = Exercise.fetchRequest()
+        request.predicate = NSPredicate(format: "id == %@", uuid as CVarArg)
+        request.fetchLimit = 1
+        return (try? database.context.fetch(request))?.first
+    }
+}

--- a/LOGIT/Services/DeterministicUUID.swift
+++ b/LOGIT/Services/DeterministicUUID.swift
@@ -1,0 +1,43 @@
+//
+//  DeterministicUUID.swift
+//  LOGIT
+//
+
+import Foundation
+
+/// Generates stable UUIDs for bundled default content (exercises, templates).
+///
+/// Seeding must be able to recognize entities it created in an earlier run — across app
+/// updates and reinstalls — so default entities get their UUID derived from a fixed
+/// namespace plus their JSON id instead of a random one. The algorithm is frozen: default
+/// exercises shipped with these UUIDs, so any change would orphan them in existing stores.
+enum DeterministicUUID {
+    static func make(namespace: String, id: String) -> UUID {
+        let input = namespace + id
+
+        guard let data = input.data(using: .utf8) else {
+            return UUID()
+        }
+
+        // Simple hash-based UUID generation
+        var hash = data.withUnsafeBytes { bytes -> [UInt8] in
+            var result = [UInt8](repeating: 0, count: 16)
+            for (index, byte) in bytes.enumerated() {
+                result[index % 16] ^= byte
+            }
+            return result
+        }
+
+        // Set version (3) and variant bits for UUID
+        hash[6] = (hash[6] & 0x0F) | 0x30
+        hash[8] = (hash[8] & 0x3F) | 0x80
+
+        let uuidString = String(format: "%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",
+                               hash[0], hash[1], hash[2], hash[3],
+                               hash[4], hash[5], hash[6], hash[7],
+                               hash[8], hash[9], hash[10], hash[11],
+                               hash[12], hash[13], hash[14], hash[15])
+
+        return UUID(uuidString: uuidString) ?? UUID()
+    }
+}

--- a/LOGIT/Services/WorkoutSharingService.swift
+++ b/LOGIT/Services/WorkoutSharingService.swift
@@ -61,7 +61,7 @@ final class WorkoutSharingService {
     /// - Returns: URL to the temporary file, or nil if export failed
     func exportTemplate(_ template: Template) -> URL? {
         let dto = TemplateDTO(from: template)
-        return exportToFile(dto, filename: sanitizeFilename(template.name ?? NSLocalizedString("template", comment: "")), extension: "logittemplate")
+        return exportToFile(dto, filename: sanitizeFilename(template.resolvedName ?? NSLocalizedString("template", comment: "")), extension: "logittemplate")
     }
     
     /// Exports a workout as a template file
@@ -267,6 +267,7 @@ final class WorkoutSharingService {
     
     private func createTemplate(from dto: TemplateDTO) throws -> Template {
         let template = database.newTemplate(name: dto.name, setGroups: [])
+        template.descriptionText = dto.description
         
         // Flag template as temporary until user confirms
         database.flagAsTemporary(template)

--- a/LOGITTests/DatabaseTests.swift
+++ b/LOGITTests/DatabaseTests.swift
@@ -244,3 +244,84 @@ final class DatabaseTests: XCTestCase {
         XCTAssertEqual(setGroup.sets.last?.restDurationSeconds, 75)
     }
 }
+
+// MARK: - Model Version 7 Migration Tests
+
+/// Proves that a store created with model version 6 opens under the current model via the same
+/// automatic lightweight migration `Database.init` configures — existing user data must survive
+/// the new `Template.id` / `Template.descriptionText` attributes.
+final class TemplateModelMigrationTests: XCTestCase {
+
+    private var storeURL: URL!
+
+    override func setUp() {
+        super.setUp()
+        storeURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("MigrationTest-\(UUID().uuidString).sqlite")
+    }
+
+    override func tearDown() {
+        for suffix in ["", "-wal", "-shm"] {
+            try? FileManager.default.removeItem(atPath: storeURL.path + suffix)
+        }
+        storeURL = nil
+        super.tearDown()
+    }
+
+    func testLightweightMigrationFromModelVersion6PreservesTemplates() throws {
+        let bundle = Bundle(for: Database.self)
+        let momdURL = try XCTUnwrap(bundle.url(forResource: "LOGIT", withExtension: "momd"))
+        let v6Model = try XCTUnwrap(
+            NSManagedObjectModel(contentsOf: momdURL.appendingPathComponent("LOGIT 6.0.mom")),
+            "Model version 6 must stay in the bundle for migration"
+        )
+        // Loading the .momd itself resolves to the current version (7)
+        let currentModel = try XCTUnwrap(NSManagedObjectModel(contentsOf: momdURL))
+        XCTAssertNotNil(
+            currentModel.entitiesByName["Template"]?.attributesByName["descriptionText"],
+            "Current model must be version 7 with the new attributes"
+        )
+
+        // 1. Create a v6 store containing a template with a set group
+        let v6Coordinator = NSPersistentStoreCoordinator(managedObjectModel: v6Model)
+        try v6Coordinator.addPersistentStore(ofType: NSSQLiteStoreType, configurationName: nil, at: storeURL)
+        let v6Context = NSManagedObjectContext(concurrencyType: .mainQueueConcurrencyType)
+        v6Context.persistentStoreCoordinator = v6Coordinator
+        let v6Template = NSEntityDescription.insertNewObject(forEntityName: "Template", into: v6Context)
+        v6Template.setValue("My Old Template", forKey: "name")
+        v6Template.setValue(Date(), forKey: "creationDate")
+        let v6SetGroup = NSEntityDescription.insertNewObject(forEntityName: "TemplateSetGroup", into: v6Context)
+        v6SetGroup.setValue(UUID(), forKey: "id")
+        v6SetGroup.setValue(v6Template, forKey: "workout")
+        try v6Context.save()
+        try v6Coordinator.remove(v6Coordinator.persistentStores[0])
+
+        // 2. Reopen with the current model and the options Database.init uses
+        let coordinator = NSPersistentStoreCoordinator(managedObjectModel: currentModel)
+        try coordinator.addPersistentStore(
+            ofType: NSSQLiteStoreType,
+            configurationName: nil,
+            at: storeURL,
+            options: [
+                NSMigratePersistentStoresAutomaticallyOption: true,
+                NSInferMappingModelAutomaticallyOption: true,
+            ]
+        )
+        let context = NSManagedObjectContext(concurrencyType: .mainQueueConcurrencyType)
+        context.persistentStoreCoordinator = coordinator
+
+        // 3. The old data survived and the new attributes are usable
+        let request = NSFetchRequest<NSManagedObject>(entityName: "Template")
+        let migrated = try context.fetch(request)
+        XCTAssertEqual(migrated.count, 1)
+        let template = try XCTUnwrap(migrated.first)
+        XCTAssertEqual(template.value(forKey: "name") as? String, "My Old Template")
+        XCTAssertEqual((template.value(forKey: "setGroups_") as? NSSet)?.count, 1)
+        XCTAssertNil(template.value(forKey: "id"), "Migrated templates start without an id (backfilled later)")
+        XCTAssertNil(template.value(forKey: "descriptionText"))
+
+        template.setValue(UUID(), forKey: "id")
+        template.setValue("A description", forKey: "descriptionText")
+        try context.save()
+    }
+}

--- a/LOGITTests/ServicesTests.swift
+++ b/LOGITTests/ServicesTests.swift
@@ -776,3 +776,145 @@ final class ChronographTests: XCTestCase {
         XCTAssertEqual(schedule, [.init(minuteMark: 3, timeInterval: 60)])
     }
 }
+
+// MARK: - DefaultTemplateService Tests
+
+final class DefaultTemplateServiceTests: XCTestCase {
+
+    private var database: Database!
+    private var defaults: UserDefaults!
+    private var defaultsSuiteName: String!
+    private var exerciseService: DefaultExerciseService!
+    private var templateService: DefaultTemplateService!
+
+    override func setUp() {
+        super.setUp()
+        database = Database(isPreview: true)
+        // Fresh suite per test so version gates and tombstones from earlier runs can't leak in
+        defaultsSuiteName = "DefaultTemplateServiceTests-\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: defaultsSuiteName)
+        exerciseService = DefaultExerciseService(database: database, defaults: defaults)
+        templateService = DefaultTemplateService(database: database, defaults: defaults)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: defaultsSuiteName)
+        database = nil
+        defaults = nil
+        exerciseService = nil
+        templateService = nil
+        super.tearDown()
+    }
+
+    private var defaultTemplates: [Template] {
+        (database.fetch(Template.self) as! [Template]).filter { $0.isDefaultTemplate }
+    }
+
+    func testSeedsDefaultTemplatesWithSetGroupsAndLocalizedNames() {
+        exerciseService.loadDefaultExercisesIfNeeded()
+        templateService.loadDefaultTemplatesIfNeeded()
+
+        let templates = defaultTemplates
+        XCTAssertEqual(templates.count, 5, "All 5 bundled templates should be seeded")
+
+        for template in templates {
+            XCTAssertNotNil(template.id, "Seeded templates need a deterministic id")
+            XCTAssertFalse(template.setGroups.isEmpty, "Seeded templates need set groups")
+            for setGroup in template.setGroups {
+                let exercise = try? XCTUnwrap(setGroup.exercise)
+                XCTAssertEqual(exercise?.isDefaultExercise, true, "Templates must reference default exercises")
+                XCTAssertFalse(setGroup.sets.isEmpty, "Each set group needs sets")
+            }
+            XCTAssertFalse(
+                template.displayName.hasPrefix("_default."),
+                "Name key \(template.name ?? "") must resolve to a localized name"
+            )
+            let description = try? XCTUnwrap(template.displayDescription)
+            XCTAssertEqual(
+                description?.hasPrefix("_default."), false,
+                "Description key \(template.descriptionText ?? "") must resolve to localized text"
+            )
+        }
+    }
+
+    func testSeedingTwiceCreatesNoDuplicates() {
+        exerciseService.loadDefaultExercisesIfNeeded()
+        templateService.loadDefaultTemplatesIfNeeded()
+        let countAfterFirst = defaultTemplates.count
+
+        templateService.loadDefaultTemplatesIfNeeded()
+
+        XCTAssertEqual(defaultTemplates.count, countAfterFirst)
+    }
+
+    func testDeletedDefaultTemplateStaysDeleted() {
+        exerciseService.loadDefaultExercisesIfNeeded()
+        templateService.loadDefaultTemplatesIfNeeded()
+
+        let victim = defaultTemplates.first!
+        database.context.performAndWait {
+            self.database.context.delete(victim)
+        }
+
+        // Simulate a future version bump re-running the seeding pass
+        defaults.set(0, forKey: "lastLoadedDefaultTemplatesVersion")
+        templateService.loadDefaultTemplatesIfNeeded()
+
+        XCTAssertEqual(defaultTemplates.count, 4, "A deleted default template must not be resurrected")
+    }
+
+    func testEditedDefaultTemplateIsNotOverwritten() {
+        exerciseService.loadDefaultExercisesIfNeeded()
+        templateService.loadDefaultTemplatesIfNeeded()
+
+        let template = defaultTemplates.first!
+        template.name = "My Custom Name"
+
+        defaults.set(0, forKey: "lastLoadedDefaultTemplatesVersion")
+        templateService.loadDefaultTemplatesIfNeeded()
+
+        XCTAssertEqual(template.name, "My Custom Name")
+        XCTAssertEqual(
+            (database.fetch(Template.self) as! [Template]).filter { $0.name == "My Custom Name" }.count,
+            1,
+            "The renamed template must not be re-seeded as a duplicate"
+        )
+    }
+
+    func testSeedingWaitsForDefaultExercises() {
+        // Exercises intentionally not loaded: nothing to attach templates to
+        templateService.loadDefaultTemplatesIfNeeded()
+        XCTAssertTrue(defaultTemplates.isEmpty, "Without default exercises no template should be seeded")
+
+        // Next launch, exercises are there — seeding must retry because the version was not advanced
+        exerciseService.loadDefaultExercisesIfNeeded()
+        templateService.loadDefaultTemplatesIfNeeded()
+        XCTAssertEqual(defaultTemplates.count, 5)
+    }
+
+    func testBackfillAssignsIdsToPreexistingTemplates() {
+        // Templates created before model version 7 have no id
+        let legacyTemplate = Template(context: database.context)
+        legacyTemplate.name = "Legacy"
+        XCTAssertNil(legacyTemplate.id)
+
+        templateService.loadDefaultTemplatesIfNeeded()
+
+        XCTAssertNotNil(legacyTemplate.id, "Backfill should assign ids to legacy templates")
+    }
+
+    func testResolvedNameAndDisplayDescription() {
+        let template = database.newTemplate(name: "_default.template.pushDay")
+        template.descriptionText = "_default.template.pushDay.description"
+
+        XCTAssertTrue(template.isDefaultTemplate)
+        XCTAssertEqual(template.resolvedName, NSLocalizedString("_default.template.pushDay", comment: ""))
+        XCTAssertFalse(template.displayName.hasPrefix("_default."))
+        XCTAssertEqual(template.displayDescription, NSLocalizedString("_default.template.pushDay.description", comment: ""))
+
+        let custom = database.newTemplate(name: "Mein Plan")
+        XCTAssertEqual(custom.resolvedName, "Mein Plan")
+        XCTAssertFalse(custom.isDefaultTemplate)
+        XCTAssertNil(custom.displayDescription)
+    }
+}


### PR DESCRIPTION
## Summary

New users currently land on an empty Templates tab with nothing to do. This PR seeds five starter templates so newcomers have proven routines to pick from on first launch:

- **Full Body A / Full Body B** — the classic alternate-2–3×/week beginner start (squat/bench/row ↔ RDL/press/pulldown)
- **Push Day / Pull Day / Leg Day** — the classic PPL split to grow into

Each template ships with target reps, sensible rest timers (120s compounds / 60–90s accessories), weights left empty, and a **localized description** explaining what it's for and how to use it — shown in the template list cell (2-line teaser) and the detail header.

## How it works

- **Core Data model v7** (`LOGIT 7.0.xcdatamodel`): adds optional `Template.id` and `Template.descriptionText` — additive-only, so the existing automatic lightweight migration and CloudKit schema rules are satisfied. Legacy templates get nil ids backfilled on launch.
- **`DefaultTemplateService`**: version-gated seeding from `default_templates.json` with deterministic UUIDs and per-template tombstones — a deleted default stays deleted, an edited/renamed one is never overwritten (unlike exercises, templates are starting points the user owns after first touch). Waits for the default exercise library; skipped during fastlane screenshot runs.
- **Localization**: names/descriptions stored as `_default.template.*` keys and resolved at display time (`Template.resolvedName`/`displayName`/`displayDescription`, mirroring `Exercise`), translated in all 8 app locales. List sorting/grouping, search, the recorder's workout naming, and share exports all use the resolved name.
- **Sharing**: `TemplateDTO` gains an optional `description` (backward compatible both ways); exports resolved text so older receivers see readable names.
- The deterministic-UUID helper is extracted verbatim from `DefaultExerciseService` into `DeterministicUUID` (identical output, shared by both seeders).

## Test plan

- [x] 341/341 unit tests pass locally (iPhone 17 Pro, iOS 26), including 12 new ones: seeding, idempotence, tombstones, no-overwrite, exercise-dependency retry, id backfill, key resolution
- [x] Dedicated migration test: builds a real v6 SQLite store, reopens under v7 with the same options `Database.init` uses, asserts data survives and new columns are writable
- [x] Simulator verification: fresh install seeds all 5 templates; list shows names + descriptions + muscle donuts; Push Day detail shows 5 exercises/15 sets with 8-rep targets and 2:00 rest; same store renders fully localized in German (Beintag under B, Ganzkörper under G)

## Release note

⚠️ Before the next App Store release, deploy the CloudKit schema changes (new `Template` fields) to Production in the CloudKit Console — standard step for any model addition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)