### PR TITLE
Extract PeriodHistoryChart, fix edge-label truncation and fresh-period trend pills

### DIFF
--- a/LOGIT.xcodeproj/project.pbxproj
+++ b/LOGIT.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		53B547C48713887B1E5542EE /* MuscleBalanceCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0258213863A5C9812190A44D /* MuscleBalanceCalculator.swift */; };
 		5701E3D211A49E43B531E6D8 /* SnapshotHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0400C2E827A4AEAF03BACDC6 /* SnapshotHelper.swift */; };
 		57A9ABF55683DB0071E02FE6 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A72B470FE19DAE1E42233F7F /* Foundation.framework */; };
+		5F6C92E180BAAEC435086790 /* PeriodHistoryChart.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3C48765200C9745764F2EAA /* PeriodHistoryChart.swift */; };
 		6A45A79A5D89B951F7726DBD /* WorkoutLiveActivitySnapshotBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F7B218CB83CEAEB494355C8 /* WorkoutLiveActivitySnapshotBuilderTests.swift */; };
 		73A9CED8C934FDF36F9C4061 /* BodyMapFigure.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBBF6087BB65A5971FB5F866 /* BodyMapFigure.swift */; };
 		773128213DE6E6FA1506597C /* WorkoutLiveActivityAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 829F12D41C231764936B6B83 /* WorkoutLiveActivityAttributes.swift */; };
@@ -196,10 +197,7 @@
 		806DE6202E1DD10A008E162F /* ChronographView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 806DE61F2E1DD106008E162F /* ChronographView.swift */; };
 		806F87E52ED0D7E7001E8B8B /* Logit.icon in Resources */ = {isa = PBXBuildFile; fileRef = 806F87E42ED0D7E7001E8B8B /* Logit.icon */; };
 		8085497B2EE9A34400761706 /* DefaultExerciseService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8085497A2EE9A34400761706 /* DefaultExerciseService.swift */; };
-		80AA10032F5CAA0200AA1003 /* DefaultTemplateService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80AA10042F5CAA0200AA1004 /* DefaultTemplateService.swift */; };
-		80AA10012F5CAA0200AA1001 /* DeterministicUUID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80AA10022F5CAA0200AA1002 /* DeterministicUUID.swift */; };
 		8085497F2EE9A37C00761706 /* default_exercises.json in Resources */ = {isa = PBXBuildFile; fileRef = 8085497D2EE9A37C00761706 /* default_exercises.json */; };
-		80AA10052F5CAA0200AA1005 /* default_templates.json in Resources */ = {isa = PBXBuildFile; fileRef = 80AA10062F5CAA0200AA1006 /* default_templates.json */; };
 		80A1D97B2EDC91B2004EE258 /* PinnedExerciseTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80A1D97A2EDC91B2004EE258 /* PinnedExerciseTile.swift */; };
 		80A1D97C2EDC91B2004EE258 /* ExercisesPinEditSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80A1D9792EDC91B2004EE258 /* ExercisesPinEditSheet.swift */; };
 		80A7A0D12F2E6C5C00112233 /* logit_terms_and_conditions.md in Resources */ = {isa = PBXBuildFile; fileRef = 80A7A0D02F2E6C5C00112233 /* logit_terms_and_conditions.md */; };
@@ -209,6 +207,9 @@
 		80AA000A2F3A000100AA0001 /* WorkoutRecorderFloatingTimerButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80AA00092F3A000100AA0001 /* WorkoutRecorderFloatingTimerButton.swift */; };
 		80AA000C2F3A000100AA0001 /* WorkoutRecorderFloatingStopwatchStopButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80AA000B2F3A000100AA0001 /* WorkoutRecorderFloatingStopwatchStopButton.swift */; };
 		80AA00102F3A000100AA0001 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 801BBCAA2DF7338A00CDB1FB /* Localizable.strings */; };
+		80AA10012F5CAA0200AA1001 /* DeterministicUUID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80AA10022F5CAA0200AA1002 /* DeterministicUUID.swift */; };
+		80AA10032F5CAA0200AA1003 /* DefaultTemplateService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80AA10042F5CAA0200AA1004 /* DefaultTemplateService.swift */; };
+		80AA10052F5CAA0200AA1005 /* default_templates.json in Resources */ = {isa = PBXBuildFile; fileRef = 80AA10062F5CAA0200AA1006 /* default_templates.json */; };
 		80B387BB2EBA187100AD7EFC /* DecimalField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80B387BA2EBA187100AD7EFC /* DecimalField.swift */; };
 		80BEEP012EF0000000000001 /* beep.wav in Resources */ = {isa = PBXBuildFile; fileRef = 80BEEP022EF0000000000001 /* beep.wav */; };
 		80C2B98F2EC9362A00118FE2 /* ColorfulX in Frameworks */ = {isa = PBXBuildFile; productRef = 80C2B98E2EC9362A00118FE2 /* ColorfulX */; };
@@ -535,20 +536,20 @@
 		806DE61F2E1DD106008E162F /* ChronographView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChronographView.swift; sourceTree = "<group>"; };
 		806F87E42ED0D7E7001E8B8B /* Logit.icon */ = {isa = PBXFileReference; lastKnownFileType = folder.iconcomposer.icon; path = Logit.icon; sourceTree = "<group>"; };
 		8085497A2EE9A34400761706 /* DefaultExerciseService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultExerciseService.swift; sourceTree = "<group>"; };
-		80AA10042F5CAA0200AA1004 /* DefaultTemplateService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultTemplateService.swift; sourceTree = "<group>"; };
-		80AA10022F5CAA0200AA1002 /* DeterministicUUID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeterministicUUID.swift; sourceTree = "<group>"; };
 		8085497D2EE9A37C00761706 /* default_exercises.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = default_exercises.json; sourceTree = "<group>"; };
-		80AA10062F5CAA0200AA1006 /* default_templates.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = default_templates.json; sourceTree = "<group>"; };
 		80A1D9792EDC91B2004EE258 /* ExercisesPinEditSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExercisesPinEditSheet.swift; sourceTree = "<group>"; };
 		80A1D97A2EDC91B2004EE258 /* PinnedExerciseTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinnedExerciseTile.swift; sourceTree = "<group>"; };
 		80A7A0D02F2E6C5C00112233 /* logit_terms_and_conditions.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = logit_terms_and_conditions.md; sourceTree = "<group>"; };
 		80AA00012F3A000100AA0001 /* RestDurationPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestDurationPicker.swift; sourceTree = "<group>"; };
 		80AA00032F3A000100AA0001 /* RestTimerBetweenSetsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestTimerBetweenSetsView.swift; sourceTree = "<group>"; };
 		80AA00052F3A000100AA0001 /* LOGIT 6.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "LOGIT 6.0.xcdatamodel"; sourceTree = "<group>"; };
-		80AA00072F5CAA0100AA0007 /* LOGIT 7.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "LOGIT 7.0.xcdatamodel"; sourceTree = "<group>"; };
 		80AA00072F3A000100AA0001 /* RestDurationEditorSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestDurationEditorSheet.swift; sourceTree = "<group>"; };
+		80AA00072F5CAA0100AA0007 /* LOGIT 7.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "LOGIT 7.0.xcdatamodel"; sourceTree = "<group>"; };
 		80AA00092F3A000100AA0001 /* WorkoutRecorderFloatingTimerButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutRecorderFloatingTimerButton.swift; sourceTree = "<group>"; };
 		80AA000B2F3A000100AA0001 /* WorkoutRecorderFloatingStopwatchStopButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutRecorderFloatingStopwatchStopButton.swift; sourceTree = "<group>"; };
+		80AA10022F5CAA0200AA1002 /* DeterministicUUID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeterministicUUID.swift; sourceTree = "<group>"; };
+		80AA10042F5CAA0200AA1004 /* DefaultTemplateService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultTemplateService.swift; sourceTree = "<group>"; };
+		80AA10062F5CAA0200AA1006 /* default_templates.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = default_templates.json; sourceTree = "<group>"; };
 		80B387BA2EBA187100AD7EFC /* DecimalField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecimalField.swift; sourceTree = "<group>"; };
 		80BEEP022EF0000000000001 /* beep.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = beep.wav; sourceTree = "<group>"; };
 		80C7068F531DB65831E8FA8F /* MuscleTargetSplitScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MuscleTargetSplitScreen.swift; sourceTree = "<group>"; };
@@ -624,6 +625,7 @@
 		E1E1E1000000000000000F16 /* PersonalBestRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonalBestRow.swift; sourceTree = "<group>"; };
 		E62F41D02C28CB089872E955 /* SummaryWelcomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryWelcomeView.swift; sourceTree = "<group>"; };
 		EF956F5D14BBB78133BD528A /* ExerciseMergeServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ExerciseMergeServiceTests.swift; sourceTree = "<group>"; };
+		F3C48765200C9745764F2EAA /* PeriodHistoryChart.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PeriodHistoryChart.swift; sourceTree = "<group>"; };
 		FE01CA11AB1E5077AE000001 /* SummaryProgressTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryProgressTab.swift; sourceTree = "<group>"; };
 		FE91C0394869857C0E932723 /* MeasurementWatchlistRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeasurementWatchlistRow.swift; sourceTree = "<group>"; };
 		FFD9E1A9B2D266CBA7AE5F18 /* MuscleGroupDetailScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MuscleGroupDetailScreen.swift; sourceTree = "<group>"; };
@@ -1180,6 +1182,7 @@
 				A1B2C3D4E5F600000003F003 /* MuscleBalanceHistoryChart.swift */,
 				E1E1E1000000000000000F13 /* TileBarChartStyle.swift */,
 				E1E1E1000000000000000F14 /* TileSparklineStyle.swift */,
+				F3C48765200C9745764F2EAA /* PeriodHistoryChart.swift */,
 			);
 			path = Charts;
 			sourceTree = "<group>";
@@ -1790,6 +1793,7 @@
 				E5F79A5B29FEF4F260749E66 /* LiveActivityShowcaseView.swift in Sources */,
 				CFBDBE49B12AA1C06C620875 /* ChartRange.swift in Sources */,
 				28E43ABE4881F802FBBACCE9 /* RangePicker.swift in Sources */,
+				5F6C92E180BAAEC435086790 /* PeriodHistoryChart.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/LOGIT/Features/Exercise/ExerciseDetail/ExerciseSetsScreen.swift
+++ b/LOGIT/Features/Exercise/ExerciseDetail/ExerciseSetsScreen.swift
@@ -5,7 +5,6 @@
 //  Created by Lukas Kaibel on 22.06.26.
 //
 
-import Charts
 import SwiftUI
 
 /// Working sets per period for a single exercise — the detail screen behind the weekly Sets tile.
@@ -62,8 +61,10 @@ struct ExerciseSetsScreen: View {
                     .fontWeight(.semibold)
                     .textCase(.uppercase)
                     .foregroundStyle(.secondary)
+                // A period count is a real value even at zero ("0 this week"), clearer than a
+                // "––" no-data dash — same rule as the stat tiles.
                 UnitView(
-                    value: currentCount > 0 ? "\(currentCount)" : "––",
+                    value: "\(currentCount)",
                     unit: "",
                     configuration: .large,
                     unitColor: .secondaryLabel
@@ -84,49 +85,13 @@ struct ExerciseSetsScreen: View {
 
     // MARK: - Chart
 
-    private struct Bucket: Identifiable {
-        let id: Int
-        let date: Date
-        let value: Int
-        let isCurrent: Bool
-    }
-
     private var chart: some View {
-        let buckets = self.buckets
-        let maxValue = buckets.map(\.value).max() ?? 0
-        // At most ~4 axis labels, counted back from the current bucket so "now" is always labeled.
-        let labelStride = max(1, Int((Double(buckets.count) / 4.0).rounded(.up)))
-        let labeledDates = stride(from: buckets.count - 1, through: 0, by: -labelStride).map { buckets[$0].date }
-        return Chart {
-            ForEach(buckets) { bucket in
-                BarMark(
-                    x: .value("Period", bucket.date, unit: period.calendarComponent),
-                    y: .value(NSLocalizedString("sets", comment: ""), bucket.value),
-                    width: .ratio(0.6)
-                )
-                .foregroundStyle(bucket.isCurrent ? AnyShapeStyle(muscleGroupColor.gradient) : AnyShapeStyle(Color.fill))
-                .clipShape(RoundedRectangle(cornerRadius: 3, style: .continuous))
-            }
-        }
-        .chartYScale(domain: 0 ... max(maxValue, 1))
-        .chartXAxis {
-            AxisMarks(values: labeledDates) { value in
-                if let date = value.as(Date.self) {
-                    let isCurrent = period.currentRange().contains(date)
-                    AxisGridLine()
-                        .foregroundStyle(Color.gray.opacity(0.4))
-                    AxisValueLabel {
-                        Text(period.axisLabel(for: date))
-                            .font(.caption.weight(isCurrent ? .bold : .semibold))
-                            .foregroundStyle(isCurrent ? Color.label : Color.secondaryLabel)
-                    }
-                }
-            }
-        }
-        .chartYAxis {
-            AxisMarks(values: .automatic(desiredCount: 3))
-        }
-        .frame(height: 260)
+        PeriodHistoryChart(
+            buckets: buckets,
+            period: period,
+            valueLabel: NSLocalizedString("sets", comment: ""),
+            currentBarStyle: AnyShapeStyle(muscleGroupColor.gradient)
+        )
     }
 
     // MARK: - Data
@@ -135,7 +100,7 @@ struct ExerciseSetsScreen: View {
     private var previousCount: Int { setCount(in: period.previousRange()) }
 
     private var percentChange: Double? {
-        previousCount > 0 ? (Double(currentCount) - Double(previousCount)) / Double(previousCount) * 100 : nil
+        PeriodHistoryChart.trendPercentChange(current: currentCount, previous: previousCount)
     }
 
     /// Working-set count in the range — only sets with a recorded entry, matching the weekly tile.
@@ -149,18 +114,8 @@ struct ExerciseSetsScreen: View {
             .count
     }
 
-    private var buckets: [Bucket] {
-        let count = period.historyBucketCount
-        return (0 ..< count).map { index in
-            let periodsAgo = count - 1 - index
-            let range = period.range(periodsAgo: periodsAgo)
-            return Bucket(
-                id: index,
-                date: range.lowerBound,
-                value: setCount(in: range),
-                isCurrent: periodsAgo == 0
-            )
-        }
+    private var buckets: [PeriodHistoryChart.Bucket] {
+        PeriodHistoryChart.buckets(for: period) { Double(setCount(in: $0)) }
     }
 
     private var muscleGroupColor: Color {

--- a/LOGIT/Features/Exercise/ExerciseDetail/ExerciseVolumeScreen.swift
+++ b/LOGIT/Features/Exercise/ExerciseDetail/ExerciseVolumeScreen.swift
@@ -5,7 +5,6 @@
 //  Created by Lukas Kaibel on 03.12.24.
 //
 
-import Charts
 import SwiftUI
 
 /// Training volume per period for a single exercise — the detail screen behind the weekly Volume
@@ -62,8 +61,10 @@ struct ExerciseVolumeScreen: View {
                     .fontWeight(.semibold)
                     .textCase(.uppercase)
                     .foregroundStyle(.secondary)
+                // A period sum is a real value even at zero ("0 kg this week"), clearer than a
+                // "––" no-data dash — same rule as the stat tiles.
                 UnitView(
-                    value: currentRawVolume > 0 ? formatWeightForDisplay(currentRawVolume) : "––",
+                    value: formatWeightForDisplay(currentRawVolume),
                     unit: WeightUnit.used.rawValue,
                     configuration: .large,
                     unitColor: .secondaryLabel
@@ -84,49 +85,13 @@ struct ExerciseVolumeScreen: View {
 
     // MARK: - Chart
 
-    private struct Bucket: Identifiable {
-        let id: Int
-        let date: Date
-        let value: Double
-        let isCurrent: Bool
-    }
-
     private var chart: some View {
-        let buckets = self.buckets
-        let maxValue = buckets.map(\.value).max() ?? 0
-        // At most ~4 axis labels, counted back from the current bucket so "now" is always labeled.
-        let labelStride = max(1, Int((Double(buckets.count) / 4.0).rounded(.up)))
-        let labeledDates = stride(from: buckets.count - 1, through: 0, by: -labelStride).map { buckets[$0].date }
-        return Chart {
-            ForEach(buckets) { bucket in
-                BarMark(
-                    x: .value("Period", bucket.date, unit: period.calendarComponent),
-                    y: .value(NSLocalizedString("volume", comment: ""), bucket.value),
-                    width: .ratio(0.6)
-                )
-                .foregroundStyle(bucket.isCurrent ? AnyShapeStyle(muscleGroupColor.gradient) : AnyShapeStyle(Color.fill))
-                .clipShape(RoundedRectangle(cornerRadius: 3, style: .continuous))
-            }
-        }
-        .chartYScale(domain: 0 ... max(maxValue, 1))
-        .chartXAxis {
-            AxisMarks(values: labeledDates) { value in
-                if let date = value.as(Date.self) {
-                    let isCurrent = period.currentRange().contains(date)
-                    AxisGridLine()
-                        .foregroundStyle(Color.gray.opacity(0.4))
-                    AxisValueLabel {
-                        Text(period.axisLabel(for: date))
-                            .font(.caption.weight(isCurrent ? .bold : .semibold))
-                            .foregroundStyle(isCurrent ? Color.label : Color.secondaryLabel)
-                    }
-                }
-            }
-        }
-        .chartYAxis {
-            AxisMarks(values: .automatic(desiredCount: 3))
-        }
-        .frame(height: 260)
+        PeriodHistoryChart(
+            buckets: buckets,
+            period: period,
+            valueLabel: NSLocalizedString("volume", comment: ""),
+            currentBarStyle: AnyShapeStyle(muscleGroupColor.gradient)
+        )
     }
 
     // MARK: - Data
@@ -135,9 +100,7 @@ struct ExerciseVolumeScreen: View {
     private var previousRawVolume: Int { rawVolume(in: period.previousRange()) }
 
     private var percentChange: Double? {
-        previousRawVolume > 0
-            ? (Double(currentRawVolume) - Double(previousRawVolume)) / Double(previousRawVolume) * 100
-            : nil
+        PeriodHistoryChart.trendPercentChange(current: currentRawVolume, previous: previousRawVolume)
     }
 
     /// Total volume (weight × reps over every set) in the range, in raw storage units.
@@ -149,18 +112,8 @@ struct ExerciseVolumeScreen: View {
         return getVolume(of: sets, for: exercise)
     }
 
-    private var buckets: [Bucket] {
-        let count = period.historyBucketCount
-        return (0 ..< count).map { index in
-            let periodsAgo = count - 1 - index
-            let range = period.range(periodsAgo: periodsAgo)
-            return Bucket(
-                id: index,
-                date: range.lowerBound,
-                value: convertWeightForDisplayingDecimal(rawVolume(in: range)),
-                isCurrent: periodsAgo == 0
-            )
-        }
+    private var buckets: [PeriodHistoryChart.Bucket] {
+        PeriodHistoryChart.buckets(for: period) { convertWeightForDisplayingDecimal(rawVolume(in: $0)) }
     }
 
     private var muscleGroupColor: Color {

--- a/LOGIT/Features/Home/SummaryStatScreen.swift
+++ b/LOGIT/Features/Home/SummaryStatScreen.swift
@@ -5,7 +5,6 @@
 //  Created by Lukas Kaibel on 29.06.26.
 //
 
-import Charts
 import SwiftUI
 
 /// Detail screen behind a Summary core-stat tile: the stat summed per period across recent history,
@@ -62,8 +61,10 @@ struct SummaryStatScreen: View {
                     .fontWeight(.semibold)
                     .textCase(.uppercase)
                     .foregroundStyle(.secondary)
+                // A period sum is a real value even at zero ("0 sets this week"), clearer than a
+                // "––" no-data dash — same rule as the stat tiles.
                 UnitView(
-                    value: currentRaw > 0 ? metric.formattedValue(fromRaw: currentRaw) : "––",
+                    value: metric.formattedValue(fromRaw: currentRaw),
                     unit: metric.unit,
                     configuration: .large,
                     unitColor: .secondaryLabel
@@ -84,56 +85,13 @@ struct SummaryStatScreen: View {
 
     // MARK: - Chart
 
-    private struct Bucket: Identifiable {
-        let id: Int
-        let date: Date
-        let value: Double
-        let isCurrent: Bool
-    }
-
     private var chart: some View {
-        let buckets = self.buckets
-        let maxValue = buckets.map(\.value).max() ?? 0
-        // At most ~4 axis labels, counted back from the current bucket so "now" is always labeled —
-        // one label per bucket sat shoulder-to-shoulder on the week view.
-        let labelStride = max(1, Int((Double(buckets.count) / 4.0).rounded(.up)))
-        let labeledDates = stride(from: buckets.count - 1, through: 0, by: -labelStride).map { buckets[$0].date }
-        return Chart {
-            ForEach(buckets) { bucket in
-                BarMark(
-                    x: .value("Period", bucket.date, unit: period.calendarComponent),
-                    y: .value(metric.title, bucket.value),
-                    width: .ratio(0.6)
-                )
-                .foregroundStyle(
-                    bucket.isCurrent
-                        ? (isDuration ? Color.secondary : Color.accentColor)
-                        : Color.fill
-                )
-                .clipShape(RoundedRectangle(cornerRadius: 3, style: .continuous))
-            }
-        }
-        .chartYScale(domain: 0 ... max(maxValue, 1))
-        .chartXAxis {
-            AxisMarks(values: labeledDates) { value in
-                if let date = value.as(Date.self) {
-                    let isCurrent = period.currentRange().contains(date)
-                    AxisGridLine()
-                        .foregroundStyle(Color.gray.opacity(0.4))
-                    // Styling lives on the Text inside the label closure — hierarchical styles on the
-                    // AxisMark itself resolve against the chart's accent on iOS 26 (labels turned lime).
-                    AxisValueLabel {
-                        Text(period.axisLabel(for: date))
-                            .font(.caption.weight(isCurrent ? .bold : .semibold))
-                            .foregroundStyle(isCurrent ? Color.label : Color.secondaryLabel)
-                    }
-                }
-            }
-        }
-        .chartYAxis {
-            AxisMarks(values: .automatic(desiredCount: 3))
-        }
-        .frame(height: 260)
+        PeriodHistoryChart(
+            buckets: buckets,
+            period: period,
+            valueLabel: metric.title,
+            currentBarStyle: AnyShapeStyle(isDuration ? Color.secondary : Color.accentColor)
+        )
     }
 
     // MARK: - Data
@@ -142,7 +100,7 @@ struct SummaryStatScreen: View {
     private var previousRaw: Int { sum(in: period.previousRange()) }
 
     private var percentChange: Double? {
-        previousRaw > 0 ? (Double(currentRaw) - Double(previousRaw)) / Double(previousRaw) * 100 : nil
+        PeriodHistoryChart.trendPercentChange(current: currentRaw, previous: previousRaw)
     }
 
     private func sum(in range: ClosedRange<Date>) -> Int {
@@ -151,18 +109,7 @@ struct SummaryStatScreen: View {
             .reduce(0) { $0 + metric.rawValue(of: $1) }
     }
 
-    private var buckets: [Bucket] {
-        let count = period.historyBucketCount
-        return (0 ..< count).map { index in
-            let periodsAgo = count - 1 - index
-            let range = period.range(periodsAgo: periodsAgo)
-            let raw = sum(in: range)
-            return Bucket(
-                id: index,
-                date: range.lowerBound,
-                value: metric.displayValue(fromRaw: raw),
-                isCurrent: periodsAgo == 0
-            )
-        }
+    private var buckets: [PeriodHistoryChart.Bucket] {
+        PeriodHistoryChart.buckets(for: period) { metric.displayValue(fromRaw: sum(in: $0)) }
     }
 }

--- a/LOGIT/SharedUI/Charts/PeriodHistoryChart.swift
+++ b/LOGIT/SharedUI/Charts/PeriodHistoryChart.swift
@@ -1,0 +1,118 @@
+//
+//  PeriodHistoryChart.swift
+//  LOGIT
+//
+//  Created by Lukas Kaibel on 05.07.26.
+//
+
+import Charts
+import SwiftUI
+
+/// The shared recent-periods bar chart behind every period-scoped stat detail — the Summary stat
+/// screens and the exercise Sets / Volume screens. One bar per period (`StatPeriod.historyBucketCount`
+/// of them, current highlighted), at most ~4 axis labels counted back from the current bucket so
+/// "now" is always labeled. The newest label is anchored trailing so it renders fully instead of
+/// truncating at the plot edge ("Jul 4", not "J…"). One component, so the history charts can't
+/// drift apart again.
+struct PeriodHistoryChart: View {
+    struct Bucket: Identifiable {
+        let id: Int
+        let date: Date
+        let value: Double
+        let isCurrent: Bool
+    }
+
+    let buckets: [Bucket]
+    let period: StatPeriod
+    /// Series name for the y-values ("Volume", "Sets", …) — accessibility, not rendered.
+    let valueLabel: String
+    /// Fill of the current period's bar; past bars stay the quiet `Color.fill`.
+    let currentBarStyle: AnyShapeStyle
+
+    var body: some View {
+        let maxValue = buckets.map(\.value).max() ?? 0
+        // At most ~4 axis labels, counted back from the current bucket so "now" is always labeled —
+        // one label per bucket sat shoulder-to-shoulder on the week view.
+        let labelStride = max(1, Int((Double(buckets.count) / 4.0).rounded(.up)))
+        let labeledDates = stride(from: buckets.count - 1, through: 0, by: -labelStride).map { buckets[$0].date }
+        Chart {
+            ForEach(buckets) { bucket in
+                BarMark(
+                    x: .value("Period", bucket.date, unit: period.calendarComponent),
+                    y: .value(valueLabel, bucket.value),
+                    width: .ratio(0.6)
+                )
+                .foregroundStyle(bucket.isCurrent ? currentBarStyle : AnyShapeStyle(Color.fill))
+                .clipShape(RoundedRectangle(cornerRadius: 3, style: .continuous))
+            }
+        }
+        .chartYScale(domain: 0 ... max(maxValue, 1))
+        .chartXAxis {
+            AxisMarks(values: labeledDates) { value in
+                if let date = value.as(Date.self) {
+                    let isCurrent = period.currentRange().contains(date)
+                    AxisGridLine()
+                        .foregroundStyle(Color.gray.opacity(0.4))
+                    // Styling lives on the Text inside the label closure — hierarchical styles on the
+                    // AxisMark itself resolve against the chart's accent on iOS 26 (labels turned lime).
+                    // The current period's label is always the newest (labels stride back from it) and
+                    // sits at the plot edge — hang it trailing off its mark so the edge can't clip it.
+                    AxisValueLabel(anchor: isCurrent ? .topTrailing : nil) {
+                        Text(period.axisLabel(for: date))
+                            .font(.caption.weight(isCurrent ? .bold : .semibold))
+                            .foregroundStyle(isCurrent ? Color.label : Color.secondaryLabel)
+                    }
+                }
+            }
+        }
+        .chartYAxis {
+            AxisMarks(values: .automatic(desiredCount: 3))
+        }
+        .frame(height: 260)
+    }
+}
+
+extension PeriodHistoryChart {
+    /// The standard history buckets for `period` — one per recent period
+    /// (`StatPeriod.historyBucketCount`), oldest first, the current period last — with each
+    /// period's value pulled from `value`. The one bucket-building loop for every consumer, so
+    /// "recent history" can't quietly mean different windows on different screens.
+    static func buckets(for period: StatPeriod, value: (ClosedRange<Date>) -> Double) -> [Bucket] {
+        let count = period.historyBucketCount
+        return (0 ..< count).map { index in
+            let periodsAgo = count - 1 - index
+            let range = period.range(periodsAgo: periodsAgo)
+            return Bucket(
+                id: index,
+                date: range.lowerBound,
+                value: value(range),
+                isCurrent: periodsAgo == 0
+            )
+        }
+    }
+
+    /// The period-over-period trend for a stat header, or nil unless both periods have data — a
+    /// freshly started week must not read as a "−100%" collapse (the same suppression rule as the
+    /// stat tiles).
+    static func trendPercentChange(current: Int, previous: Int) -> Double? {
+        guard current > 0, previous > 0 else { return nil }
+        return (Double(current) - Double(previous)) / Double(previous) * 100
+    }
+}
+
+#Preview {
+    PeriodHistoryChart(
+        buckets: (0 ..< 12).map { index in
+            PeriodHistoryChart.Bucket(
+                id: index,
+                date: StatPeriod.week.range(periodsAgo: 11 - index).lowerBound,
+                value: Double((index * 37) % 90) + 10,
+                isCurrent: index == 11
+            )
+        },
+        period: .week,
+        valueLabel: "Volume",
+        currentBarStyle: AnyShapeStyle(Color.accentColor)
+    )
+    .padding()
+}

--- a/LOGITTests/StatPeriodTests.swift
+++ b/LOGITTests/StatPeriodTests.swift
@@ -160,6 +160,37 @@ final class ChartRangeTests: XCTestCase {
     }
 }
 
+// MARK: - PeriodHistoryChart helpers
+
+final class PeriodHistoryChartTests: XCTestCase {
+    func testBucketsFollowHistoryDepthOldestFirstCurrentLast() {
+        let buckets = PeriodHistoryChart.buckets(for: .week) { _ in 1 }
+        XCTAssertEqual(buckets.count, StatPeriod.week.historyBucketCount)
+        XCTAssertEqual(buckets.last?.isCurrent, true)
+        XCTAssertEqual(buckets.filter(\.isCurrent).count, 1)
+        XCTAssertEqual(buckets.first?.date, StatPeriod.week.range(periodsAgo: buckets.count - 1).lowerBound)
+        XCTAssertEqual(buckets.last?.date, StatPeriod.week.currentRange().lowerBound)
+    }
+
+    func testBucketsPullValuesFromTheirPeriodRange() {
+        // Value = days since the current week's start, so each bucket must carry its own range.
+        let currentStart = StatPeriod.week.currentRange().lowerBound
+        let buckets = PeriodHistoryChart.buckets(for: .week) { range in
+            range.lowerBound.timeIntervalSince(currentStart) / (3600 * 24)
+        }
+        XCTAssertEqual(buckets.last?.value, 0)
+        XCTAssertEqual(buckets[buckets.count - 2].value, -7, accuracy: 0.1)
+    }
+
+    func testTrendSuppressedUnlessBothPeriodsHaveData() {
+        XCTAssertNil(PeriodHistoryChart.trendPercentChange(current: 0, previous: 10), "Fresh period must not read as −100%")
+        XCTAssertNil(PeriodHistoryChart.trendPercentChange(current: 10, previous: 0))
+        XCTAssertNil(PeriodHistoryChart.trendPercentChange(current: 0, previous: 0))
+        XCTAssertEqual(PeriodHistoryChart.trendPercentChange(current: 15, previous: 10) ?? 0, 50, accuracy: 0.001)
+        XCTAssertEqual(PeriodHistoryChart.trendPercentChange(current: 5, previous: 10) ?? 0, -50, accuracy: 0.001)
+    }
+}
+
 // MARK: - MuscleTargetSplit
 
 final class MuscleTargetSplitTests: XCTestCase {


### PR DESCRIPTION
Follow-up polish to #51, driven by an end-to-end review of the timeframe unification.

## Fixes

- **Right-edge axis label no longer truncates.** The current period's label sits at the plot edge and was ellipsized ("J…"); it now hangs trailing off its mark and renders in full ("Jul 5"). Anchoring keys off the label being the current period's — a semantic check, not date equality.
- **Fresh periods no longer show a misleading −100% pill.** A just-started week rendered "––" with a "▾100%" trend on the stat detail screens (caught live when the calendar week rolled over during verification). Period sums now read as a real **0** and the trend pill only renders when both periods have data — the rule the stat tiles already document.

## Refactor

The three period-scoped detail screens (Summary stats, exercise Sets, exercise Volume) carried three copies of the same history chart. They now share one [`PeriodHistoryChart`](LOGIT/SharedUI/Charts/PeriodHistoryChart.swift), which owns the chart, the bucket-building loop (`buckets(for:value:)`) and the trend-suppression rule (`trendPercentChange(current:previous:)`) — so the screens can't drift apart again. Dead `import Charts` removed from the three screens.

## Verification

- 8-angle code review over the diff: no correctness findings; all cleanup findings applied.
- 344 unit tests green, including new coverage for both shared helpers.
- Simulator-verified: full "Jul 5" label at the chart edge, "THIS WEEK 0" with no pill on an empty fresh week, unchanged rendering everywhere else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)