### PR TITLE
Fix date/time editor sheet bouncing on open from the menu

### DIFF
--- a/LOGIT/Features/Workout/WorkoutEditorScreen.swift
+++ b/LOGIT/Features/Workout/WorkoutEditorScreen.swift
@@ -216,7 +216,14 @@ struct WorkoutEditorScreen: View {
                             Label(NSLocalizedString("rename", comment: ""), systemImage: "pencil")
                         }
                         Button {
-                            isEditingStartEndDate = true
+                            // Defer presenting to the next runloop turn so the Menu's dismissal and the
+                            // sheet's presentation land in separate transactions. Flipping this flag
+                            // synchronously inside the Menu action entangles the two, and because the
+                            // date editor is a sheet-on-sheet, the entanglement makes it bounce in and
+                            // out several times before settling.
+                            DispatchQueue.main.async {
+                                isEditingStartEndDate = true
+                            }
                         } label: {
                             Label(NSLocalizedString("editDateTime", comment: ""), systemImage: "clock.arrow.trianglehead.counterclockwise.rotate.90")
                         }


### PR DESCRIPTION
## Problem

Tapping **Edit Date & Time** in the workout editor made the date/time sheet play its show/hide animation ~3 times before settling.

## Root cause

The button flipped `isEditingStartEndDate` **synchronously inside the `Menu` action**. The date editor is a sheet-on-sheet (the editor is a sheet → the exercise picker is a sheet on top → the date editor is a sheet on top of *that*), so SwiftUI tried to present it in the **same update transaction** that was dismissing the menu. The two transactions entangle, and the sheet bounces in and out several times before settling.

This is a different trigger from the earlier scrub-flicker fix (#29) — opening the sheet only *reads* the dates into local `@State` and writes no Core Data, so that path is already clean.

## Fix

Defer the flag flip to the next runloop turn so the menu dismissal and the sheet presentation land in separate transactions. This mirrors the deferral already used by the **Rename** action in the same menu.

## Verification

This is a transaction-timing fix that only manifests during the live menu→sheet interaction, so it can't be shown by a static screenshot or a compile. The one-line change wraps an in-scope `@State` in `DispatchQueue.main.async` (already used elsewhere in this file). Corroborated by the sibling sheets in this screen (rest-duration, exercise-detail), which present from direct taps rather than a `Menu` and don't bounce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)