### PR TITLE
Add launch scenarios for testing critical data states

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1,4 +1,71 @@
-If you are making UI/UX changes, please verify the design in the simulator!
+# UI verification: scenario matrix (mandatory for UI changes)
+
+Every user-visible UI change must be verified in the simulator across the
+app's critical data states, and the screenshots must be shown to the user in
+the final response (clickable file paths per scenario; for larger matrices
+also render an HTML contact sheet so the states can be compared side by side).
+Point out any scenario where the change looks wrong or degenerate.
+
+The states, all driven by launch arguments (DEBUG builds only, implemented in
+`LOGIT/App/TestScenarios.swift`):
+
+| State | Launch arguments |
+| --- | --- |
+| Empty (brand-new user, 0 workouts, no goal) | `-SCENARIO empty` |
+| One workout (single data points, fresh trends) | `-SCENARIO one` |
+| Many workouts (long-time user, rich history) | `-SCENARIO many` |
+| Free tier (Pro locked) | add `-UITEST_FORCE_FREE` to any scenario |
+
+Standard matrix for a change: **empty, one, many (Pro implied on the
+simulator) + the free variant of the most relevant scenario.** If the change
+touches a Pro-gated feature, always show Pro vs. free side by side.
+
+How scenarios work (so you don't fight them):
+
+- A scenario boots a **fresh in-memory store** seeded for that state plus
+  session-only UserDefaults overrides in the argument domain. Nothing
+  persists, every launch is identical, and the simulator's real store and
+  defaults are untouched. Flip side: overridden keys (`setupDone`,
+  `weightUnit`, `workoutPerWeekTarget`, `pinnedExercises`,
+  `pinnedMeasurements`, `muscleTargetSplit`, default-content version keys)
+  read as pinned for the whole session, so tests/interactions that must
+  *change* one of those keys should launch without the scenario instead.
+- `many` is the curated preview dataset **without** the in-progress workout.
+  Use `-UITEST_FIXTURES 1` when the mid-workout state (recorder, mini bar)
+  is itself under test.
+- Pro is force-unlocked in DEBUG simulator builds; `-UITEST_FORCE_FREE` is
+  the only way to see locked/teaser states.
+
+Capturing the matrix (agents; user is usually away — never wait for manual
+checks):
+
+1. Run the standing suite `LOGITUITests/ScenarioScreenshots.swift` — it walks
+   the four tab roots per scenario and attaches screenshots:
+
+   ```
+   xcodebuild test -workspace LOGIT.xcworkspace -scheme LOGITScreenshots \
+     -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.4' \
+     -only-testing:LOGITUITests/ScenarioScreenshots \
+     -resultBundlePath /tmp/scenarios.xcresult
+   xcrun xcresulttool export attachments --path /tmp/scenarios.xcresult \
+     --output-path /tmp/scenario-shots
+   ```
+
+   Use the **iOS 26.4** simulator runtime — the 26.0 runner dies
+   nondeterministically. To capture only the states relevant to a small
+   change, narrow further, e.g.
+   `-only-testing:LOGITUITests/ScenarioScreenshots/testEmptyScenario`.
+2. If the changed screen is not a tab root, temporarily add a test method to
+   `ScenarioScreenshots.swift` that uses `launchApp(scenario:)` and navigates
+   to it in each relevant scenario (one launch per test method — relaunching
+   within a method kills the iOS 26 test runner). Remove the temp method
+   afterwards.
+3. Read the exported PNGs to verify the change yourself before showing them.
+
+For manual testing there are shared schemes with the arguments preconfigured:
+**LOGIT Empty / LOGIT One Workout / LOGIT Many Workouts** (each also carries a
+disabled `-UITEST_FORCE_FREE` toggle — tick it in Edit Scheme for the free
+tier). The plain LOGIT scheme keeps using the real on-disk store.
 
 # App Store automation (Fastlane)
 

--- a/LOGIT.xcodeproj/project.pbxproj
+++ b/LOGIT.xcodeproj/project.pbxproj
@@ -249,6 +249,7 @@
 		A1000000000000000000001B /* logit_terms_and_conditions_ja.md in Resources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000005B /* logit_terms_and_conditions_ja.md */; };
 		A1000000000000000000001C /* logit_terms_and_conditions_ko.md in Resources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000005C /* logit_terms_and_conditions_ko.md */; };
 		A1000000000000000000001D /* logit_terms_and_conditions_it.md in Resources */ = {isa = PBXBuildFile; fileRef = A1000000000000000000005D /* logit_terms_and_conditions_it.md */; };
+		A10F7CBC23FBD8F36CC4A1D6 /* TestScenarios.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9071DE852500F5E9CEA5CC7 /* TestScenarios.swift */; };
 		A1B2C3D4E5F600000001B001 /* MuscleBalanceHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F600000001F001 /* MuscleBalanceHistory.swift */; };
 		A1B2C3D4E5F600000003B003 /* MuscleBalanceHistoryChart.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F600000003F003 /* MuscleBalanceHistoryChart.swift */; };
 		A1B2C3D4E5F600000007B007 /* MuscleBalanceBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F600000007F007 /* MuscleBalanceBar.swift */; };
@@ -264,6 +265,7 @@
 		CFBDBE49B12AA1C06C620875 /* ChartRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = C82BC4F48812B4D49D4E38E2 /* ChartRange.swift */; };
 		D0AF3C855D8D73E72DA7AF92 /* SummaryWelcomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E62F41D02C28CB089872E955 /* SummaryWelcomeView.swift */; };
 		D1D1D1000000000000000B01 /* MetricTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1D1D1000000000000000F01 /* MetricTile.swift */; };
+		E01F0F57C3115A2C00EB638E /* ScenarioScreenshots.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD6EBE9FCA104B46ACA995DE /* ScenarioScreenshots.swift */; };
 		E18E0521AED5762B30E5FA1F /* MuscleGroupDetailScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFD9E1A9B2D266CBA7AE5F18 /* MuscleGroupDetailScreen.swift */; };
 		E1E1E1000000000000000B01 /* ExerciseE1RMTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1E1E1000000000000000F01 /* ExerciseE1RMTile.swift */; };
 		E1E1E1000000000000000B02 /* ExerciseE1RMScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1E1E1000000000000000F02 /* ExerciseE1RMScreen.swift */; };
@@ -607,6 +609,7 @@
 		D1D1D1000000000000000F01 /* MetricTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetricTile.swift; sourceTree = "<group>"; };
 		DC42311A655A248061E11238 /* SummaryEmptyStates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryEmptyStates.swift; sourceTree = "<group>"; };
 		DD50531C168D4EDFB527D76A /* SetEntityClasses.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetEntityClasses.swift; sourceTree = "<group>"; };
+		DD6EBE9FCA104B46ACA995DE /* ScenarioScreenshots.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ScenarioScreenshots.swift; sourceTree = "<group>"; };
 		DE557E27ADC9A2C02BE79DBE /* SummaryStatScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryStatScreen.swift; sourceTree = "<group>"; };
 		E1E1E1000000000000000F01 /* ExerciseE1RMTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseE1RMTile.swift; sourceTree = "<group>"; };
 		E1E1E1000000000000000F02 /* ExerciseE1RMScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseE1RMScreen.swift; sourceTree = "<group>"; };
@@ -624,6 +627,7 @@
 		E1E1E1000000000000000F15 /* MetricComparisonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetricComparisonView.swift; sourceTree = "<group>"; };
 		E1E1E1000000000000000F16 /* PersonalBestRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonalBestRow.swift; sourceTree = "<group>"; };
 		E62F41D02C28CB089872E955 /* SummaryWelcomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryWelcomeView.swift; sourceTree = "<group>"; };
+		E9071DE852500F5E9CEA5CC7 /* TestScenarios.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TestScenarios.swift; sourceTree = "<group>"; };
 		EF956F5D14BBB78133BD528A /* ExerciseMergeServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ExerciseMergeServiceTests.swift; sourceTree = "<group>"; };
 		F3C48765200C9745764F2EAA /* PeriodHistoryChart.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PeriodHistoryChart.swift; sourceTree = "<group>"; };
 		FE01CA11AB1E5077AE000001 /* SummaryProgressTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryProgressTab.swift; sourceTree = "<group>"; };
@@ -676,6 +680,7 @@
 			children = (
 				0400C2E827A4AEAF03BACDC6 /* SnapshotHelper.swift */,
 				3CDACB5BDD447438F8D60BAE /* LOGITScreenshots.swift */,
+				DD6EBE9FCA104B46ACA995DE /* ScenarioScreenshots.swift */,
 			);
 			path = LOGITUITests;
 			sourceTree = "<group>";
@@ -757,6 +762,7 @@
 				801BBC962DF7338A00CDB1FB /* LOGITApp.swift */,
 				C05F3FE01CADB8E0526C799F /* ScreenshotFixtures.swift */,
 				9D2E7A012F30AA0100C1D2E1 /* DemoWorkoutSeeder.swift */,
+				E9071DE852500F5E9CEA5CC7 /* TestScenarios.swift */,
 			);
 			path = App;
 			sourceTree = "<group>";
@@ -1534,6 +1540,7 @@
 			files = (
 				5701E3D211A49E43B531E6D8 /* SnapshotHelper.swift in Sources */,
 				B3DC6B7D9EF58D3A51C28227 /* LOGITScreenshots.swift in Sources */,
+				E01F0F57C3115A2C00EB638E /* ScenarioScreenshots.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1794,6 +1801,7 @@
 				CFBDBE49B12AA1C06C620875 /* ChartRange.swift in Sources */,
 				28E43ABE4881F802FBBACCE9 /* RangePicker.swift in Sources */,
 				5F6C92E180BAAEC435086790 /* PeriodHistoryChart.swift in Sources */,
+				A10F7CBC23FBD8F36CC4A1D6 /* TestScenarios.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/LOGIT.xcodeproj/xcshareddata/xcschemes/LOGIT Empty.xcscheme
+++ b/LOGIT.xcodeproj/xcshareddata/xcschemes/LOGIT Empty.xcscheme
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2640"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8065AA6A2686667F00F53A5A"
+               BuildableName = "LOGIT.app"
+               BlueprintName = "LOGIT"
+               ReferencedContainer = "container:LOGIT.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "79E849062A7EA28000C0DF95"
+               BuildableName = "LOGITTests.xctest"
+               BlueprintName = "LOGITTests"
+               ReferencedContainer = "container:LOGIT.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4E4A46293BF0001C3B98CF77"
+               BuildableName = "LOGITUITests.xctest"
+               BlueprintName = "LOGITUITests"
+               ReferencedContainer = "container:LOGIT.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8065AA6A2686667F00F53A5A"
+            BuildableName = "LOGIT.app"
+            BlueprintName = "LOGIT"
+            ReferencedContainer = "container:LOGIT.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "-SCENARIO empty"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-UITEST_FORCE_FREE"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-com.apple.CoreData.CloudKitDebug 0"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-com.apple.CoreData.Logging.stderr 0"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
+      <StoreKitConfigurationFileReference
+         identifier = "../LOGIT/Config/LOGITStoreKit.storekit">
+      </StoreKitConfigurationFileReference>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8065AA6A2686667F00F53A5A"
+            BuildableName = "LOGIT.app"
+            BlueprintName = "LOGIT"
+            ReferencedContainer = "container:LOGIT.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/LOGIT.xcodeproj/xcshareddata/xcschemes/LOGIT Many Workouts.xcscheme
+++ b/LOGIT.xcodeproj/xcshareddata/xcschemes/LOGIT Many Workouts.xcscheme
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2640"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8065AA6A2686667F00F53A5A"
+               BuildableName = "LOGIT.app"
+               BlueprintName = "LOGIT"
+               ReferencedContainer = "container:LOGIT.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "79E849062A7EA28000C0DF95"
+               BuildableName = "LOGITTests.xctest"
+               BlueprintName = "LOGITTests"
+               ReferencedContainer = "container:LOGIT.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4E4A46293BF0001C3B98CF77"
+               BuildableName = "LOGITUITests.xctest"
+               BlueprintName = "LOGITUITests"
+               ReferencedContainer = "container:LOGIT.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8065AA6A2686667F00F53A5A"
+            BuildableName = "LOGIT.app"
+            BlueprintName = "LOGIT"
+            ReferencedContainer = "container:LOGIT.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "-SCENARIO many"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-UITEST_FORCE_FREE"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-com.apple.CoreData.CloudKitDebug 0"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-com.apple.CoreData.Logging.stderr 0"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
+      <StoreKitConfigurationFileReference
+         identifier = "../LOGIT/Config/LOGITStoreKit.storekit">
+      </StoreKitConfigurationFileReference>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8065AA6A2686667F00F53A5A"
+            BuildableName = "LOGIT.app"
+            BlueprintName = "LOGIT"
+            ReferencedContainer = "container:LOGIT.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/LOGIT.xcodeproj/xcshareddata/xcschemes/LOGIT One Workout.xcscheme
+++ b/LOGIT.xcodeproj/xcshareddata/xcschemes/LOGIT One Workout.xcscheme
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2640"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8065AA6A2686667F00F53A5A"
+               BuildableName = "LOGIT.app"
+               BlueprintName = "LOGIT"
+               ReferencedContainer = "container:LOGIT.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "79E849062A7EA28000C0DF95"
+               BuildableName = "LOGITTests.xctest"
+               BlueprintName = "LOGITTests"
+               ReferencedContainer = "container:LOGIT.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4E4A46293BF0001C3B98CF77"
+               BuildableName = "LOGITUITests.xctest"
+               BlueprintName = "LOGITUITests"
+               ReferencedContainer = "container:LOGIT.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8065AA6A2686667F00F53A5A"
+            BuildableName = "LOGIT.app"
+            BlueprintName = "LOGIT"
+            ReferencedContainer = "container:LOGIT.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "-SCENARIO one"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-UITEST_FORCE_FREE"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-com.apple.CoreData.CloudKitDebug 0"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-com.apple.CoreData.Logging.stderr 0"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
+      <StoreKitConfigurationFileReference
+         identifier = "../LOGIT/Config/LOGITStoreKit.storekit">
+      </StoreKitConfigurationFileReference>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8065AA6A2686667F00F53A5A"
+            BuildableName = "LOGIT.app"
+            BlueprintName = "LOGIT"
+            ReferencedContainer = "container:LOGIT.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/LOGIT/App/LOGITApp.swift
+++ b/LOGIT/App/LOGITApp.swift
@@ -53,19 +53,40 @@ struct LOGIT: App {
         #if DEBUG
         DemoWorkoutSeeder.prepareUserDefaultsIfNeeded()
         #endif
+        TestScenario.active?.prepareUserDefaults()
 
         let database: Database
         if ScreenshotFixtures.isEnabled {
             // Fastlane snapshot run: use the seeded in-memory preview store so
             // every captured screen shows the same curated, photogenic data.
             database = Database(isPreview: true)
+        } else if let scenario = TestScenario.active {
+            // Scenario launch (-SCENARIO empty|one|many): fresh in-memory
+            // store seeded for one critical data state; the real store and
+            // defaults stay untouched.
+            database = Database(inMemory: true)
+            scenario.seedAtLaunch(into: database)
         } else {
             database = Database()
         }
 
+        let measurementController = MeasurementEntryController(database: database)
+        TestScenario.active?.seedMeasurements(using: measurementController)
+
+        let defaultExerciseService = DefaultExerciseService(database: database)
+        let defaultTemplateService = DefaultTemplateService(database: database)
+        if let scenario = TestScenario.active {
+            // Scenario stores are ephemeral: import the default content and
+            // seed synchronously so the very first frame already shows the
+            // final state (the `.task` import would race the initial render).
+            defaultExerciseService.loadDefaultExercisesIfNeeded()
+            defaultTemplateService.loadDefaultTemplatesIfNeeded()
+            scenario.seedAfterDefaultContentLoaded(database: database)
+        }
+
         _database = StateObject(wrappedValue: database)
         _templateService = StateObject(wrappedValue: TemplateService(database: database))
-        _measurementController = StateObject(wrappedValue: MeasurementEntryController(database: database))
+        _measurementController = StateObject(wrappedValue: measurementController)
         let workoutRecorder = WorkoutRecorder(database: database)
         _workoutRecorder = StateObject(wrappedValue: workoutRecorder)
         let chronograph = Chronograph()
@@ -79,8 +100,8 @@ struct LOGIT: App {
         )
         _muscleGroupService = StateObject(wrappedValue: MuscleGroupService())
         _homeNavigationCoordinator = StateObject(wrappedValue: HomeNavigationCoordinator())
-        _defaultExerciseService = StateObject(wrappedValue: DefaultExerciseService(database: database))
-        _defaultTemplateService = StateObject(wrappedValue: DefaultTemplateService(database: database))
+        _defaultExerciseService = StateObject(wrappedValue: defaultExerciseService)
+        _defaultTemplateService = StateObject(wrappedValue: defaultTemplateService)
         _exerciseSuggestionService = StateObject(wrappedValue: ExerciseSuggestionService(database: database))
 
         UserDefaults.standard.register(defaults: [
@@ -165,11 +186,14 @@ struct LOGIT: App {
                     if !setupDone {
                         isShowingWelcome = true
                     }
-                    defaultExerciseService.loadDefaultExercisesIfNeeded()
-                    // Skipped for fastlane screenshot runs so the curated fixture data stays
-                    // exactly what the marketing screenshots expect.
-                    if !ScreenshotFixtures.isEnabled {
-                        defaultTemplateService.loadDefaultTemplatesIfNeeded()
+                    // Scenario launches already imported default content in init.
+                    if TestScenario.active == nil {
+                        defaultExerciseService.loadDefaultExercisesIfNeeded()
+                        // Skipped for fastlane screenshot runs so the curated fixture data stays
+                        // exactly what the marketing screenshots expect.
+                        if !ScreenshotFixtures.isEnabled {
+                            defaultTemplateService.loadDefaultTemplatesIfNeeded()
+                        }
                     }
                     #if DEBUG
                     DemoWorkoutSeeder.seedIfRequested(database: database)

--- a/LOGIT/App/TestScenarios.swift
+++ b/LOGIT/App/TestScenarios.swift
@@ -1,0 +1,156 @@
+//
+//  TestScenarios.swift
+//  LOGIT
+//
+//  Launch scenarios for testing the app in its critical data states. Launching
+//  with `-SCENARIO empty|one|many` boots a fresh in-memory store seeded for
+//  that state, plus session-only UserDefaults overrides — the simulator's real
+//  store and defaults are never touched, and every launch is identical.
+//
+//      empty   brand-new user: default content only, no workouts, no goal
+//      one     exactly one completed workout: single-data-point charts,
+//              trends without a prior period, singular strings
+//      many    long-time user: the curated preview dataset (same as the
+//              marketing screenshots) minus the in-progress workout
+//
+//  Combine with `-UITEST_FORCE_FREE` to see the free tier (DEBUG simulator
+//  builds force-unlock Pro otherwise). Scenarios are ignored in Release
+//  builds. Shared schemes "LOGIT Empty / One Workout / Many Workouts" have
+//  the arguments preconfigured.
+//
+
+import Foundation
+
+enum TestScenario: String {
+    case empty
+    case one
+    case many
+
+    /// Parsed once at process start from `-SCENARIO <name>`. Always `nil` in
+    /// Release builds, so scenario branches are unreachable outside DEBUG.
+    static let active: TestScenario? = {
+        #if DEBUG
+        let args = ProcessInfo.processInfo.arguments
+        guard let flagIndex = args.firstIndex(of: "-SCENARIO"),
+              args.indices.contains(flagIndex + 1)
+        else { return nil }
+        guard let scenario = TestScenario(rawValue: args[flagIndex + 1]) else {
+            NSLog("TestScenario: unknown scenario '%@' — expected empty|one|many", args[flagIndex + 1])
+            return nil
+        }
+        return scenario
+        #else
+        return nil
+        #endif
+    }()
+
+    // MARK: - UserDefaults
+
+    /// Injects session-only defaults into the argument domain (highest
+    /// precedence, never persisted): reads see these values for the whole
+    /// session while the developer's real defaults stay untouched. Flip side:
+    /// writes to these keys during a scenario session aren't readable back,
+    /// so e.g. the weight-unit toggle appears inert while a scenario runs.
+    func prepareUserDefaults() {
+        var overrides = UserDefaults.standard.volatileDomain(forName: UserDefaults.argumentDomain)
+
+        // Skip onboarding, keep units deterministic across sim locales.
+        overrides["setupDone"] = true
+        overrides["weightUnit"] = WeightUnit.kg.rawValue
+        // `empty` shows the no-goal state, the other scenarios a realistic goal.
+        overrides["workoutPerWeekTarget"] = self == .empty ? -1 : 4
+        // Per-user layout state stored as Data (object URIs / JSON) must not
+        // leak in from the real store — the URIs wouldn't resolve against the
+        // in-memory store anyway. A string value makes the Data reads fail so
+        // the views fall back to their defaults.
+        overrides["pinnedExercises"] = "cleared"
+        overrides["pinnedMeasurements"] = "cleared"
+        overrides["muscleTargetSplit"] = "cleared"
+        // Force the default exercises/templates to import into the fresh
+        // in-memory store even though the persistent domain records them as
+        // already loaded into the real store (templates additionally remember
+        // every id they ever seeded).
+        overrides["lastLoadedDefaultExercisesVersion"] = 0
+        overrides["lastLoadedDefaultExercisesLocale"] = ""
+        overrides["lastLoadedDefaultTemplatesVersion"] = 0
+        overrides["seededDefaultTemplateIds"] = [String]()
+        // No system permission / rating prompts mid-scenario.
+        overrides["hasRequestedNotificationPermission"] = true
+        overrides["wasPromptedToRateApp"] = true
+
+        UserDefaults.standard.setVolatileDomain(overrides, forName: UserDefaults.argumentDomain)
+    }
+
+    // MARK: - Seeding
+
+    /// Called from `LOGITApp.init` right after the in-memory database is
+    /// created, before any views or services read from it.
+    func seedAtLaunch(into database: Database) {
+        switch self {
+        case .empty, .one:
+            break
+        case .many:
+            // The curated dataset the marketing screenshots use, but without
+            // the in-progress workout so the recorder mini bar doesn't cover
+            // the bottom of every screen. Use `-UITEST_FIXTURES` when the
+            // mid-workout state itself is under test.
+            database.setupPreviewDatabase(includeCurrentWorkout: false)
+        }
+    }
+
+    /// Called from `LOGITApp.init` once the `MeasurementEntryController`
+    /// exists — it owns the preview measurement entries.
+    func seedMeasurements(using controller: MeasurementEntryController) {
+        guard self == .many else { return }
+        controller.setupPreviewMeasurementEntries()
+    }
+
+    /// Called from `LOGITApp.init` after the default exercise library import,
+    /// so the single workout references built-in exercises instead of
+    /// creating duplicate-looking copies (same approach as DemoWorkoutSeeder).
+    func seedAfterDefaultContentLoaded(database: Database) {
+        guard self == .one else { return }
+
+        let bench = exercise("_default.exercise.barbellBenchPress", "Bench Press", .chest, database)
+        let squats = exercise("_default.exercise.squats", "Squats", .legs, database)
+        let latPulldowns = exercise("_default.exercise.latPulldowns", "Lat Pulldowns", .back, database)
+
+        // Earlier today, so the workout counts toward the current week (and
+        // its stats stay "fresh period" single data points) on every weekday.
+        let start = Date.now.addingTimeInterval(-2 * 3600)
+        let workout = database.newWorkout(name: "Full Body", date: start)
+        workout.endDate = start.addingTimeInterval(52 * 60)
+
+        let benchGroup = database.newWorkoutSetGroup(createFirstSetAutomatically: false, exercise: bench, workout: workout)
+        database.newStandardSet(repetitions: 10, weight: 60000, setGroup: benchGroup)
+        database.newStandardSet(repetitions: 8, weight: 70000, setGroup: benchGroup)
+        database.newStandardSet(repetitions: 8, weight: 70000, setGroup: benchGroup)
+
+        let squatGroup = database.newWorkoutSetGroup(createFirstSetAutomatically: false, exercise: squats, workout: workout)
+        database.newStandardSet(repetitions: 10, weight: 80000, setGroup: squatGroup)
+        database.newStandardSet(repetitions: 8, weight: 90000, setGroup: squatGroup)
+        database.newStandardSet(repetitions: 8, weight: 90000, setGroup: squatGroup)
+
+        let latGroup = database.newWorkoutSetGroup(createFirstSetAutomatically: false, exercise: latPulldowns, workout: workout)
+        database.newStandardSet(repetitions: 12, weight: 50000, setGroup: latGroup)
+        database.newStandardSet(repetitions: 10, weight: 55000, setGroup: latGroup)
+        database.newStandardSet(repetitions: 10, weight: 55000, setGroup: latGroup)
+
+        database.save()
+        NSLog("TestScenario: seeded single-workout scenario")
+    }
+
+    /// The built-in exercise matching the default-library name key, or a new
+    /// stand-alone exercise when the library isn't loaded (or the key changed).
+    private func exercise(
+        _ nameKey: String,
+        _ fallbackName: String,
+        _ muscleGroup: MuscleGroup,
+        _ database: Database
+    ) -> Exercise {
+        if let existing = (database.fetch(Exercise.self) as? [Exercise])?.first(where: { $0.name == nameKey }) {
+            return existing
+        }
+        return database.newExercise(name: fallbackName, muscleGroup: muscleGroup)
+    }
+}

--- a/LOGIT/Core/Utilities/MeasurementController.swift
+++ b/LOGIT/Core/Utilities/MeasurementController.swift
@@ -60,7 +60,8 @@ class MeasurementEntryController: ObservableObject {
 
     // MARK: - Setup Controller for Preview
 
-    private func setupPreviewMeasurementEntries() {
+    // Internal so scenario launches can seed measurements explicitly (see TestScenario).
+    func setupPreviewMeasurementEntries() {
         // Starting weight in grams (for example, 100,000 grams or 100 kg)
         var currentWeight = 100
 

--- a/LOGIT/Data/Database/Database+Preview.swift
+++ b/LOGIT/Data/Database/Database+Preview.swift
@@ -8,7 +8,10 @@
 import Foundation
 
 extension Database {
-    func setupPreviewDatabase() {
+    /// Seeds the curated preview dataset. `includeCurrentWorkout: false` skips the
+    /// in-progress workout (and with it the recorder mini bar) — used by the `many`
+    /// launch scenario, while previews and fastlane fixtures keep the default.
+    func setupPreviewDatabase(includeCurrentWorkout: Bool = true) {
         let database = self
 
         (database.fetch(Workout.self) as! [Workout]).forEach { database.delete($0) }
@@ -335,41 +338,43 @@ extension Database {
         // We mark the first few sets of each exercise as "entered" (non-zero
         // reps + weight) so the screenshot shows completed work in the log,
         // and leave later sets empty so the "what's next" state is obvious.
-        let inProgressStart = Calendar.current.date(byAdding: .minute, value: -23, to: .now)!
-        let currentPushDay = database.newWorkout(name: NSLocalizedString("previewPushDay", comment: ""), date: inProgressStart)
-        currentPushDay.isCurrentWorkout = true
+        if includeCurrentWorkout {
+            let inProgressStart = Calendar.current.date(byAdding: .minute, value: -23, to: .now)!
+            let currentPushDay = database.newWorkout(name: NSLocalizedString("previewPushDay", comment: ""), date: inProgressStart)
+            currentPushDay.isCurrentWorkout = true
 
-        // Ordering matters for the screenshot: the recorder scrolls its set
-        // list to the bottom on appear, so we put the exercise with the most
-        // filled-in sets (Benchpress) LAST so it's fully visible when the
-        // capture test fires.
-        let currentOhpGroup = database.newWorkoutSetGroup(
-            createFirstSetAutomatically: false,
-            exercise: overheadPress,
-            workout: currentPushDay
-        )
-        database.newStandardSet(repetitions: 8, weight: 45000, setGroup: currentOhpGroup)
-        database.newStandardSet(repetitions: 8, weight: 45000, setGroup: currentOhpGroup)
-        database.newStandardSet(repetitions: 0, weight: 0, setGroup: currentOhpGroup)
+            // Ordering matters for the screenshot: the recorder scrolls its set
+            // list to the bottom on appear, so we put the exercise with the most
+            // filled-in sets (Benchpress) LAST so it's fully visible when the
+            // capture test fires.
+            let currentOhpGroup = database.newWorkoutSetGroup(
+                createFirstSetAutomatically: false,
+                exercise: overheadPress,
+                workout: currentPushDay
+            )
+            database.newStandardSet(repetitions: 8, weight: 45000, setGroup: currentOhpGroup)
+            database.newStandardSet(repetitions: 8, weight: 45000, setGroup: currentOhpGroup)
+            database.newStandardSet(repetitions: 0, weight: 0, setGroup: currentOhpGroup)
 
-        let currentInclineGroup = database.newWorkoutSetGroup(
-            createFirstSetAutomatically: false,
-            exercise: inclinedBenchpress,
-            workout: currentPushDay
-        )
-        database.newStandardSet(repetitions: 10, weight: 55000, setGroup: currentInclineGroup)
-        database.newStandardSet(repetitions: 10, weight: 55000, setGroup: currentInclineGroup)
-        database.newStandardSet(repetitions: 9, weight: 55000, setGroup: currentInclineGroup)
+            let currentInclineGroup = database.newWorkoutSetGroup(
+                createFirstSetAutomatically: false,
+                exercise: inclinedBenchpress,
+                workout: currentPushDay
+            )
+            database.newStandardSet(repetitions: 10, weight: 55000, setGroup: currentInclineGroup)
+            database.newStandardSet(repetitions: 10, weight: 55000, setGroup: currentInclineGroup)
+            database.newStandardSet(repetitions: 9, weight: 55000, setGroup: currentInclineGroup)
 
-        let currentBenchGroup = database.newWorkoutSetGroup(
-            createFirstSetAutomatically: false,
-            exercise: benchpress,
-            workout: currentPushDay
-        )
-        database.newStandardSet(repetitions: 8, weight: 70000, setGroup: currentBenchGroup)
-        database.newStandardSet(repetitions: 8, weight: 70000, setGroup: currentBenchGroup)
-        database.newStandardSet(repetitions: 7, weight: 70000, setGroup: currentBenchGroup)
-        database.newStandardSet(repetitions: 0, weight: 0, setGroup: currentBenchGroup)
+            let currentBenchGroup = database.newWorkoutSetGroup(
+                createFirstSetAutomatically: false,
+                exercise: benchpress,
+                workout: currentPushDay
+            )
+            database.newStandardSet(repetitions: 8, weight: 70000, setGroup: currentBenchGroup)
+            database.newStandardSet(repetitions: 8, weight: 70000, setGroup: currentBenchGroup)
+            database.newStandardSet(repetitions: 7, weight: 70000, setGroup: currentBenchGroup)
+            database.newStandardSet(repetitions: 0, weight: 0, setGroup: currentBenchGroup)
+        }
 
         // MARK: Completed NSLocalizedString("previewArmDay", comment: "") workout with superset + drop set
         //

--- a/LOGIT/Data/Database/Database.swift
+++ b/LOGIT/Data/Database/Database.swift
@@ -24,14 +24,20 @@ public class Database: ObservableObject {
 
     // MARK: - Init
 
-    init(isPreview: Bool = false) {
+    /// - Parameters:
+    ///   - isPreview: seeds the curated preview dataset (SwiftUI previews, fastlane fixtures).
+    ///   - inMemory: backs the store with `/dev/null` instead of the on-disk SQLite file.
+    ///     Defaults to `isPreview`; pass `true` on its own for an unseeded throwaway store
+    ///     (launch scenarios, see `TestScenario`).
+    init(isPreview: Bool = false, inMemory: Bool? = nil) {
         self.isPreview = isPreview
+        let usesInMemoryStore = inMemory ?? isPreview
         container = NSPersistentCloudKitContainer(name: "LOGIT")
         let description = container.persistentStoreDescriptions.first
         description?.setOption(true as NSNumber, forKey: NSMigratePersistentStoresAutomaticallyOption)
         description?.setOption(true as NSNumber, forKey: NSInferMappingModelAutomaticallyOption)
 
-        if isPreview {
+        if usesInMemoryStore {
             container.persistentStoreDescriptions.first!.url = URL(fileURLWithPath: "/dev/null")
         }
         loadStores()

--- a/LOGITUITests/ScenarioScreenshots.swift
+++ b/LOGITUITests/ScenarioScreenshots.swift
@@ -1,0 +1,141 @@
+//
+//  ScenarioScreenshots.swift
+//  LOGITUITests
+//
+//  Standing verification suite: captures the app's main screens in each launch
+//  scenario (see LOGIT/App/TestScenarios.swift) so UI changes can be checked
+//  against the critical data states — brand-new user (empty), single workout
+//  (one), long-time user (many), and the free tier (many + -UITEST_FORCE_FREE).
+//
+//  Run on the iOS 26.4 simulator (the 26.0 test runner dies nondeterministically):
+//      xcodebuild test -workspace LOGIT.xcworkspace -scheme LOGITScreenshots \
+//        -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.4' \
+//        -only-testing:LOGITUITests/ScenarioScreenshots \
+//        -resultBundlePath scenarios.xcresult
+//      xcrun xcresulttool export attachments --path scenarios.xcresult --output-path <dir>
+//
+//  Screenshots land as attachments named <scenario>_<NN>_<screen>. For screens
+//  the tab-root walkthrough doesn't reach, temporarily add a test method here
+//  that launches via launchApp(scenario:) and navigates there (one launch per
+//  test method — relaunching within a method kills the iOS 26 test runner).
+//
+
+import XCTest
+
+@MainActor
+final class ScenarioScreenshots: XCTestCase {
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        // Keep capturing later screens even if one navigation step fails.
+        continueAfterFailure = true
+    }
+
+    // MARK: - Scenarios
+
+    func testEmptyScenario() {
+        captureMainScreens(scenario: "empty")
+    }
+
+    func testOneWorkoutScenario() {
+        captureMainScreens(scenario: "one")
+    }
+
+    func testManyWorkoutsScenario() {
+        captureMainScreens(scenario: "many")
+    }
+
+    /// Free tier on the rich dataset — Pro is force-unlocked in DEBUG
+    /// simulator builds, so this is the only way to see locked/teaser states.
+    func testFreeUserScenario() {
+        captureMainScreens(
+            scenario: "many",
+            extraArguments: ["-UITEST_FORCE_FREE"],
+            attachmentPrefix: "free"
+        )
+    }
+
+    // MARK: - Walkthrough
+
+    private func captureMainScreens(
+        scenario: String,
+        extraArguments: [String] = [],
+        attachmentPrefix: String? = nil
+    ) {
+        let app = launchApp(scenario: scenario, extraArguments: extraArguments)
+        let prefix = attachmentPrefix ?? scenario
+
+        let tabBar = app.tabBars.firstMatch
+        XCTAssertTrue(tabBar.waitForExistence(timeout: 30), "Tab bar never appeared for scenario \(scenario)")
+        waitABit(2) // let the summary tiles settle
+
+        attach(app, "\(prefix)_01_summary")
+
+        // Visit the other tabs BEFORE any scrolling: a swipe minimizes the
+        // tab bar (tabBarMinimizeBehavior) and on short screens (empty
+        // scenario) no scroll-up exists to restore it, which would make the
+        // History/Templates buttons unreachable.
+        tapTab(app, at: 1)
+        waitABit()
+        attach(app, "\(prefix)_03_history")
+
+        tapTab(app, at: 2)
+        waitABit()
+        attach(app, "\(prefix)_04_templates")
+
+        tapTab(app, at: 3)
+        waitABit()
+        attach(app, "\(prefix)_05_search")
+
+        tapTab(app, at: 0)
+        waitABit()
+        app.swipeUp()
+        waitABit()
+        attach(app, "\(prefix)_02_summary_scrolled")
+    }
+
+    // MARK: - Helpers
+
+    private func launchApp(scenario: String, extraArguments: [String] = []) -> XCUIApplication {
+        // Explicit bundle ID because the UI test target has no "Target
+        // Application" wiring in the scheme (see LOGITScreenshots.swift).
+        let app = XCUIApplication(bundleIdentifier: ".com.lukaskbl.LOGIT")
+        app.launchArguments += [
+            "-SCENARIO", scenario,
+            // The simulator device may be set to a non-English locale;
+            // captures should be deterministic.
+            "-AppleLanguages", "(en)",
+            "-AppleLocale", "en_US",
+        ] + extraArguments
+        app.launch()
+        return app
+    }
+
+    private func tapTab(_ app: XCUIApplication, at index: Int) {
+        let tabBar = app.tabBars.firstMatch
+        guard tabBar.waitForExistence(timeout: 5) else { return }
+        var buttons = tabBar.buttons.allElementsBoundByIndex
+        if index >= buttons.count {
+            // Tab bar is minimized after a scroll — swipe down to restore it.
+            app.swipeDown()
+            sleep(1)
+            buttons = tabBar.buttons.allElementsBoundByIndex
+        }
+        guard index < buttons.count else {
+            XCTFail("Tab index \(index) not reachable (\(buttons.count) tab buttons visible)")
+            return
+        }
+        buttons[index].tap()
+    }
+
+    private func attach(_ app: XCUIApplication, _ name: String) {
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = name
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+
+    private func waitABit(_ seconds: UInt32 = 1) {
+        sleep(seconds)
+    }
+}


### PR DESCRIPTION
## Summary

Adds **launch scenarios** so the app can be booted directly into its critical data states — for manual testing in the simulator and for automated screenshot verification of UI changes.

`-SCENARIO empty|one|many` (DEBUG-only) boots a **fresh in-memory store** seeded for one state, plus session-only `UserDefaults` overrides in the argument domain. Nothing persists and the real simulator store/defaults are untouched, so every launch renders an identical, known state:

| Scenario | State |
| --- | --- |
| `-SCENARIO empty` | Brand-new user — default exercises + starter templates, no workouts, no goal, onboarding skipped |
| `-SCENARIO one` | A single completed workout — single-data-point charts, fresh-period trend pills, singular strings |
| `-SCENARIO many` | The curated preview dataset (incl. measurements) **without** the in-progress workout, so no recorder mini-bar |

Combine any scenario with `-UITEST_FORCE_FREE` for the **free tier** (Pro is force-unlocked in DEBUG simulator builds otherwise).

## How to use it

- **In Xcode:** three shared schemes — **LOGIT Empty / LOGIT One Workout / LOGIT Many Workouts** — pick one and ⌘R. Each carries a disabled `-UITEST_FORCE_FREE` toggle for the free tier. The plain `LOGIT` scheme keeps using the real on-disk store.
- **Automated:** the standing `LOGITUITests/ScenarioScreenshots` suite walks the main screens in all four states. `AGENT.md` now makes this screenshot matrix mandatory for every UI change (Pro-vs-free always shown for gated features).

## Supporting changes

- `Database` gains an `inMemory:` parameter so a throwaway store can be created without seeding the preview dataset.
- `setupPreviewDatabase(includeCurrentWorkout:)` skips the in-progress workout for `many`; previews and fastlane fixtures keep the default (mid-workout state stays available via `-UITEST_FIXTURES`).
- Scenario default-content import + single-workout seeding run in `LOGITApp.init` so the first frame already shows the final state.

## Verification

All four scenarios × five screens captured on the iPhone 17 Pro / iOS 26.4 simulator and reviewed — empty states, single-data-point views, rich history, and the free-tier teasers all render correctly. **All 344 unit tests pass.** The fastlane fixture path (`-UITEST_FIXTURES`) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)