### PR TITLE
Fix silent workout data loss under CloudKit sync

### DIFF
--- a/LOGIT/App/LOGITApp.swift
+++ b/LOGIT/App/LOGITApp.swift
@@ -273,6 +273,17 @@ struct LOGIT: App {
                 } message: {
                     Text(importErrorMessage)
                 }
+                // Persisting to disk failed even after the retry: without this, the data loss
+                // would be silent — the UI keeps showing the in-memory objects until the app is
+                // relaunched, and only then does the user find their workout gone.
+                .alert(
+                    NSLocalizedString("saveFailedTitle", comment: ""),
+                    isPresented: $database.lastSaveFailed
+                ) {
+                    Button(NSLocalizedString("ok", comment: ""), role: .cancel) {}
+                } message: {
+                    Text(NSLocalizedString("saveFailedMessage", comment: ""))
+                }
         }
     }
 

--- a/LOGIT/Core/Environment/de.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/de.lproj/Localizable.strings
@@ -312,6 +312,8 @@
 
 "save" = "Speichern";
 "saveAsTemplate" = "Als Vorlage";
+"saveFailedMessage" = "Deine letzten Änderungen konnten nicht gespeichert werden. Sie gehen möglicherweise verloren, wenn die App geschlossen wird. Bitte versuche es erneut.";
+"saveFailedTitle" = "Speichern fehlgeschlagen";
 "saveTemplate" = "Vorlage speichern";
 "saveTime" = "Spare Zeit";
 "scanATemplate" = "Scanne eine Vorlage";

--- a/LOGIT/Core/Environment/en.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/en.lproj/Localizable.strings
@@ -316,6 +316,8 @@
 
 "save" = "Save";
 "saveAsTemplate" = "Save as Template";
+"saveFailedMessage" = "Your latest changes couldn't be saved. They may be lost when the app is closed. Please try again.";
+"saveFailedTitle" = "Saving Failed";
 "saveTemplate" = "Save Template";
 "saveTime" = "Save Time";
 "scanATemplate" = "Scan a Template";

--- a/LOGIT/Core/Environment/es.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/es.lproj/Localizable.strings
@@ -316,6 +316,8 @@
 
 "save" = "Ahorrar";
 "saveAsTemplate" = "Guardar como plantilla";
+"saveFailedMessage" = "No se pudieron guardar tus últimos cambios. Podrían perderse al cerrar la app. Inténtalo de nuevo.";
+"saveFailedTitle" = "Error al guardar";
 "saveTemplate" = "Guardar plantilla";
 "saveTime" = "Ahorra tiempo";
 "scanATemplate" = "Escanear una plantilla";

--- a/LOGIT/Core/Environment/fr.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/fr.lproj/Localizable.strings
@@ -316,6 +316,8 @@
 
 "save" = "Sauvegarder";
 "saveAsTemplate" = "Enregistrer comme modèle";
+"saveFailedMessage" = "Vos dernières modifications n'ont pas pu être enregistrées. Elles pourraient être perdues à la fermeture de l'app. Veuillez réessayer.";
+"saveFailedTitle" = "Échec de l'enregistrement";
 "saveTemplate" = "Enregistrer le modèle";
 "saveTime" = "Gagnez du temps";
 "scanATemplate" = "Scanner un modèle";

--- a/LOGIT/Core/Environment/it.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/it.lproj/Localizable.strings
@@ -316,6 +316,8 @@
 
 "save" = "Salva";
 "saveAsTemplate" = "Salva come modello";
+"saveFailedMessage" = "Non è stato possibile salvare le ultime modifiche. Potrebbero andare perse alla chiusura dell'app. Riprova.";
+"saveFailedTitle" = "Salvataggio non riuscito";
 "saveTemplate" = "Salva modello";
 "saveTime" = "Risparmia tempo";
 "scanATemplate" = "Scansiona un modello";

--- a/LOGIT/Core/Environment/ja.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/ja.lproj/Localizable.strings
@@ -316,6 +316,8 @@
 
 "save" = "保存";
 "saveAsTemplate" = "テンプレートとして保存";
+"saveFailedMessage" = "最新の変更を保存できませんでした。アプリを終了すると失われる可能性があります。もう一度お試しください。";
+"saveFailedTitle" = "保存に失敗しました";
 "saveTemplate" = "テンプレートの保存";
 "saveTime" = "時間を節約する";
 "scanATemplate" = "テンプレートをスキャンする";

--- a/LOGIT/Core/Environment/ko.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/ko.lproj/Localizable.strings
@@ -316,6 +316,8 @@
 
 "save" = "저장";
 "saveAsTemplate" = "템플릿으로 저장";
+"saveFailedMessage" = "최근 변경 사항을 저장하지 못했습니다. 앱을 종료하면 손실될 수 있습니다. 다시 시도해 주세요.";
+"saveFailedTitle" = "저장 실패";
 "saveTemplate" = "템플릿 저장";
 "saveTime" = "시간 절약";
 "scanATemplate" = "템플릿 스캔";

--- a/LOGIT/Core/Environment/pt-BR.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/pt-BR.lproj/Localizable.strings
@@ -316,6 +316,8 @@
 
 "save" = "Salvar";
 "saveAsTemplate" = "Salvar como modelo";
+"saveFailedMessage" = "Não foi possível salvar suas últimas alterações. Elas podem ser perdidas ao fechar o app. Tente novamente.";
+"saveFailedTitle" = "Falha ao salvar";
 "saveTemplate" = "Salvar modelo";
 "saveTime" = "Economize tempo";
 "scanATemplate" = "Digitalizar um modelo";

--- a/LOGIT/Data/Database/Database.swift
+++ b/LOGIT/Data/Database/Database.swift
@@ -20,6 +20,10 @@ public class Database: ObservableObject {
 
     @Published var canUndo: Bool = false
     @Published var canRedo: Bool = false
+    /// Set when persisting to disk failed even after retrying. The app shows an alert for it:
+    /// a failed save means everything still on screen is memory-only and would vanish with the
+    /// next relaunch, so the user must know — silently swallowing it loses their training data.
+    @Published var lastSaveFailed = false
     var isPreview: Bool
 
     // MARK: - Init
@@ -38,6 +42,17 @@ public class Database: ObservableObject {
         if isPreview {
             setupPreviewDatabase()
         }
+
+        // The CloudKit mirroring delegate writes to the store through its own background
+        // contexts. Without merging those changes into the view context, its row snapshots go
+        // stale, and the next save fails optimistic locking with an NSMergeConflict (the default
+        // NSErrorMergePolicy refuses to resolve it). Since that only happens with live iCloud
+        // sync, it surfaces on real devices: a saved workout survives in memory for the session,
+        // then is gone after a relaunch. Merge remote changes automatically, and on conflict keep
+        // the user's local edits property by property — on this device, what the user just
+        // entered is the truth.
+        container.viewContext.automaticallyMergesChangesFromParent = true
+        container.viewContext.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
 
         container.viewContext.undoManager = UndoManager()
         observeUndoManager()
@@ -104,7 +119,28 @@ public class Database: ObservableObject {
                 try self.context.save()
                 os_log("Database: Context saved successfully", type: .info)
             } catch {
-                os_log("Database: Failed to save context: %@", type: .error, error.localizedDescription)
+                // Most likely a merge conflict from row snapshots gone stale under CloudKit
+                // mirroring. Refreshing re-reads the store rows while keeping the unsaved
+                // edits on top, so one retry usually recovers. Log the full error —
+                // localizedDescription of an NSMergeConflict is uselessly generic, and
+                // non-public log arguments are redacted to "<private>" on device.
+                os_log(
+                    "Database: Failed to save context, retrying after refresh: %{public}@",
+                    type: .error, String(describing: error)
+                )
+                self.context.refreshAllObjects()
+                do {
+                    try self.context.save()
+                    os_log("Database: Context saved successfully on retry", type: .info)
+                } catch {
+                    os_log(
+                        "Database: Failed to save context after retry: %{public}@",
+                        type: .fault, String(describing: error)
+                    )
+                    DispatchQueue.main.async {
+                        self.lastSaveFailed = true
+                    }
+                }
             }
         }
     }

--- a/LOGIT/Data/PredicateFactories/WorkoutSetGroupPredicateFactory.swift
+++ b/LOGIT/Data/PredicateFactories/WorkoutSetGroupPredicateFactory.swift
@@ -16,9 +16,12 @@ enum WorkoutSetGroupPredicateFactory {
         var subpredicates = [NSPredicate]()
 
         if let exerciseId = exercise?.id {
+            // Compare against the UUID itself, not its string. SQLite coerces a string to the
+            // UUID attribute, but pending (unsaved) objects are matched in memory, where
+            // UUID == String is always false — set groups would stay invisible until persisted.
             let exercisePredicate = NSPredicate(
                 format: "ANY exercises_.id == %@",
-                exerciseId.uuidString
+                exerciseId as CVarArg
             )
             subpredicates.append(exercisePredicate)
         }

--- a/LOGIT/Data/PredicateFactories/WorkoutSetPredicateFactory.swift
+++ b/LOGIT/Data/PredicateFactories/WorkoutSetPredicateFactory.swift
@@ -19,7 +19,9 @@ enum WorkoutSetPredicateFactory {
         var subpredicates = [NSPredicate]()
 
         if let exerciseId = exercise?.id {
-            let exercisePredicate = NSPredicate(format: "ANY setGroup.exercises_.id == %@", exerciseId.uuidString)
+            // UUID, not uuidString: string comparison works in SQLite but never matches during
+            // the in-memory evaluation of pending objects (see WorkoutSetGroupPredicateFactory).
+            let exercisePredicate = NSPredicate(format: "ANY setGroup.exercises_.id == %@", exerciseId as CVarArg)
             subpredicates.append(exercisePredicate)
         }
 
@@ -34,7 +36,7 @@ enum WorkoutSetPredicateFactory {
         }
         
         if let workoutId = workout?.id {
-            let workoutPredicate = NSPredicate(format: "setGroup.workout.id == %@", workoutId.uuidString)
+            let workoutPredicate = NSPredicate(format: "setGroup.workout.id == %@", workoutId as CVarArg)
             subpredicates.append(workoutPredicate)
         }
 

--- a/LOGIT/Features/Workout/WorkoutListScreen.swift
+++ b/LOGIT/Features/Workout/WorkoutListScreen.swift
@@ -16,7 +16,10 @@ struct WorkoutListScreen: View {
 
     @State private var searchedText: String = ""
     @State private var selectedMuscleGroup: MuscleGroup? = nil
-    @State private var isShowingAddWorkout = false
+    /// The workout being added via the editor sheet. Created once on button tap — creating it
+    /// inside the sheet's ViewBuilder inserts a fresh orphan workout into the context on every
+    /// re-evaluation of the builder, and they all get persisted by the next save.
+    @State private var workoutToAdd: Workout?
     @State private var selectedWorkout: Workout?
 
     // MARK: - Body
@@ -90,14 +93,14 @@ struct WorkoutListScreen: View {
             .toolbar {
                 ToolbarItemGroup(placement: .navigationBarTrailing) {
                     Button {
-                        isShowingAddWorkout = true
+                        workoutToAdd = database.newWorkout()
                     } label: {
                         Image(systemName: "plus")
                     }
                 }
             }
-            .sheet(isPresented: $isShowingAddWorkout) {
-                WorkoutEditorScreen(workout: database.newWorkout(), isAddingNewWorkout: true)
+            .sheet(item: $workoutToAdd) { workout in
+                WorkoutEditorScreen(workout: workout, isAddingNewWorkout: true)
             }
         }
         .navigationDestination(item: $selectedWorkout) { workout in

--- a/LOGITTests/DatabaseTests.swift
+++ b/LOGITTests/DatabaseTests.swift
@@ -243,6 +243,112 @@ final class DatabaseTests: XCTestCase {
         XCTAssertEqual(setGroup.sets.count, 2)
         XCTAssertEqual(setGroup.sets.last?.restDurationSeconds, 75)
     }
+
+    // MARK: - Predicate Factory Tests
+
+    /// @FetchRequest evaluates *pending* (unsaved) objects in memory, where a UUID attribute never
+    /// equals a uuidString. The factories must therefore compare against the UUID itself, or a
+    /// just-edited workout stays invisible on the exercise detail screen until it is persisted.
+    func testEditorPredicatesMatchPendingUnsavedObjects() throws {
+        let exercise = database.newExercise(name: "Benchpress", muscleGroup: .chest)
+        let workout = database.newWorkout(name: "Push Day")
+        let setGroup = database.newWorkoutSetGroup(exercise: exercise, workout: workout)
+        let workoutSet = try XCTUnwrap(setGroup.sets.first)
+
+        let setGroupPredicate = try XCTUnwrap(
+            WorkoutSetGroupPredicateFactory.getWorkoutSetGroups(withExercise: exercise)
+        )
+        XCTAssertTrue(
+            setGroupPredicate.evaluate(with: setGroup),
+            "Pending set group must match the exercise-detail predicate before it is saved"
+        )
+
+        let setPredicate = try XCTUnwrap(WorkoutSetPredicateFactory.getWorkoutSets(with: exercise))
+        XCTAssertTrue(
+            setPredicate.evaluate(with: workoutSet),
+            "Pending workout set must match the per-exercise predicate before it is saved"
+        )
+
+        let workoutSetPredicate = try XCTUnwrap(WorkoutSetPredicateFactory.getWorkoutSets(in: workout))
+        XCTAssertTrue(
+            workoutSetPredicate.evaluate(with: workoutSet),
+            "Pending workout set must match the per-workout predicate before it is saved"
+        )
+    }
+
+    /// The flip side of the pending-object test: the same predicates still match through SQLite
+    /// once the objects are persisted (the store must accept the UUID argument).
+    func testEditorPredicatesMatchPersistedObjectsThroughStore() throws {
+        let exercise = database.newExercise(name: "Benchpress", muscleGroup: .chest)
+        let workout = database.newWorkout(name: "Push Day")
+        let setGroup = database.newWorkoutSetGroup(exercise: exercise, workout: workout)
+        try database.context.save()
+
+        let fetchedSetGroups = database.fetch(
+            WorkoutSetGroup.self,
+            predicate: WorkoutSetGroupPredicateFactory.getWorkoutSetGroups(withExercise: exercise)
+        ) as? [WorkoutSetGroup]
+        XCTAssertEqual(fetchedSetGroups?.contains(setGroup), true)
+
+        let fetchedSets = database.fetch(
+            WorkoutSet.self,
+            predicate: WorkoutSetPredicateFactory.getWorkoutSets(with: exercise)
+        ) as? [WorkoutSet]
+        XCTAssertEqual(fetchedSets?.contains(where: { $0.setGroup == setGroup }), true)
+    }
+
+    // MARK: - Save Conflict Tests
+
+    /// Reproduces the on-device data loss: another writer (the CloudKit mirroring delegate in
+    /// production) updates a row behind the view context's back, making its snapshot stale. With
+    /// the default error merge policy the next save throws an unresolved merge conflict, which
+    /// used to be swallowed — the workout lived on in memory and vanished with the next launch.
+    /// The context must resolve the conflict in favor of the local edit and actually persist it.
+    func testSaveSurvivesConcurrentStoreWriteToSameObject() throws {
+        let workout = database.newWorkout(name: "Original")
+        try database.context.save()
+        let workoutID = workout.objectID
+
+        // Local pending edit, made while the row is about to go stale underneath us
+        workout.name = "Local Edit"
+
+        // Simulate the CloudKit mirroring delegate: a direct store write from another context
+        let coordinator = try XCTUnwrap(database.context.persistentStoreCoordinator)
+        let backgroundContext = NSManagedObjectContext(concurrencyType: .privateQueueConcurrencyType)
+        backgroundContext.persistentStoreCoordinator = coordinator
+        try backgroundContext.performAndWait {
+            let backgroundWorkout = try XCTUnwrap(
+                backgroundContext.existingObject(with: workoutID) as? Workout
+            )
+            backgroundWorkout.name = "Remote Edit"
+            try backgroundContext.save()
+        }
+
+        database.save()
+
+        // save() runs async on the context's queue; perform blocks execute in order,
+        // so an expectation enqueued after it fires once the save has finished.
+        let saveCompleted = expectation(description: "save block completed")
+        database.context.perform { saveCompleted.fulfill() }
+        wait(for: [saveCompleted], timeout: 5)
+        // The failure flag is published via the main queue; drain it before asserting.
+        let mainQueueDrained = expectation(description: "main queue drained")
+        DispatchQueue.main.async { mainQueueDrained.fulfill() }
+        wait(for: [mainQueueDrained], timeout: 5)
+
+        XCTAssertFalse(database.lastSaveFailed, "The conflicting save must be resolved, not dropped")
+
+        // The store — not the in-memory context — must hold the local edit: verify through a
+        // fresh context so a silently failed save can't masquerade as success.
+        let verificationContext = NSManagedObjectContext(concurrencyType: .privateQueueConcurrencyType)
+        verificationContext.persistentStoreCoordinator = coordinator
+        try verificationContext.performAndWait {
+            let persistedWorkout = try XCTUnwrap(
+                verificationContext.existingObject(with: workoutID) as? Workout
+            )
+            XCTAssertEqual(persistedWorkout.name, "Local Edit")
+        }
+    }
 }
 
 // MARK: - Model Version 7 Migration Tests


### PR DESCRIPTION
## Problem

A workout saved from the editor could show up in **history** and **workout goals** but be missing from **exercise detail**, then disappear entirely after an app restart — on a real device. Reported from live use.

## Root causes

**1. Silent save failure (the data loss).** The `NSPersistentCloudKitContainer` view context never set `automaticallyMergesChangesFromParent` or a merge policy. On device, the CloudKit mirroring delegate writes to the store in the background, staling the view context's row snapshots. The next `save()` then throws an unresolved `NSMergeConflict` — which `save()` caught, logged, and swallowed. The workout lived on in memory (history/goals read the in-memory context) and was gone after relaunch (the store never had it). Only reproduces with live iCloud sync, so it never surfaced in development.

**2. UUID-vs-String predicate (empty exercise detail before restart).** The exercise-detail fetch matched set groups with `exercises_.id == uuidString`. SQLite coerces that for persisted rows, but `@FetchRequest` evaluates pending (unsaved) objects **in memory**, where a `UUID` never equals a `String` — so the just-entered workout stayed invisible on exercise detail until it was persisted.

**3. Orphan workouts.** `WorkoutListScreen` created the new workout inside the sheet's ViewBuilder, inserting a fresh empty workout on each re-evaluation. Previously masked by the broken saves; with saving fixed they would have accumulated.

## Fixes

- **`Database.swift`**: view context now auto-merges background/CloudKit changes and resolves conflicts with `NSMergeByPropertyObjectTrumpMergePolicy` (local edits win). `save()` logs the full error, retries once after refreshing stale snapshots, and on persistent failure sets a published flag that raises a localized **"Saving Failed"** alert — no more silent loss.
- **Both predicate factories**: compare against the `UUID` itself, so pending data appears in exercise detail immediately.
- **`WorkoutListScreen.swift`**: create the workout once on button tap via `.sheet(item:)`.
- **Localization**: `saveFailedTitle` / `saveFailedMessage` added in all 8 languages.

## Tests

Three regression tests in `DatabaseTests.swift`, including one that simulates a concurrent CloudKit-style store write and asserts the local edit survives **in the store** (verified through a separate context). All were confirmed to **fail against the pre-fix code** and pass after. Full `LOGITTests` suite passes.

## Note

A related hazard — `WorkoutRecorder.saveWorkout()/discardWorkout()` mutating Core Data objects off the main queue — is being addressed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)