### PR TITLE
Lead pinned exercise tiles with the exercise name

### DIFF
--- a/LOGIT/Features/Exercise/ExerciseDetail/Tiles/ExerciseE1RMTile.swift
+++ b/LOGIT/Features/Exercise/ExerciseDetail/Tiles/ExerciseE1RMTile.swift
@@ -10,6 +10,8 @@ import SwiftUI
 struct ExerciseE1RMTile: View {
     let exercise: Exercise
     let workoutSets: [WorkoutSet]
+    /// Leads the tile with the exercise name (the pinned Summary grid); see `ExerciseBestMetricTile`.
+    var showsExerciseName: Bool = false
 
     var body: some View {
         ExerciseBestMetricTile(
@@ -18,6 +20,7 @@ struct ExerciseE1RMTile: View {
             title: NSLocalizedString("e1RM", comment: ""),
             unit: WeightUnit.used.rawValue,
             requiresPro: true,
+            showsExerciseName: showsExerciseName,
             metricValue: { $0.estimatedOneRepMax(for: exercise) },
             formattedValue: { formatEstimatedOneRepMax($0) },
             chartValue: { convertWeightForDisplayingDecimal($0) }

--- a/LOGIT/Features/Exercise/ExerciseDetail/Tiles/ExerciseMetricTile.swift
+++ b/LOGIT/Features/Exercise/ExerciseDetail/Tiles/ExerciseMetricTile.swift
@@ -364,6 +364,11 @@ struct ExerciseBestMetricTile: View {
     let unit: String
     /// Pro-gates the tile's data (see `MetricTile.requiresPro`).
     var requiresPro: Bool = false
+    /// Leads the tile with the exercise's name and demotes the metric name (`title`) to the subtitle
+    /// — the pinned Summary tiles, which stand alone with no exercise heading around them, unlike the
+    /// detail screen where the exercise is already the screen title and the metric name belongs up top.
+    /// Off by default (the detail screen); the pinned grid turns it on. Mirrors `SampleExerciseTile`.
+    var showsExerciseName: Bool = false
     /// The metric's base value of a single set, in raw storage units (grams for weights).
     let metricValue: (WorkoutSet) -> Int
     /// Display string for a base value (handles unit conversion).
@@ -383,10 +388,15 @@ struct ExerciseBestMetricTile: View {
         let isLapsed = trend.currentBest == nil && trend.allTimeBest != nil
         let lastBest = isLapsed ? lastSessionBest(in: sets) : nil
         MetricTile(
-            title: title,
-            label: isLapsed
-                ? .info(NSLocalizedString("lastBest", comment: ""), explanation: NSLocalizedString("lastBestInfo", comment: ""))
-                : .currentBest,
+            title: showsExerciseName ? exercise.displayName : title,
+            // Pinned tiles put the exercise name in the title, so the metric name moves down to the
+            // subtitle here; the pill still carries the current-vs-last-best distinction. The detail
+            // screen keeps "current best" / "last best", where the metric name is already the title.
+            label: showsExerciseName
+                ? .plain(title)
+                : (isLapsed
+                    ? .info(NSLocalizedString("lastBest", comment: ""), explanation: NSLocalizedString("lastBestInfo", comment: ""))
+                    : .currentBest),
             value: trend.currentBest.map(formattedValue) ?? lastBest.map { formattedValue($0.value) },
             unit: unit,
             accent: AnyShapeStyle(color),

--- a/LOGIT/Features/Exercise/ExerciseDetail/Tiles/ExerciseRepetitionsTile.swift
+++ b/LOGIT/Features/Exercise/ExerciseDetail/Tiles/ExerciseRepetitionsTile.swift
@@ -10,6 +10,8 @@ import SwiftUI
 struct ExerciseRepetitionsTile: View {
     let exercise: Exercise
     let workoutSets: [WorkoutSet]
+    /// Leads the tile with the exercise name (the pinned Summary grid); see `ExerciseBestMetricTile`.
+    var showsExerciseName: Bool = false
 
     var body: some View {
         ExerciseBestMetricTile(
@@ -17,6 +19,7 @@ struct ExerciseRepetitionsTile: View {
             workoutSets: workoutSets,
             title: ExercisePrimaryMetric.repetitions.shortTitle,
             unit: NSLocalizedString("rps", comment: ""),
+            showsExerciseName: showsExerciseName,
             metricValue: { $0.maximum(.repetitions, for: exercise) },
             formattedValue: { String($0) },
             chartValue: { Double($0) }

--- a/LOGIT/Features/Exercise/ExerciseDetail/Tiles/ExerciseSetVolumeTile.swift
+++ b/LOGIT/Features/Exercise/ExerciseDetail/Tiles/ExerciseSetVolumeTile.swift
@@ -10,6 +10,8 @@ import SwiftUI
 struct ExerciseSetVolumeTile: View {
     let exercise: Exercise
     let workoutSets: [WorkoutSet]
+    /// Leads the tile with the exercise name (the pinned Summary grid); see `ExerciseBestMetricTile`.
+    var showsExerciseName: Bool = false
 
     var body: some View {
         ExerciseBestMetricTile(
@@ -18,6 +20,7 @@ struct ExerciseSetVolumeTile: View {
             title: NSLocalizedString("setVolume", comment: ""),
             unit: WeightUnit.used.rawValue,
             requiresPro: true,
+            showsExerciseName: showsExerciseName,
             metricValue: { $0.volume(for: exercise) },
             formattedValue: { formatWeightForDisplay($0) },
             chartValue: { convertWeightForDisplayingDecimal($0) }

--- a/LOGIT/Features/Exercise/ExerciseDetail/Tiles/ExerciseVolumeTile.swift
+++ b/LOGIT/Features/Exercise/ExerciseDetail/Tiles/ExerciseVolumeTile.swift
@@ -17,6 +17,9 @@ import SwiftUI
 struct ExerciseVolumeTile: View {
     let exercise: Exercise
     let workoutSets: [WorkoutSet]
+    /// Leads the tile with the exercise name and moves the metric name into the subtitle (the pinned
+    /// Summary grid); see `ExerciseBestMetricTile`. Off by default (the detail screen).
+    var showsExerciseName: Bool = false
 
     private struct WeeklyVolume: Identifiable {
         let week: Date
@@ -43,8 +46,14 @@ struct ExerciseVolumeTile: View {
         let lastBestDate = isLapsed ? sets.filter { $0.volume(for: exercise) > 0 }.compactMap({ $0.workout?.date }).max() : nil
         let muscleColor = exercise.muscleGroup?.color ?? .accentColor
         MetricTile(
-            title: NSLocalizedString("volume", comment: ""),
-            label: .plain(NSLocalizedString(isLapsed ? "lastBest" : "thisWeek", comment: "")),
+            title: showsExerciseName ? exercise.displayName : NSLocalizedString("volume", comment: ""),
+            // Pinned: the exercise name is the title, so the subtitle names the metric ("Volume").
+            // Detail: the metric name is already the title, so the subtitle qualifies the value's span
+            // ("This Week", or "Last Best" once the exercise has lapsed).
+            label: .plain(NSLocalizedString(
+                showsExerciseName ? "volume" : (isLapsed ? "lastBest" : "thisWeek"),
+                comment: ""
+            )),
             value: weeklyVolumes.isEmpty
                 ? nil
                 : formatWeightForDisplay(isLapsed ? weeklyVolumes.last?.volume ?? 0 : thisWeekVolume),

--- a/LOGIT/Features/Exercise/ExerciseDetail/Tiles/ExerciseWeightTile.swift
+++ b/LOGIT/Features/Exercise/ExerciseDetail/Tiles/ExerciseWeightTile.swift
@@ -10,6 +10,8 @@ import SwiftUI
 struct ExerciseWeightTile: View {
     let exercise: Exercise
     let workoutSets: [WorkoutSet]
+    /// Leads the tile with the exercise name (the pinned Summary grid); see `ExerciseBestMetricTile`.
+    var showsExerciseName: Bool = false
 
     var body: some View {
         ExerciseBestMetricTile(
@@ -18,6 +20,7 @@ struct ExerciseWeightTile: View {
             title: NSLocalizedString("weight", comment: ""),
             unit: WeightUnit.used.rawValue,
             requiresPro: true,
+            showsExerciseName: showsExerciseName,
             metricValue: { $0.maximum(.weight, for: exercise) },
             formattedValue: { formatWeightForDisplay($0) },
             chartValue: { convertWeightForDisplayingDecimal($0) }

--- a/LOGIT/Features/Home/HomeScreen.swift
+++ b/LOGIT/Features/Home/HomeScreen.swift
@@ -468,17 +468,19 @@ struct HomeScreen: View {
             Button {
                 homeNavigationCoordinator.path.append(.exercise(exercise))
             } label: {
+                // Pinned tiles stand alone with no exercise heading around them, so each leads with
+                // the exercise name and carries its metric name in the subtitle (`showsExerciseName`).
                 switch tileType {
                 case .weight:
-                    ExerciseWeightTile(exercise: exercise, workoutSets: workoutSets)
+                    ExerciseWeightTile(exercise: exercise, workoutSets: workoutSets, showsExerciseName: true)
                 case .repetitions:
-                    ExerciseRepetitionsTile(exercise: exercise, workoutSets: workoutSets)
+                    ExerciseRepetitionsTile(exercise: exercise, workoutSets: workoutSets, showsExerciseName: true)
                 case .volume:
-                    ExerciseVolumeTile(exercise: exercise, workoutSets: workoutSets)
+                    ExerciseVolumeTile(exercise: exercise, workoutSets: workoutSets, showsExerciseName: true)
                 case .setVolume:
-                    ExerciseSetVolumeTile(exercise: exercise, workoutSets: workoutSets)
+                    ExerciseSetVolumeTile(exercise: exercise, workoutSets: workoutSets, showsExerciseName: true)
                 case .estimatedOneRepMax:
-                    ExerciseE1RMTile(exercise: exercise, workoutSets: workoutSets)
+                    ExerciseE1RMTile(exercise: exercise, workoutSets: workoutSets, showsExerciseName: true)
                 }
             }
             .buttonStyle(TileButtonStyle())

--- a/LOGIT/Features/Home/SummaryEmptyStates.swift
+++ b/LOGIT/Features/Home/SummaryEmptyStates.swift
@@ -142,7 +142,9 @@ private struct SampleExerciseTile: View {
     var body: some View {
         MetricTile(
             title: name,
-            label: .plain(NSLocalizedString("estimatedOneRepMax", comment: "")),
+            // The metric name the real E1RM pinned tile shows in its subtitle — kept in step so this
+            // teaser matches a real pinned tile rather than drifting to a different label.
+            label: .plain(NSLocalizedString("e1RM", comment: "")),
             value: value,
             unit: WeightUnit.used.rawValue,
             accent: AnyShapeStyle(color),


### PR DESCRIPTION
## What & why
The Summary's pinned-exercise tiles led with the *metric* ("Weight", "e1RM", "Volume") and showed "Current Best" as the subtitle. With no exercise context around them on the Home screen, you couldn't tell which lift a tile was for.

Now each pinned tile **leads with the exercise name** and carries the **metric name** in the subtitle slot (where "Current Best" used to be).

| | Before | After |
|---|---|---|
| Header | `Weight` | `Bench Press` |
| Subtitle | `CURRENT BEST` | `Weight` |

## How
- New `showsExerciseName` flag (default `false`) on `ExerciseBestMetricTile` / `ExerciseVolumeTile` and the four metric wrappers. When set, the title becomes `exercise.displayName` and the metric name moves to a `.plain` subtitle.
- The **exercise-detail screen is unchanged** — there the exercise is already the screen title, so the metric stays the header and "Current Best" the subtitle. Only the Home pinned grid passes `true`.
- Realigned the empty-state teaser (`SampleExerciseTile`) subtitle to `e1RM` so it keeps matching the real E1RM tile (it already previewed this exact layout).

## Verification
- `** TEST BUILD SUCCEEDED **` (app + UI test target); detail-screen call sites unchanged.
- On-simulator (iOS 26.4): pinned tiles render **Bench Press / Deadlift / Lat Pulldown / Squat** as headers; the empty-state teaser shows the full anatomy — exercise-name header + `e1RM` subtitle + value + trend pill + sparkline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
