### PR TITLE
Fix Core Data threading violation in template scan pipeline

### DIFF
--- a/LOGIT/Core/Utilities/ExerciseService.swift
+++ b/LOGIT/Core/Utilities/ExerciseService.swift
@@ -82,6 +82,9 @@ class ExerciseService {
         .flatMap { text -> AnyPublisher<Data, Swift.Error> in
             return TextProcessing.extractJsonDataFromString(text)
         }
+        // getExercises(withNameIncluding:) fetches on the main-queue viewContext, so hop off
+        // the OpenAI callback thread before touching the database.
+        .receive(on: DispatchQueue.main)
         .flatMap { jsonData -> AnyPublisher<[String: Exercise?], Swift.Error> in
             return Future<[String: Exercise?], Swift.Error> { [unowned self] promise in
                 guard
@@ -162,6 +165,9 @@ class ExerciseService {
         .flatMap { text -> AnyPublisher<Data, Swift.Error> in
             return TextProcessing.extractJsonDataFromString(text)
         }
+        // newExercise inserts into the main-queue viewContext, so hop off the OpenAI
+        // callback thread before creating the entity.
+        .receive(on: DispatchQueue.main)
         .flatMap { [unowned self] jsonData -> AnyPublisher<Exercise, Swift.Error> in
             return createExercise(from: jsonData)
         }

--- a/LOGIT/Core/Utilities/TemplateService.swift
+++ b/LOGIT/Core/Utilities/TemplateService.swift
@@ -67,6 +67,9 @@ class TemplateService: ObservableObject {
             .flatMap { [unowned self] in generateTemplateJSONText(from: $0) }
             .flatMap { TextProcessing.extractJsonDataFromString($0) }
             .flatMap { [unowned self] in createTemplateDTO(from: $0) }
+            // The DTO-to-entity step inserts into the main-queue viewContext and must not
+            // run on the background queue used for OCR, OpenAI and JSON processing above.
+            .receive(on: DispatchQueue.main)
             .flatMap { [unowned self] in createTemplateFromDTO($0) }
             .receive(on: DispatchQueue.main)
             .eraseToAnyPublisher()


### PR DESCRIPTION
## Summary

`TemplateService.createTemplate(from uiImage:)` ran its Combine chain on a global background queue via `.subscribe(on: DispatchQueue.global(qos: .userInitiated))`. The downstream steps create and mutate `NSManagedObject`s (`Template`, `TemplateSetGroup`, `Exercise`, etc.) on `Database.context` — the main-queue-confined `viewContext` — so those managed-object operations executed off the context's queue. This is the same bug class fixed in `WorkoutRecorder.saveWorkout`/`discardWorkout`.

The fix keeps OCR, OpenAI, and JSON steps on the background queue, but hops to the main queue before any managed-object work:

- **TemplateService**: `receive(on: .main)` before `createTemplateFromDTO`, so `Template`/`TemplateSetGroup`/`TemplateStandardSet` creation runs on main.
- **ExerciseService.matchExercisesToExisting**: `receive(on: .main)` before the exercise fetch. Combine delivers OpenAI results on a URLSession callback thread, so this hop is required — and it also makes the publisher *emit* on main, keeping TemplateService's downstream template-building closures on main.
- **ExerciseService.createExercise(for:)**: `receive(on: .main)` before the `newExercise` insert, off the OpenAI/URLSession callback thread.

A single outer `receive(on:)` in TemplateService alone would not have been sufficient, because `createTemplateFromDTO` subscribes to `ExerciseService` publishers that make their own OpenAI calls and resume on URLSession callback threads; the exercise fetches and inserts happen downstream of those hops. Fixing the two `ExerciseService` spots also resolves the same violation for its direct callers.

## Testing

- LOGITTests suite: 347 tests, 0 failures (3 OpenAI integration tests skipped by design) on iPhone 16 Pro, iOS 26.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)