### PR TITLE
Fix Core Data threading violation in workout/template file imports

### DIFF
--- a/LOGIT/Services/WorkoutSharingService.swift
+++ b/LOGIT/Services/WorkoutSharingService.swift
@@ -117,13 +117,15 @@ final class WorkoutSharingService {
     
     /// Imports a workout from a .logitworkout file
     /// Creates the workout and all necessary exercises, flagging new entities as temporary
+    /// Safe to call from any thread: file reading and decoding run on the calling
+    /// thread, entity creation on the context's queue.
     /// - Parameter url: URL to the .logitworkout file
     /// - Returns: The imported Workout, or throws an error
     func importWorkout(from url: URL) throws -> Workout {
         guard url.pathExtension.lowercased() == "logitworkout" else {
             throw ImportError.invalidFileFormat
         }
-        
+
         let data: Data
         if url.startAccessingSecurityScopedResource() {
             defer { url.stopAccessingSecurityScopedResource() }
@@ -131,7 +133,7 @@ final class WorkoutSharingService {
         } else {
             data = try Data(contentsOf: url)
         }
-        
+
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
         let workoutDTO: WorkoutDTO
@@ -140,19 +142,25 @@ final class WorkoutSharingService {
         } catch {
             throw ImportError.decodingFailed(error)
         }
-        
-        return try createWorkout(from: workoutDTO)
+
+        // The viewContext is main-queue-confined, but imports arrive on a
+        // background queue (see LOGITApp.handleIncomingFile).
+        return try database.context.performAndWait {
+            try createWorkout(from: workoutDTO)
+        }
     }
     
     /// Imports a template from a .logittemplate file
     /// Creates the template and all necessary exercises, flagging new entities as temporary
+    /// Safe to call from any thread: file reading and decoding run on the calling
+    /// thread, entity creation on the context's queue.
     /// - Parameter url: URL to the .logittemplate file
     /// - Returns: The imported Template, or throws an error
     func importTemplate(from url: URL) throws -> Template {
         guard url.pathExtension.lowercased() == "logittemplate" else {
             throw ImportError.invalidFileFormat
         }
-        
+
         let data: Data
         if url.startAccessingSecurityScopedResource() {
             defer { url.stopAccessingSecurityScopedResource() }
@@ -160,7 +168,7 @@ final class WorkoutSharingService {
         } else {
             data = try Data(contentsOf: url)
         }
-        
+
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
         let templateDTO: TemplateDTO
@@ -169,8 +177,12 @@ final class WorkoutSharingService {
         } catch {
             throw ImportError.decodingFailed(error)
         }
-        
-        return try createTemplate(from: templateDTO)
+
+        // The viewContext is main-queue-confined, but imports arrive on a
+        // background queue (see LOGITApp.handleIncomingFile).
+        return try database.context.performAndWait {
+            try createTemplate(from: templateDTO)
+        }
     }
     
     // MARK: - Private Export Helpers

--- a/LOGITTests/WorkoutSharingTests.swift
+++ b/LOGITTests/WorkoutSharingTests.swift
@@ -969,13 +969,75 @@ final class WorkoutSharingServiceTests: XCTestCase {
         
         XCTAssertEqual(importedWorkout.name, "Import Test")
         XCTAssertEqual(importedWorkout.setGroups.count, 2)
-        
+
         for setGroup in importedWorkout.setGroups {
             XCTAssertEqual(setGroup.sets.count, 3)
             XCTAssertNotNil(setGroup.exercise)
         }
     }
-    
+
+    // LOGITApp.handleIncomingFile dispatches imports to a background queue, so the
+    // service must confine entity creation to the context's queue itself.
+
+    func testImportWorkoutFromBackgroundQueue() throws {
+        let originalWorkout = builder.createCompleteWorkout(name: "Background Import", exerciseCount: 2, setsPerExercise: 3)
+        guard let exportURL = sharingService.exportWorkout(originalWorkout) else {
+            XCTFail("Export returned nil")
+            return
+        }
+        defer { try? FileManager.default.removeItem(at: exportURL) }
+
+        let importDB = Database(isPreview: true)
+        let importService = WorkoutSharingService(database: importDB)
+
+        let importCompleted = expectation(description: "Import completed")
+        var importResult: Result<Workout, Error>?
+        DispatchQueue.global(qos: .userInitiated).async {
+            importResult = Result { try importService.importWorkout(from: exportURL) }
+            importCompleted.fulfill()
+        }
+        wait(for: [importCompleted], timeout: 10)
+
+        let imported = try XCTUnwrap(importResult).get()
+        XCTAssertEqual(imported.name, "Background Import")
+        XCTAssertEqual(imported.setGroups.count, 2)
+        for setGroup in imported.setGroups {
+            XCTAssertEqual(setGroup.sets.count, 3)
+            XCTAssertNotNil(setGroup.exercise)
+        }
+    }
+
+    func testImportTemplateFromBackgroundQueue() throws {
+        let exercise = builder.createExercise(name: "Cable Row Custom", muscleGroup: .back)
+        let template = database.newTemplate(name: "Background Template Import")
+        let sg = database.newTemplateSetGroup(createFirstSetAutomatically: false, exercise: exercise, template: template)
+        database.newTemplateStandardSet(repetitions: 12, weight: 60000, setGroup: sg)
+        database.newTemplateStandardSet(repetitions: 10, weight: 65000, setGroup: sg)
+
+        guard let exportURL = sharingService.exportTemplate(template) else {
+            XCTFail("Export returned nil")
+            return
+        }
+        defer { try? FileManager.default.removeItem(at: exportURL) }
+
+        let importDB = Database(isPreview: true)
+        let importService = WorkoutSharingService(database: importDB)
+
+        let importCompleted = expectation(description: "Import completed")
+        var importResult: Result<Template, Error>?
+        DispatchQueue.global(qos: .userInitiated).async {
+            importResult = Result { try importService.importTemplate(from: exportURL) }
+            importCompleted.fulfill()
+        }
+        wait(for: [importCompleted], timeout: 10)
+
+        let imported = try XCTUnwrap(importResult).get()
+        XCTAssertEqual(imported.name, "Background Template Import")
+        XCTAssertEqual(imported.setGroups.count, 1)
+        XCTAssertEqual(imported.setGroups[0].sets.count, 2)
+        XCTAssertNotNil(imported.setGroups[0].exercise)
+    }
+
     func testImportWorkoutWithSuperSets() throws {
         let workout = database.newWorkout(name: "Superset Import", date: Date())
         let exA = builder.createExercise(name: "Bench Press", muscleGroup: .chest)


### PR DESCRIPTION
## Problem

Opening a shared `.logitworkout` or `.logittemplate` file routes through `LOGITApp.handleIncomingFile`, which dispatches to `DispatchQueue.global(qos: .userInitiated)` and then calls `WorkoutSharingService.importWorkout(from:)` / `importTemplate(from:)`. Those methods create and mutate `NSManagedObject`s — `database.newWorkout()`, the set/exercise factories, `flagAsTemporary`'s `obtainPermanentIDs`, and the exercise-matching fetches — all against `Database.context`, which is the **main-queue-confined viewContext**.

Doing that work off the main queue violates Core Data's threading contract. It's undefined behavior that can corrupt the object graph or crash, and it typically only surfaces with the Core Data concurrency debugger (`-com.apple.CoreData.ConcurrencyDebug 1`) enabled — so it can ship silently.

This is the same bug class as the CloudKit save fix in #59, and as `WorkoutRecorder.saveWorkout`/`discardWorkout` (still live on `main` — tracked separately).

## Fix

Keep file reading and JSON decoding on the calling thread (so I/O stays off the main thread), then confine **only** the managed-object work to the context's queue via `database.context.performAndWait { ... }`. Because the viewContext runs on the main queue, `performAndWait` executes inline when already on main, so the ~60 existing synchronous callers (including all sharing tests) behave exactly as before. This mirrors the `performAndWait` idiom already used in `Database.discardUnsavedChanges`.

`handleIncomingFile` itself needs no change: its background dispatch keeps I/O off the main thread, and its main-queue hop for the `@State` updates is still correct.

## Tests

Adds `testImportWorkoutFromBackgroundQueue` and `testImportTemplateFromBackgroundQueue`, which run the import from a global queue to exercise the real cross-thread path.

Verified with:
```
xcodebuild test -project LOGIT.xcodeproj -scheme LOGIT \
  -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=26.0' \
  -only-testing:LOGITTests
```
**349 tests executed, 0 failures** (3 pre-existing skips), including both new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)