### PR TITLE
Fix Core Data threading violation in saveWorkout/discardWorkout

### DIFF
--- a/LOGIT/Features/Workout/WorkoutRecorder/WorkoutRecorder.swift
+++ b/LOGIT/Features/Workout/WorkoutRecorder/WorkoutRecorder.swift
@@ -87,11 +87,13 @@ final class WorkoutRecorder: ObservableObject {
 
         workout.isCurrentWorkout = false
         objectWillChange.send()
-        // Use a local copy of the workout for the background operations to avoid race conditions
+        // Use a local copy of the workout for the deferred cleanup to avoid race conditions
         let workoutCopy = workout
         self.workout = nil
 
-        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+        // The context is main-queue-confined, so the workout must only be read and mutated
+        // on its queue — never on a global background queue.
+        database.context.perform { [weak self] in
             guard let database = self?.database else {
                 Self.logger.error("Failed to clean up workout after finish: self already uninitialized")
                 return
@@ -112,14 +114,14 @@ final class WorkoutRecorder: ObservableObject {
 
             workoutCopy.sets.filter { !$0.hasEntry }.forEach { database.delete($0) }
 
-            // This refresh is needed, as otherwise workoutCopy.isEmpty will still put out false
-            // even if all the WorkoutSetGroups have been deleted, as the workoutCopy object has not refreshed yet
-
-            if workoutCopy.isEmpty {
-                database.delete(workoutCopy, saveContext: true)
+            // database.delete only enqueues the deletions on the context's queue, so evaluate
+            // isEmpty in a follow-up block that runs after they have been processed.
+            database.context.perform {
+                if workoutCopy.isEmpty {
+                    database.delete(workoutCopy, saveContext: true)
+                }
+                database.save()
             }
-
-            database.save()
         }
     }
 
@@ -135,7 +137,8 @@ final class WorkoutRecorder: ObservableObject {
         let workoutCopy = workout
         self.workout = nil
 
-        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+        // See saveWorkout: the workout must only be accessed on the context's queue.
+        database.context.perform { [weak self] in
             guard let database = self?.database else {
                 Self.logger.error("Failed to discard workout: self already uninitialized")
                 return

--- a/LOGITTests/ServicesTests.swift
+++ b/LOGITTests/ServicesTests.swift
@@ -681,6 +681,129 @@ final class WorkoutRecorderTests: XCTestCase {
         XCTAssertEqual(restBehavior, .timer(120))
     }
 
+    // MARK: - Save / Discard Workout
+
+    /// saveWorkout and discardWorkout run their cleanup asynchronously on the context's
+    /// queue, and those blocks enqueue follow-up blocks of their own. Each round waits for
+    /// one sentinel block, so `depth` rounds drain `depth` levels of nested enqueues.
+    private func drainContextQueue(depth: Int = 5) {
+        for _ in 0..<depth {
+            let drained = expectation(description: "context queue drained")
+            database.context.perform { drained.fulfill() }
+            wait(for: [drained], timeout: 2)
+        }
+    }
+
+    private func fetchWorkout(with id: UUID) -> Workout? {
+        (database.fetch(
+            Workout.self,
+            predicate: NSPredicate(format: "id == %@", id as CVarArg)
+        ) as? [Workout])?.first
+    }
+
+    func testSaveWorkoutPersistsWorkoutAndDeletesSetsWithoutEntries() {
+        workoutRecorder.startWorkout()
+        guard let workoutID = workoutRecorder.workout?.id else {
+            XCTFail("Expected started workout with id")
+            return
+        }
+        let setGroup = database.newWorkoutSetGroup(
+            createFirstSetAutomatically: false,
+            exercise: database.newExercise(name: "Bench Press", muscleGroup: .chest),
+            workout: workoutRecorder.workout
+        )
+        database.newStandardSet(repetitions: 12, weight: 60000, setGroup: setGroup)
+        database.newStandardSet(setGroup: setGroup)
+
+        workoutRecorder.saveWorkout()
+
+        XCTAssertNil(workoutRecorder.workout)
+
+        drainContextQueue()
+
+        guard let workout = fetchWorkout(with: workoutID) else {
+            XCTFail("Expected workout to be persisted")
+            return
+        }
+        XCTAssertFalse(workout.isCurrentWorkout)
+        XCTAssertFalse(workout.name?.isEmpty ?? true)
+        XCTAssertNotNil(workout.endDate)
+        XCTAssertEqual(workout.sets.count, 1)
+        XCTAssertTrue(workout.sets.allSatisfy { $0.hasEntry })
+    }
+
+    func testSaveWorkoutDeletesWorkoutWhenNoSetHasEntries() {
+        workoutRecorder.startWorkout()
+        guard let workoutID = workoutRecorder.workout?.id else {
+            XCTFail("Expected started workout with id")
+            return
+        }
+        let setGroup = database.newWorkoutSetGroup(
+            createFirstSetAutomatically: false,
+            workout: workoutRecorder.workout
+        )
+        database.newStandardSet(setGroup: setGroup)
+
+        workoutRecorder.saveWorkout()
+        drainContextQueue()
+
+        XCTAssertNil(workoutRecorder.workout)
+        XCTAssertNil(fetchWorkout(with: workoutID))
+    }
+
+    func testSaveWorkoutConvertsSuperSetsWithoutSecondaryExerciseToStandardSets() {
+        workoutRecorder.startWorkout()
+        guard let workoutID = workoutRecorder.workout?.id else {
+            XCTFail("Expected started workout with id")
+            return
+        }
+        let setGroup = database.newWorkoutSetGroup(
+            createFirstSetAutomatically: false,
+            workout: workoutRecorder.workout
+        )
+        database.newSuperSet(
+            repetitionsFirstExercise: 10,
+            weightFirstExercise: 50000,
+            setGroup: setGroup
+        )
+
+        workoutRecorder.saveWorkout()
+        drainContextQueue()
+
+        guard let workout = fetchWorkout(with: workoutID) else {
+            XCTFail("Expected workout to be persisted")
+            return
+        }
+        XCTAssertEqual(workout.sets.count, 1)
+        guard let standardSet = workout.sets.first as? StandardSet else {
+            XCTFail("Expected super set to be converted to a standard set")
+            return
+        }
+        XCTAssertEqual(standardSet.repetitions, 10)
+        XCTAssertEqual(standardSet.weight, 50000)
+    }
+
+    func testDiscardWorkoutDeletesWorkout() {
+        workoutRecorder.startWorkout()
+        guard let workoutID = workoutRecorder.workout?.id else {
+            XCTFail("Expected started workout with id")
+            return
+        }
+        let setGroup = database.newWorkoutSetGroup(
+            createFirstSetAutomatically: false,
+            workout: workoutRecorder.workout
+        )
+        database.newStandardSet(repetitions: 10, weight: 50000, setGroup: setGroup)
+
+        workoutRecorder.discardWorkout()
+
+        XCTAssertNil(workoutRecorder.workout)
+
+        drainContextQueue()
+
+        XCTAssertNil(fetchWorkout(with: workoutID))
+    }
+
 }
 
 final class ChronographTests: XCTestCase {


### PR DESCRIPTION
## Problem

`saveWorkout()` and `discardWorkout()` in `WorkoutRecorder` dispatched to `DispatchQueue.global(qos: .userInitiated)` and then read and mutated the workout — `name`, `endDate`, reading `setGroups`, deleting entry-less sets — directly on that background thread. `Database.context` is the **main-queue-confined `viewContext`**, so this violated Core Data's threading rules and could cause intermittent crashes or corrupted saves.

The background dispatch bought nothing: `Database.save()`/`delete()` already funnel their work through `context.perform` onto the main queue. Only the raw property access/reads in between were on the wrong thread.

## Fix

Wrap the cleanup in `database.context.perform { ... }` so all managed-object access stays on the context's queue.

## Second bug fixed in passing

The stale `// This refresh is needed…` comment pointed at real breakage. `database.delete()` only *enqueues* deletions on the context's queue, so the old `workoutCopy.isEmpty` check ran **before** the entry-less sets were actually deleted (the `refreshObjects()` call that used to make this work was removed long ago). Empty workouts were therefore never cleaned up. The `isEmpty` check now runs in a follow-up `context.perform` block that executes after the deletions, so finishing a workout with no entries deletes it as intended.

## Verification

- **ConcurrencyDebug proof:** with `-com.apple.CoreData.ConcurrencyDebug 1`, the old code traps mid-test — `EXC_BREAKPOINT` in CoreData's `_PFAssertSafeMultiThreadedAccess_impl`, faulting frame `closure #1 in WorkoutRecorder.saveWorkout()` / `discardWorkout()` on `com.apple.root.user-initiated-qos`. The fixed code passes the same tests with the flag on.
- **Full suite:** 348 tests, 0 failures on iPhone 16 Pro (iOS 26.0).
- Added 4 regression tests: save persistence + entry-less set purge, empty-workout deletion, single-exercise super-set conversion, discard deletion.

## Follow-ups (not in this PR)

Two more sites have the same bug class and are being fixed separately: the `.logitworkout`/`.logittemplate` file-import path in `LOGITApp.handleIncomingFile`, and `TemplateService.createTemplate(from:)`'s Combine chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)