### PR TITLE
Let workouts save without a duration; fix date/time sheet not opening

### DIFF
--- a/LOGIT/Data/EntityExtensions/Workout+.swift
+++ b/LOGIT/Data/EntityExtensions/Workout+.swift
@@ -88,6 +88,16 @@ extension Workout {
         }
     }
 
+    /// Whether the workout holds enough to be saved to history from the editor: a start date (its
+    /// place in the timeline) and at least one set group.
+    ///
+    /// Duration is deliberately *not* required. A workout with no end date simply has no duration —
+    /// every consumer (history cell, detail screen, duration stat) already omits it when `endDate`
+    /// is nil — so forcing one would only fabricate a value the user never entered.
+    var canBeSavedToHistory: Bool {
+        date != nil && !setGroups.isEmpty
+    }
+
     func remove(setGroup: WorkoutSetGroup) {
         setGroups = setGroups.filter { $0 != setGroup }
     }

--- a/LOGIT/Features/Workout/WorkoutEditorScreen.swift
+++ b/LOGIT/Features/Workout/WorkoutEditorScreen.swift
@@ -13,6 +13,11 @@ struct WorkoutEditorScreen: View {
         case workoutName, workoutSetEntry(index: IntegerField.Index)
     }
 
+    /// One iOS context-menu dismissal animation. The date/time editor is deferred by this long
+    /// after its menu item is tapped so its (sheet-on-sheet) presentation doesn't overlap the
+    /// menu closing; see the "Edit date & time" button.
+    private static let menuDismissAnimationDuration: TimeInterval = 0.35
+
     // MARK: - Environment
 
     @EnvironmentObject var database: Database
@@ -216,12 +221,14 @@ struct WorkoutEditorScreen: View {
                             Label(NSLocalizedString("rename", comment: ""), systemImage: "pencil")
                         }
                         Button {
-                            // Defer presenting to the next runloop turn so the Menu's dismissal and the
-                            // sheet's presentation land in separate transactions. Flipping this flag
-                            // synchronously inside the Menu action entangles the two, and because the
-                            // date editor is a sheet-on-sheet, the entanglement makes it bounce in and
-                            // out several times before settling.
-                            DispatchQueue.main.async {
+                            // Present only after the menu's dismissal animation has finished. The date
+                            // editor is a sheet-on-sheet (it opens from the always-present exercise
+                            // selection sheet), so its presentation is fragile while another transition
+                            // is in flight: flipping the flag synchronously made it bounce in and out,
+                            // and deferring by a single runloop turn (`main.async`) still overlapped the
+                            // menu dismissal — the dismissal then cancelled the presentation and nothing
+                            // appeared. Waiting one menu-animation cycle lets the two stay separate.
+                            DispatchQueue.main.asyncAfter(deadline: .now() + Self.menuDismissAnimationDuration) {
                                 isEditingStartEndDate = true
                             }
                         } label: {
@@ -236,8 +243,10 @@ struct WorkoutEditorScreen: View {
                                     .lineLimit(1)
                                 HStack(spacing: 5) {
                                     Text(workout.date?.formatted(.dateTime.day().month().year()) ?? "")
-                                    Text("•")
-                                    Text(workoutDurationString)
+                                    if let workoutDurationString {
+                                        Text("•")
+                                        Text(workoutDurationString)
+                                    }
                                 }
                                 .font(.caption)
                                 .foregroundStyle(Color.secondaryLabel)
@@ -285,9 +294,11 @@ struct WorkoutEditorScreen: View {
                 }
             }
             .onAppear {
+                // Guarantee a start date (a workout's place in history); `newWorkout()` already sets
+                // one, this is just defensive. The end date stays untouched — duration is optional,
+                // so a workout with none is saved without one rather than getting a fabricated value.
                 if workout.date == nil {
                     workout.date = .now
-                    workout.endDate = .now.addingTimeInterval(1000)
                 }
                 refreshOnChange()
                 exerciseSelectionPresentationDetent = workout.isEmpty ? .medium : .height(BOTTOM_SHEET_SMALL)
@@ -301,8 +312,10 @@ struct WorkoutEditorScreen: View {
         Binding(get: { workout.name ?? "" }, set: { workout.name = $0 })
     }
 
-    private var workoutDurationString: String {
-        guard let start = workout.date, let end = workout.endDate else { return "0:00" }
+    /// The header's duration string, or nil when the workout has no end date — a workout without a
+    /// logged duration shows no duration rather than a fabricated "0:00".
+    private var workoutDurationString: String? {
+        guard let start = workout.date, let end = workout.endDate else { return nil }
         let hours = Calendar.current.dateComponents([.hour], from: start, to: end).hour ?? 0
         let minutes =
             (Calendar.current.dateComponents([.minute], from: start, to: end).minute ?? 0) % 60
@@ -310,7 +323,7 @@ struct WorkoutEditorScreen: View {
     }
 
     private var canSaveWorkout: Bool {
-        workout.date != nil && workout.endDate != nil && !workout.setGroups.isEmpty
+        workout.canBeSavedToHistory
     }
 
     // MARK: - Autosave

--- a/LOGITTests/EntityExtensionTests.swift
+++ b/LOGITTests/EntityExtensionTests.swift
@@ -512,8 +512,44 @@ final class EntityExtensionTests: XCTestCase {
             workout: workout
         )
         database.newStandardSet(repetitions: 0, weight: 0, setGroup: setGroup)
-        
+
         XCTAssertFalse(workout.hasEntries, "Workout with empty sets should not have entries")
+    }
+
+    // MARK: - Save Eligibility Tests
+
+    /// A workout with a date and at least one set group can be saved even with no end date —
+    /// duration is optional, so the editor must not require it (the "0:00" default is never
+    /// fabricated).
+    func testCanBeSavedToHistoryWithoutDuration() {
+        let workout = database.newWorkout(name: "No Duration")
+        database.newWorkoutSetGroup(workout: workout)
+        XCTAssertNil(workout.endDate, "newWorkout leaves the end date unset")
+
+        XCTAssertTrue(
+            workout.canBeSavedToHistory,
+            "A dated workout with set groups is saveable without a duration"
+        )
+    }
+
+    /// An empty workout (no set groups) still can't be saved, duration or not.
+    func testCannotSaveEmptyWorkout() {
+        let workout = database.newWorkout(name: "Empty")
+        workout.endDate = workout.date?.addingTimeInterval(3600)
+
+        XCTAssertFalse(
+            workout.canBeSavedToHistory,
+            "A workout with no set groups is not saveable even with a duration"
+        )
+    }
+
+    /// A workout with a duration set is of course still saveable.
+    func testCanBeSavedToHistoryWithDuration() {
+        let workout = database.newWorkout(name: "With Duration")
+        database.newWorkoutSetGroup(workout: workout)
+        workout.endDate = workout.date?.addingTimeInterval(3600)
+
+        XCTAssertTrue(workout.canBeSavedToHistory)
     }
     
     // MARK: - WorkoutSet Match Tests


### PR DESCRIPTION
Two fixes to the manual workout editor (the "+" flow in History).

## 1. Save button was permanently disabled

A workout added from history gets a start date (from `newWorkout()`) but no `endDate`, and the Save gate required **both** `date` and `endDate` — so no matter how many exercises/sets you entered, Save stayed greyed out.

Duration is now **optional**:
- `canSaveWorkout` defers to a new, testable model rule `Workout.canBeSavedToHistory` = a start date + at least one set group.
- The editor no longer fabricates a default `endDate` on appear.
- The header hides the duration entirely instead of showing a made-up `0:00`.

This is safe and consistent with the rest of the app: every `endDate` consumer (history cell, detail screen, duration stat) already omits a missing duration, and the sharing importer already creates zero-duration workouts (`endDate = dto.endDate ?? dto.date`). A workout with no duration entered simply has none, rather than an invented ~16-minute value.

## 2. "Edit date & time" sheet wouldn't open

Regression from #57. That commit changed the menu trigger to a single `DispatchQueue.main.async` to stop the sheet **bouncing**, but one runloop turn still overlaps the ~0.35s menu-dismiss animation. Because the date editor is a **sheet-on-sheet** (presented from the always-open exercise-selection sheet), the menu dismissal then cancelled the presentation and **nothing appeared**.

Fix: defer the flag flip by one full menu-dismiss animation cycle (named constant `menuDismissAnimationDuration = 0.35`) so the dismissal and the presentation never overlap.

> Note: fix #2 is a presentation-timing change, not something covered by a unit test — verified by reasoning about the transaction race; confirmed opening reliably on device.

## Tests

Three tests for the save-eligibility rule in `EntityExtensionTests.swift`: saveable without a duration, saveable with one, not saveable when empty. Full `LOGITTests` suite passes (350 tests, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)