### PR TITLE
Fix Core Data 134020 save faults from duplicate model copies in tests

### DIFF
--- a/LOGIT/Data/Database/Database.swift
+++ b/LOGIT/Data/Database/Database.swift
@@ -12,6 +12,22 @@ import OSLog
 public class Database: ObservableObject {
     // MARK: - Constants
 
+    /// Loaded exactly once and shared by every container. Each additional
+    /// `NSManagedObjectModel(contentsOf:)` copy — which `NSPersistentContainer(name:)` performs
+    /// per instance — registers a competing entity claim for every `NSManagedObject` subclass,
+    /// making `+entity`, and with it `Entity(context:)`, ambiguous as soon as a second `Database`
+    /// exists (tests, previews). An object bound to one copy but saved through a coordinator
+    /// holding another fails with Core Data error 134020.
+    static let model: NSManagedObjectModel = {
+        guard
+            let modelURL = Bundle(for: Database.self).url(forResource: "LOGIT", withExtension: "momd"),
+            let model = NSManagedObjectModel(contentsOf: modelURL)
+        else {
+            fatalError("Database: Failed to load the LOGIT Core Data model from the app bundle")
+        }
+        return model
+    }()
+
     private let container: NSPersistentContainer
     private let TEMPORARY_OBJECT_IDS_KEY = "temporaryObjectIds"
     private var cancellables = Set<AnyCancellable>()
@@ -30,19 +46,29 @@ public class Database: ObservableObject {
 
     /// - Parameters:
     ///   - isPreview: seeds the curated preview dataset (SwiftUI previews, fastlane fixtures).
-    ///   - inMemory: backs the store with `/dev/null` instead of the on-disk SQLite file.
-    ///     Defaults to `isPreview`; pass `true` on its own for an unseeded throwaway store
-    ///     (launch scenarios, see `TestScenario`).
+    ///   - inMemory: backs the store with a per-instance throwaway temporary file instead
+    ///     of the app's SQLite store. Defaults to `isPreview`; pass `true` on its own for
+    ///     an unseeded throwaway store (launch scenarios, see `TestScenario`).
     init(isPreview: Bool = false, inMemory: Bool? = nil) {
         self.isPreview = isPreview
         let usesInMemoryStore = inMemory ?? isPreview
-        container = NSPersistentCloudKitContainer(name: "LOGIT")
+        container = NSPersistentCloudKitContainer(name: "LOGIT", managedObjectModel: Self.model)
         let description = container.persistentStoreDescriptions.first
         description?.setOption(true as NSNumber, forKey: NSMigratePersistentStoresAutomaticallyOption)
         description?.setOption(true as NSNumber, forKey: NSInferMappingModelAutomaticallyOption)
 
         if usesInMemoryStore {
-            container.persistentStoreDescriptions.first!.url = URL(fileURLWithPath: "/dev/null")
+            // The URL must be unique per instance: throwaway stores sharing one URL (the
+            // old /dev/null trick) collide — when a later container re-initializes the
+            // shared store, saves still queued on an earlier instance (finished tests,
+            // discarded previews) fail with Core Data 134020 "model configuration is
+            // incompatible".
+            container.persistentStoreDescriptions.first!.url = FileManager.default
+                .temporaryDirectory
+                .appendingPathComponent("LOGIT-ephemeral-\(UUID().uuidString).sqlite")
+            // Unlike /dev/null, this is a real SQLite file the CloudKit mirror could
+            // sync; throwaway stores must stay strictly local.
+            description?.cloudKitContainerOptions = nil
         }
         loadStores()
         if isPreview {

--- a/LOGITTests/DatabaseTests.swift
+++ b/LOGITTests/DatabaseTests.swift
@@ -381,8 +381,13 @@ final class TemplateModelMigrationTests: XCTestCase {
             NSManagedObjectModel(contentsOf: momdURL.appendingPathComponent("LOGIT 6.0.mom")),
             "Model version 6 must stay in the bundle for migration"
         )
-        // Loading the .momd itself resolves to the current version (7)
-        let currentModel = try XCTUnwrap(NSManagedObjectModel(contentsOf: momdURL))
+        // This throwaway copy must not claim the NSManagedObject subclasses — a second claim
+        // makes `+entity` ambiguous for every test that runs afterwards (see `Database.model`).
+        // The v6 side only uses string-keyed inserts and KVC, so plain NSManagedObject suffices.
+        // Version hashes come from the schema alone, so migration behavior is unaffected.
+        v6Model.entities.forEach { $0.managedObjectClassName = "NSManagedObject" }
+        // The current version must be the shared model, never a second loaded copy (same reason).
+        let currentModel = Database.model
         XCTAssertNotNil(
             currentModel.entitiesByName["Template"]?.attributesByName["descriptionText"],
             "Current model must be version 7 with the new attributes"


### PR DESCRIPTION
## Problem

Full-suite `LOGITTests` runs logged two `Failed to save context after retry` faults with `Code=134020 "The model configuration used to open the store is incompatible with the one that was used to create the store."` (observed in `WorkoutSharingServiceTests`). Tests passed, but the noise would mask a genuinely failed save.

The suspected cause was every in-memory `Database` sharing a single `/dev/null` store URL. That was a real smell, but **not** the mechanism.

## Root cause

`NSPersistentContainer(name:)` loads a **fresh `NSManagedObjectModel` copy per instance** (~322 per suite run). Once a second `Database` exists, every `NSManagedObject` subclass is claimed by multiple model copies, so `+entity` — and therefore `Entity(context:)` — becomes ambiguous (the log shows 13 `Multiple NSEntityDescriptions claim the NSManagedObject subclass …` warnings). An object bound to one model copy but saved through a coordinator holding another fails with 134020.

Only two tests tripped it — the ones that build an `importDB` *between* creating the class-level `database` and calling `database.newWorkout(...)`, so the workout binds to `importDB`'s model but saves through `database`'s coordinator.

## Fix

- **One shared model**: a `static let Database.model`, loaded once and passed to every `NSPersistentCloudKitContainer(name:managedObjectModel:)`. Production is unaffected — same model file, and the app only ever creates one `Database`.
- **Real store isolation**: each in-memory instance gets `tmp/LOGIT-ephemeral-<UUID>.sqlite` and nils `cloudKitContainerOptions` — unlike `/dev/null`, a real file could be synced by the CloudKit mirror, so throwaway stores stay strictly local.
- **De-poisoned the migration test**: `TemplateModelMigrationTests` was loading two extra model copies that re-poisoned `+entity` process-wide. It now reuses `Database.model` for the current version and strips `managedObjectClassName` from its throwaway v6 copy (it only uses string-keyed inserts and KVC; version hashes come from the schema, so migration coverage is unchanged).

## Verification

Full `LOGITTests` suite on iPhone 16 Pro / iOS 26.0: **`** TEST SUCCEEDED **`, 349 tests, 0 failures, 3 skipped.**

| Signal | Before | After |
|---|---|---|
| `Failed to save context` | 2 | 0 |
| `134020` occurrences | 4 | 0 |
| `Multiple NSEntityDescriptions` warnings | 13 | 0 |
| Total `[error]` log lines | 9,965 | 82 |

The remaining 82 `[error]` lines are pre-existing `Declared Objective-C type "[UUID]"…` transformable-attribute complaints, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)