### PR TITLE
Keep the workout recorder smooth while typing set values

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -15,6 +15,7 @@ The states, all driven by launch arguments (DEBUG builds only, implemented in
 | One workout (single data points, fresh trends) | `-SCENARIO one` |
 | Many workouts (long-time user, rich history) | `-SCENARIO many` |
 | Free tier (Pro locked) | add `-UITEST_FORCE_FREE` to any scenario |
+| Stress (2 years dense history + in-progress workout; for performance work, not part of the standard matrix) | `-SCENARIO stress`, add `-UITEST_SHOW_RECORDER 1` to land in the recorder |
 
 Standard matrix for a change: **empty, one, many (Pro implied on the
 simulator) + the free variant of the most relevant scenario.** If the change

--- a/LOGIT/App/TestScenarios.swift
+++ b/LOGIT/App/TestScenarios.swift
@@ -12,6 +12,10 @@
 //              trends without a prior period, singular strings
 //      many    long-time user: the curated preview dataset (same as the
 //              marketing screenshots) minus the in-progress workout
+//      stress  power user: two years of dense history (hundreds of workouts,
+//              thousands of sets) plus an in-progress workout — for
+//              performance work; combine with -UITEST_SHOW_RECORDER to land
+//              in the recorder mid-session
 //
 //  Combine with `-UITEST_FORCE_FREE` to see the free tier (DEBUG simulator
 //  builds force-unlock Pro otherwise). Scenarios are ignored in Release
@@ -25,6 +29,7 @@ enum TestScenario: String {
     case empty
     case one
     case many
+    case stress
 
     /// Parsed once at process start from `-SCENARIO <name>`. Always `nil` in
     /// Release builds, so scenario branches are unreachable outside DEBUG.
@@ -35,7 +40,7 @@ enum TestScenario: String {
               args.indices.contains(flagIndex + 1)
         else { return nil }
         guard let scenario = TestScenario(rawValue: args[flagIndex + 1]) else {
-            NSLog("TestScenario: unknown scenario '%@' — expected empty|one|many", args[flagIndex + 1])
+            NSLog("TestScenario: unknown scenario '%@' — expected empty|one|many|stress", args[flagIndex + 1])
             return nil
         }
         return scenario
@@ -58,7 +63,7 @@ enum TestScenario: String {
         overrides["setupDone"] = true
         overrides["weightUnit"] = WeightUnit.kg.rawValue
         // `empty` shows the no-goal state, the other scenarios a realistic goal.
-        overrides["workoutPerWeekTarget"] = self == .empty ? -1 : 4
+        overrides["workoutPerWeekTarget"] = self == .empty ? -1 : self == .stress ? 2 : 4
         // Per-user layout state stored as Data (object URIs / JSON) must not
         // leak in from the real store — the URIs wouldn't resolve against the
         // in-memory store anyway. A string value makes the Data reads fail so
@@ -87,7 +92,7 @@ enum TestScenario: String {
     /// created, before any views or services read from it.
     func seedAtLaunch(into database: Database) {
         switch self {
-        case .empty, .one:
+        case .empty, .one, .stress:
             break
         case .many:
             // The curated dataset the marketing screenshots use, but without
@@ -109,6 +114,10 @@ enum TestScenario: String {
     /// so the single workout references built-in exercises instead of
     /// creating duplicate-looking copies (same approach as DemoWorkoutSeeder).
     func seedAfterDefaultContentLoaded(database: Database) {
+        if self == .stress {
+            seedStressData(database: database)
+            return
+        }
         guard self == .one else { return }
 
         let bench = exercise("_default.exercise.barbellBenchPress", "Bench Press", .chest, database)
@@ -138,6 +147,83 @@ enum TestScenario: String {
 
         database.save()
         NSLog("TestScenario: seeded single-workout scenario")
+    }
+
+    /// Two years of dense, deterministic history — two sessions per week
+    /// alternating push/pull, four exercises with four sets each — plus an
+    /// in-progress push workout (`isCurrentWorkout`). This is the data shape
+    /// where per-keystroke work in the recorder becomes visible: every main
+    /// exercise accumulates 400+ historical sets, so anything that scans an
+    /// exercise's history per UI update gets amplified to realistic cost.
+    private func seedStressData(database: Database) {
+        let bench = exercise("_default.exercise.barbellBenchPress", "Bench Press", .chest, database)
+        let overheadPress = exercise("_default.exercise.overheadPress", "Overhead Press", .shoulders, database)
+        let inclineBench = exercise("_default.exercise.inclineBenchPress", "Incline Bench Press", .chest, database)
+        let tricepsExtensions = exercise("_default.exercise.tricepsExtensions", "Triceps Extensions", .triceps, database)
+        let deadlift = exercise("_default.exercise.deadlift", "Deadlift", .back, database)
+        let rows = exercise("_default.exercise.barbellRows", "Barbell Rows", .back, database)
+        let latPulldowns = exercise("_default.exercise.latPulldowns", "Lat Pulldowns", .back, database)
+        let bicepsCurls = exercise("_default.exercise.bicepsCurls", "Biceps Curls", .biceps, database)
+
+        let pushExercises = [bench, overheadPress, inclineBench, tricepsExtensions]
+        let pullExercises = [deadlift, rows, latPulldowns, bicepsCurls]
+        let baseWeights = [60000, 40000, 45000, 25000, 120000, 70000, 55000, 30000]
+
+        let calendar = Calendar.current
+        let sessionCount = 208 // 2 years, 2 sessions/week
+        for session in 0 ..< sessionCount {
+            let daysBack = (sessionCount - session) * 7 / 2 + 1
+            let date = calendar.date(byAdding: .day, value: -daysBack, to: .now)!
+            let isPush = session % 2 == 0
+            let workout = database.newWorkout(name: isPush ? "Push Day" : "Pull Day", date: date)
+            workout.endDate = date.addingTimeInterval(70 * 60)
+            let exercises = isPush ? pushExercises : pullExercises
+            for (slot, exercise) in exercises.enumerated() {
+                let weightIndex = (isPush ? 0 : 4) + slot
+                // Slow linear progression with a deterministic wobble so
+                // trends, records, and current bests all have real signal.
+                let progress = session / 8 * 2500
+                let wobble = (session % 3) * 1250 - 1250
+                let weight = baseWeights[weightIndex] + progress + wobble
+                let group = database.newWorkoutSetGroup(
+                    createFirstSetAutomatically: false,
+                    exercise: exercise,
+                    workout: workout
+                )
+                for setIndex in 0 ..< 4 {
+                    database.newStandardSet(
+                        repetitions: 12 - setIndex - (session % 3),
+                        weight: weight,
+                        setGroup: group
+                    )
+                }
+            }
+        }
+
+        // The in-progress workout the recorder picks up: push day, first
+        // half of the sets already entered, the rest waiting for input.
+        let start = Date.now.addingTimeInterval(-23 * 60)
+        let current = database.newWorkout(name: "Push Day", date: start)
+        current.isCurrentWorkout = true
+        for (slot, exercise) in pushExercises.enumerated() {
+            let group = database.newWorkoutSetGroup(
+                createFirstSetAutomatically: false,
+                exercise: exercise,
+                workout: current
+            )
+            let weight = baseWeights[slot] + sessionCount / 8 * 2500
+            for setIndex in 0 ..< 4 {
+                let isEntered = slot < 2 || (slot == 2 && setIndex < 2)
+                database.newStandardSet(
+                    repetitions: isEntered ? 12 - setIndex : 0,
+                    weight: isEntered ? weight : 0,
+                    setGroup: group
+                )
+            }
+        }
+
+        database.save()
+        NSLog("TestScenario: seeded stress scenario (%d workouts)", sessionCount + 1)
     }
 
     /// The built-in exercise matching the default-library name key, or a new

--- a/LOGIT/Data/EntityExtensions/Exercise+.swift
+++ b/LOGIT/Data/EntityExtensions/Exercise+.swift
@@ -45,13 +45,7 @@ extension Exercise {
     }
 
     var setGroups: [WorkoutSetGroup] {
-        return (setGroupOrder ?? .emptyList)
-            .compactMap { id in
-                (setGroups_?.allObjects as? [WorkoutSetGroup])?
-                    .first { setGroup in
-                        setGroup.id == id
-                    }
-            }
+        resolvedOrder(of: setGroups_, by: setGroupOrder)
     }
 
     @objc var firstLetterOfName: String {
@@ -59,14 +53,7 @@ extension Exercise {
     }
 
     var templateSetGroups: [TemplateSetGroup] {
-        return (templateSetGroupOrder ?? .emptyList)
-            .compactMap { id in
-                (templateSetGroups_?.allObjects as? [TemplateSetGroup])?
-                    .first {
-                        templateSetGroup in
-                        templateSetGroup.id == id
-                    }
-            }
+        resolvedOrder(of: templateSetGroups_, by: templateSetGroupOrder)
     }
 
     var sets: [WorkoutSet] {

--- a/LOGIT/Data/EntityExtensions/Template+.swift
+++ b/LOGIT/Data/EntityExtensions/Template+.swift
@@ -82,13 +82,7 @@ extension Template {
 
     var setGroups: [TemplateSetGroup] {
         get {
-            return (templateSetGroupOrder ?? .emptyList)
-                .compactMap { id in
-                    (setGroups_?.allObjects as? [TemplateSetGroup])?
-                        .first { templateSetGroup in
-                            templateSetGroup.id == id
-                        }
-                }
+            resolvedOrder(of: setGroups_, by: templateSetGroupOrder)
         }
         set {
             templateSetGroupOrder = newValue.map { $0.id! }

--- a/LOGIT/Data/EntityExtensions/TemplateSetGroup+.swift
+++ b/LOGIT/Data/EntityExtensions/TemplateSetGroup+.swift
@@ -18,8 +18,7 @@ extension TemplateSetGroup {
 
     public var sets: [TemplateSet] {
         get {
-            return (setOrder ?? .emptyList)
-                .compactMap { id in (sets_?.allObjects as? [TemplateSet])?.first { $0.id == id } }
+            resolvedOrder(of: sets_, by: setOrder)
         }
         set {
             setOrder = newValue.map { $0.id! }
@@ -29,8 +28,7 @@ extension TemplateSetGroup {
 
     private var exercises: [Exercise] {
         get {
-            return (exerciseOrder ?? .emptyList)
-                .compactMap { id in (exercises_?.allObjects as? [Exercise])?.first { $0.id == id } }
+            resolvedOrder(of: exercises_, by: exerciseOrder)
         }
         set {
             exerciseOrder = newValue.map { $0.id! }

--- a/LOGIT/Data/EntityExtensions/Workout+.swift
+++ b/LOGIT/Data/EntityExtensions/Workout+.swift
@@ -24,6 +24,37 @@ extension Workout {
     }
 }
 
+// MARK: - Ordered Relationship Resolution
+
+/// Common shape of every entity that lives in an ordered to-many
+/// relationship: the id its parent's persisted order list refers to.
+protocol UUIDOrderable: NSObject {
+    var id: UUID? { get }
+}
+
+extension WorkoutSetGroup: UUIDOrderable {}
+extension WorkoutSet: UUIDOrderable {}
+extension Exercise: UUIDOrderable {}
+extension TemplateSetGroup: UUIDOrderable {}
+extension TemplateSet: UUIDOrderable {}
+
+/// Resolves a parent's persisted id-order list against its unordered to-many
+/// relationship in linear time. The straightforward per-id
+/// `allObjects.first { $0.id == id }` lookup is quadratic — it bridges the
+/// NSSet to an array and scans it once per id — which made every read of an
+/// ordered relationship a hot spot: the workout recorder walks these
+/// relationships on each UI update, and exercises accumulate hundreds of set
+/// groups over time.
+func resolvedOrder<Entity: UUIDOrderable>(of members: NSSet?, by order: [UUID]?) -> [Entity] {
+    guard let order, !order.isEmpty, let members, members.count > 0 else { return [] }
+    var byId = [UUID: Entity](minimumCapacity: members.count)
+    for case let member as Entity in members {
+        guard let id = member.id, byId[id] == nil else { continue }
+        byId[id] = member
+    }
+    return order.compactMap { byId[$0] }
+}
+
 // MARK: - Workout Extension
 
 extension Workout {
@@ -41,13 +72,7 @@ extension Workout {
 
     var setGroups: [WorkoutSetGroup] {
         get {
-            return (setGroupOrder ?? .emptyList)
-                .compactMap { id in
-                    (setGroups_?.allObjects as? [WorkoutSetGroup])?
-                        .first { setGroup in
-                            setGroup.id == id
-                        }
-                }
+            resolvedOrder(of: setGroups_, by: setGroupOrder)
         }
         set {
             setGroupOrder = newValue.map { $0.id! }

--- a/LOGIT/Data/EntityExtensions/WorkoutSetGroup+.swift
+++ b/LOGIT/Data/EntityExtensions/WorkoutSetGroup+.swift
@@ -18,8 +18,7 @@ public extension WorkoutSetGroup {
 
     internal var sets: [WorkoutSet] {
         get {
-            return (setOrder ?? .emptyList)
-                .compactMap { id in (sets_?.allObjects as? [WorkoutSet])?.first { $0.id == id } }
+            resolvedOrder(of: sets_, by: setOrder)
         }
         set {
             setOrder = newValue.map { $0.id! }
@@ -37,8 +36,7 @@ public extension WorkoutSetGroup {
 
     private var exercises: [Exercise] {
         get {
-            return (exerciseOrder ?? .emptyList)
-                .compactMap { id in (exercises_?.allObjects as? [Exercise])?.first { $0.id == id } }
+            resolvedOrder(of: exercises_, by: exerciseOrder)
         }
         set {
             exerciseOrder = newValue.map { $0.id! }

--- a/LOGIT/Features/Workout/WorkoutEditorScreen.swift
+++ b/LOGIT/Features/Workout/WorkoutEditorScreen.swift
@@ -316,7 +316,11 @@ struct WorkoutEditorScreen: View {
     // MARK: - Autosave
 
     private func refreshOnChange() {
+        // Throttled: typing into a set field fires a context change per
+        // keystroke, and rebroadcasting each one re-rendered the whole screen
+        // per digit (see the recorder's autosave pipeline for the same fix).
         cancellable = NotificationCenter.default.publisher(for: .NSManagedObjectContextObjectsDidChange, object: database.context)
+            .throttle(for: .milliseconds(300), scheduler: RunLoop.main, latest: true)
             .sink { _ in
                 self.workout.objectWillChange.send()
             }

--- a/LOGIT/Features/Workout/WorkoutRecorder/WorkoutRecorderScreen+Toolbar.swift
+++ b/LOGIT/Features/Workout/WorkoutRecorder/WorkoutRecorderScreen+Toolbar.swift
@@ -39,27 +39,29 @@ extension WorkoutRecorderScreen {
                             )
                         }
                     }
+                    let previousIndex = previousIntegerFieldIndex()
+                    let nextIndex = nextIntegerFieldIndex()
                     HStack(spacing: 0) {
                         Button {
-                            focusedIntegerFieldIndex = previousIntegerFieldIndex()
+                            focusedIntegerFieldIndex = previousIndex
                         } label: {
                             Image(systemName: "chevron.up")
                                 .foregroundColor(
-                                    previousIntegerFieldIndex() == nil ? Color.placeholder : .label
+                                    previousIndex == nil ? Color.placeholder : .label
                                 )
                                 .keyboardToolbarButtonStyle()
                         }
-                        .disabled(previousIntegerFieldIndex() == nil)
+                        .disabled(previousIndex == nil)
                         Button {
-                            focusedIntegerFieldIndex = nextIntegerFieldIndex()
+                            focusedIntegerFieldIndex = nextIndex
                         } label: {
                             Image(systemName: "chevron.down")
                                 .foregroundColor(
-                                    nextIntegerFieldIndex() == nil ? Color.placeholder : .label
+                                    nextIndex == nil ? Color.placeholder : .label
                                 )
                                 .keyboardToolbarButtonStyle()
                         }
-                        .disabled(nextIntegerFieldIndex() == nil)
+                        .disabled(nextIndex == nil)
                     }
                 }
                 Button {

--- a/LOGIT/Features/Workout/WorkoutRecorder/WorkoutRecorderScreen.swift
+++ b/LOGIT/Features/Workout/WorkoutRecorder/WorkoutRecorderScreen.swift
@@ -23,6 +23,7 @@ struct WorkoutRecorderScreen: View {
     @Environment(\.fullScreenDraggableCoverIsDragging) var fullScreenDraggableCoverIsDragging
     @Environment(\.colorScheme) var colorScheme: ColorScheme
     @Environment(\.dismissWorkoutRecorder) var dismissWorkoutRecorder
+    @Environment(\.scenePhase) private var scenePhase
 
     @EnvironmentObject private var database: Database
     @EnvironmentObject var workoutRecorder: WorkoutRecorder
@@ -43,7 +44,7 @@ struct WorkoutRecorderScreen: View {
     @State var isShowingChronoSheet = false
     @State private var didAppear = false
     @State private var progress: Float = 0
-    @State private var cancellable: AnyCancellable?
+    @State private var cancellables: [AnyCancellable] = []
 
     @State private var isShowingFinishConfirmation = false
     @State private var exerciseSelectionPresentationDetent: PresentationDetent = .medium
@@ -343,6 +344,15 @@ struct WorkoutRecorderScreen: View {
         }
         .onDisappear {
             UIApplication.shared.isIdleTimerDisabled = false
+            // Flush anything the debounced autosave hasn't written yet.
+            database.save()
+        }
+        .onChange(of: scenePhase) { _, newPhase in
+            // Backgrounding must not race the debounced autosave — persist
+            // pending edits while the process is still guaranteed to run.
+            if newPhase != .active {
+                database.save()
+            }
         }
         .scrollDismissesKeyboard(.interactively)
         #if targetEnvironment(simulator)
@@ -491,13 +501,19 @@ struct WorkoutRecorderScreen: View {
     }
 
     private func updateProgress() {
-        guard let workout = workoutRecorder.workout else {
-            progress = 0
-            return
+        let newProgress: Float
+        if let workout = workoutRecorder.workout {
+            let sets = workout.sets
+            let completedSets = sets.filter { $0.hasEntry }.count
+            newProgress = sets.isEmpty ? 0 : Float(completedSets) / Float(sets.count)
+        } else {
+            newProgress = 0
         }
-        let totalSets = workout.sets.count
-        let completedSets = workout.sets.filter { $0.hasEntry }.count
-        progress = totalSets > 0 ? Float(completedSets) / Float(totalSets) : 0
+        // Writing an unchanged @State still invalidates the screen body —
+        // and most keystrokes don't move the completed-sets ratio.
+        if progress != newProgress {
+            progress = newProgress
+        }
     }
 
     private func checkForNewSetEntries() {
@@ -704,12 +720,38 @@ struct WorkoutRecorderScreen: View {
 
     // MARK: - Autosave
 
+    /// Typing into a set field mutates only that set, so this pipeline does two
+    /// things the set-level observation can't: refresh workout-level views and
+    /// persist the edit. Both used to run on *every* context change — one
+    /// keystroke = one full re-render of every set group cell (with the metric
+    /// badges re-scanning the exercise's whole history) plus one synchronous
+    /// store commit with a CloudKit export cycle — which made the recorder
+    /// visibly stutter while typing. Batching them keeps typing smooth without
+    /// changing what ends up on screen or on disk.
     private func setUpAutoSaveForWorkout() {
-        cancellable = NotificationCenter.default.publisher(for: .NSManagedObjectContextObjectsDidChange, object: database.context)
-            .sink { _ in
-                self.workoutRecorder.workout?.objectWillChange.send()
-                self.database.save()
-            }
+        let contextDidChange = NotificationCenter.default.publisher(
+            for: .NSManagedObjectContextObjectsDidChange,
+            object: database.context
+        )
+        cancellables = [
+            // Workout-level observers (progress, muscle chart, metric badges)
+            // re-render at most a few times per second; the edited cell itself
+            // updates instantly through its own @ObservedObject set.
+            contextDidChange
+                .throttle(for: .milliseconds(300), scheduler: RunLoop.main, latest: true)
+                .sink { _ in
+                    self.workoutRecorder.workout?.objectWillChange.send()
+                },
+            // Persist at typing pauses. The debounce only defers the save, it
+            // never skips it: finishing/discarding saves explicitly, and the
+            // scene-phase/disappear hooks in `body` flush pending changes
+            // whenever the recorder leaves the screen.
+            contextDidChange
+                .debounce(for: .seconds(1.5), scheduler: RunLoop.main)
+                .sink { _ in
+                    self.database.save()
+                },
+        ]
     }
 }
 


### PR DESCRIPTION
## Problem

Typing into an integer/decimal set field in the workout recorder made the whole UI lag for a moment — and worse for long-time users. Reproduced in the simulator under a new dense-history state, profiled per keystroke with `sample`, fixed, and re-measured.

Each keystroke writes one Core Data set, which posts `NSManagedObjectContextObjectsDidChange`. The recorder's autosave sink reacted to every one of those by:

1. **Rebroadcasting a whole-workout `objectWillChange`** → every set-group cell, the muscle chart, the progress ring, and every metric badge re-rendered *per digit*.
2. **Running a synchronous main-thread `database.save()`** with a CloudKit export cycle *per digit* — logs showed **49 saves for 48 keystrokes**.
3. Each re-rendered `MetricBadgeView` then re-scanned the exercise's **entire set history** (hundreds of sets) three times per render, through ordered-relationship getters that were **accidentally quadratic** (`allObjects.first { $0.id == id }` per element).

Under a long-time user's data this saturated the main thread on every keystroke.

## Fix

- **Linear ordered-relationship getters** — all seven order-resolved getters (`Workout`, `WorkoutSetGroup`, `Exercise`, `Template`, `TemplateSetGroup`) now go through a shared `resolvedOrder(of:by:)` (one dictionary build instead of an NSSet bridge + scan per element; identical ordering/dedup semantics).
- **Throttled the workout-level `objectWillChange` rebroadcast to ~3×/s** in the recorder and the workout editor; the cell being edited still updates instantly via its own observed set.
- **Debounced the recorder autosave to typing pauses (1.5s)**, never skipped — finish/discard still save explicitly, plus new flushes on `onDisappear` and when the scene leaves `.active`.
- Skip the redundant `progress` `@State` write when the completed-sets ratio is unchanged.
- Adds a DEBUG-only `-SCENARIO stress` launch state (2 years / 209 workouts + an in-progress workout) for reproducing recorder perf under a heavy dataset.

## Results (simulator, `-SCENARIO stress`, same test/device/data)

| Signal | Before | After |
| --- | --- | --- |
| Core Data saves over 48 keystrokes | 49 | 3 (at pauses; flush on close/background) |
| Badge + PR-scan samples in typing profile | ~58/s | ~7/s |
| Quadratic getter closures in profile | ~118/s | 0 (→ `resolvedOrder`, ~4/s) |
| SwiftUI `sizeThatFits` layout samples | 85/s | 40/s (floor: keyboard + test harness) |

On a real device the save win is larger than the simulator shows — the stress store is in-memory with no iCloud account, so the old per-keystroke commits skipped the disk fsync and real CloudKit export a device pays.

## Verification

- Unit tests: **36/36 pass** (`LOGITTests`).
- Scenario screenshot matrix (empty / one / many / free) — **all pass, no visual regressions**; History still lists exercises in the right order (fed by the rewritten getters), Pro gate intact, recorder reorder-interaction tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)