### PR TITLE
Harden Database.delete against off-queue relationship faults

### DIFF
--- a/LOGIT/Data/Database/Database.swift
+++ b/LOGIT/Data/Database/Database.swift
@@ -189,10 +189,12 @@ public class Database: ObservableObject {
 
     func delete(_ object: NSManagedObject?, saveContext: Bool = false) {
         guard let object = object else { return }
-        if let workoutSet = object as? WorkoutSet,
-           let setGroup = workoutSet.setGroup
-        {
-            context.perform {
+        // Even reading workoutSet.setGroup can fire a fault, so the entire branch belongs on
+        // the context's queue.
+        context.perform {
+            if let workoutSet = object as? WorkoutSet,
+               let setGroup = workoutSet.setGroup
+            {
                 var updatedSets = setGroup.sets
                 if let index = updatedSets.firstIndex(of: workoutSet) {
                     updatedSets.remove(at: index)
@@ -204,9 +206,7 @@ public class Database: ObservableObject {
                     self.context.delete(workoutSet)
                 }
                 self.objectWillChange.send()
-            }
-        } else {
-            context.perform {
+            } else {
                 self.context.delete(object)
             }
         }


### PR DESCRIPTION
## What

`Database.delete(_:)` read `workoutSet.setGroup` — a Core Data relationship access that can fire a fault — on the **calling thread**, before entering its internal `context.perform`. Since `context` is the main-queue-confined `viewContext`, calling `delete` from any other queue violated Core Data's threading contract before the safe block ever ran.

This moves the entire branch inside `context.perform`, so `delete` is safe to call from any thread by contract, not just when the caller happens to be on the context's queue.

## Why this is separate from #65

This is the one piece of the WorkoutRecorder threading investigation that #65 did **not** cover. The recorder-side fix (`saveWorkout`/`discardWorkout` → `context.perform`) was produced independently in this worktree and matched #65 almost line-for-line, so that duplicate was dropped in favor of #65. What's left is this complementary hardening of the shared `delete` helper those callers rely on. It closes the last item in the viewContext-off-queue cleanup (alongside merged #61, #63, #65).

## Verification

- Full `LOGITTests` suite passes on the iPhone 16 Pro / iOS 26 simulator, rebased onto current `main` (which already includes #65 and #66).
- Touches only `Database.swift`; no behavior change for the existing main-thread callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)