### PR TITLE
Add reorder options to the workout editor and recorder

### DIFF
--- a/LOGIT/Features/Workout/WorkoutEditorScreen.swift
+++ b/LOGIT/Features/Workout/WorkoutEditorScreen.swift
@@ -104,6 +104,17 @@ struct WorkoutEditorScreen: View {
                                 canReorder: true,
                                 reduceShadow: true,
                                 showDetailAsSheet: true,
+                                // Defer the flag to the next runloop turn so the set-group Menu's
+                                // dismissal and the reorder sheet's presentation land in separate
+                                // transactions — flipping it synchronously inside the Menu action
+                                // entangles the two and, because the reorder sheet is a sheet-on-sheet,
+                                // the entanglement keeps it from ever presenting (same reason as the
+                                // editDateTime button below).
+                                onReorderSetGroups: {
+                                    DispatchQueue.main.async {
+                                        isShowingReorderSheet = true
+                                    }
+                                },
                                 onTapPreviousSet: { exerciseForDetailSheet = $0 }
                             )
                             .padding(.bottom, exerciseSelectionPresentationDetent == .medium ? (UIScreen.current?.bounds.height ?? 0) * 0.5 : BOTTOM_SHEET_SMALL)
@@ -286,8 +297,20 @@ struct WorkoutEditorScreen: View {
                             Spacer()
                             Button {
                                 focusedIntegerFieldIndex = nil
+                                // Defer — same transaction entanglement as the
+                                // editDateTime button above.
+                                DispatchQueue.main.async {
+                                    isShowingReorderSheet = true
+                                }
+                            } label: {
+                                Image(systemName: "arrow.up.arrow.down")
+                                    .keyboardToolbarButtonStyle()
+                            }
+                            Button {
+                                focusedIntegerFieldIndex = nil
                             } label: {
                                 Image(systemName: "keyboard.chevron.compact.down")
+                                    .keyboardToolbarButtonStyle()
                             }
                         }
                     }

--- a/LOGIT/Features/Workout/WorkoutRecorder/WorkoutRecorderScreen+Toolbar.swift
+++ b/LOGIT/Features/Workout/WorkoutRecorder/WorkoutRecorderScreen+Toolbar.swift
@@ -13,31 +13,18 @@ extension WorkoutRecorderScreen {
             HStack {
                 Spacer()
                 if focusedIntegerFieldIndex != nil {
-                    if let workoutSet = selectedWorkoutSet {
-                        if let templateSet = workoutRecorder.templateSet(for: workoutSet), templateSet.hasEntry {
-                            Button {
-                                workoutRecorder.toggleSetCompleted(for: workoutSet)
-                            } label: {
-                                Image(systemName: "\(workoutSet.hasEntry ? "xmark" : "checkmark")")
-                                    .keyboardToolbarButtonStyle()
-                            }
-                        } else {
-                            Button {
-                                workoutRecorder.toggleCopyPrevious(for: workoutSet)
-                            } label: {
-                                Image(systemName: "\(workoutSet.hasEntry ? "xmark" : "plus.square.on.square")")
-                                    .foregroundColor(
-                                        !(workoutSet.previousSetInSetGroup?.hasEntry ?? false)
-                                            && !workoutSet.hasEntry
-                                            ? Color.placeholder : .primary
-                                    )
-                                    .keyboardToolbarButtonStyle()
-                            }
-                            .disabled(
-                                !(workoutSet.previousSetInSetGroup?.hasEntry ?? false)
-                                    && !workoutSet.hasEntry
-                            )
+                    Button {
+                        focusedIntegerFieldIndex = nil
+                        // Defer so the keyboard's dismissal and the reorder sheet's
+                        // presentation land in separate transactions — same
+                        // entanglement the workout editor documents on its
+                        // editDateTime button; here it hangs the presentation.
+                        DispatchQueue.main.async {
+                            isShowingReorderSheet = true
                         }
+                    } label: {
+                        Image(systemName: "arrow.up.arrow.down")
+                            .keyboardToolbarButtonStyle()
                     }
                     let previousIndex = previousIntegerFieldIndex()
                     let nextIndex = nextIntegerFieldIndex()

--- a/LOGIT/Features/Workout/WorkoutRecorder/WorkoutRecorderScreen.swift
+++ b/LOGIT/Features/Workout/WorkoutRecorder/WorkoutRecorderScreen.swift
@@ -50,7 +50,7 @@ struct WorkoutRecorderScreen: View {
     @State private var exerciseSelectionPresentationDetent: PresentationDetent = .medium
     @State private var isShowingDetailsSheet = false
     @State private var isShowingExerciseSelectionSheet = false
-    @State private var isShowingReorderSheet = false
+    @State var isShowingReorderSheet = false
     @State private var selectedRestDurationSet: WorkoutSet?
     @State private var exerciseForDetailSheet: Exercise?
     /// When the exercise-detail sheet is opened from the metric popover, the metric whose chart
@@ -86,6 +86,14 @@ struct WorkoutRecorderScreen: View {
                                     canReorder: true,
                                     showDetailAsSheet: true,
                                     onTapRestDuration: { selectedRestDurationSet = $0 },
+                                    // Deferred for the same Menu-dismissal / sheet-on-sheet
+                                    // entanglement the workout editor documents on its
+                                    // onReorderSetGroups.
+                                    onReorderSetGroups: {
+                                        DispatchQueue.main.async {
+                                            isShowingReorderSheet = true
+                                        }
+                                    },
                                     onTapPreviousSet: { scrollToRecentAttempts = true; exerciseDetailAutoMetric = nil; exerciseForDetailSheet = $0 },
                                     onTapExerciseName: { scrollToRecentAttempts = false; exerciseDetailAutoMetric = nil; exerciseForDetailSheet = $0 }
                                 )

--- a/LOGIT/Features/Workout/WorkoutSetGroupList.swift
+++ b/LOGIT/Features/Workout/WorkoutSetGroupList.swift
@@ -20,6 +20,7 @@ struct WorkoutSetGroupList: View {
     var reduceShadow: Bool = false
     var showDetailAsSheet: Bool = false
     var onTapRestDuration: ((WorkoutSet) -> Void)? = nil
+    var onReorderSetGroups: (() -> Void)? = nil
     var onTapPreviousSet: ((Exercise) -> Void)? = nil
     var onTapExerciseName: ((Exercise) -> Void)? = nil
 
@@ -40,6 +41,7 @@ struct WorkoutSetGroupList: View {
                         supplementaryText: nil,
                         showDetailAsSheet: showDetailAsSheet,
                         onTapRestDuration: onTapRestDuration,
+                        onReorderSetGroups: onReorderSetGroups,
                         onTapPreviousSet: onTapPreviousSet,
                         onTapExerciseName: onTapExerciseName
                     )


### PR DESCRIPTION
## What

The set-group reorder sheet already existed in both the workout editor and recorder, but nothing could open it. This wires it up from **four entry points**:

- **Editor** — set group's `…` menu + a new keyboard-toolbar `↕` button
- **Recorder** — set group's `…` menu + a new keyboard-toolbar `↕` button (replacing the clear / copy-previous button, per request)

## How

- Thread the pre-existing `onReorderSetGroups` callback through `WorkoutSetGroupList` (it lived on the cell but was never passed).
- Every trigger defers the flag via `DispatchQueue.main.async`. Flipping `isShowingReorderSheet` synchronously inside a Menu action or alongside keyboard dismissal entangles that dismissal with the sheet-on-sheet presentation — from the menu the sheet silently never presents; from the keyboard the app **hangs** (caught because the UI-test runner died at that exact step on every run). Same reasoning as the existing `editDateTime` button.
- Editor keyboard buttons adopt the app's `.keyboardToolbarButtonStyle()` so they sit evenly spaced, matching the recorder.

## Verification

All four entry points exercised via XCUITest on iPhone 17 Pro (iOS 26.4) with fixture data; the reorder sheet presents and the menu/keyboard items appear in every case. Rebased onto latest `main` (auto-merged with #66/#68 recorder+editor changes) and rebuilt clean.

Note: `WorkoutRecorder.toggleSetCompleted` / `toggleCopyPrevious` lost their only caller (the replaced keyboard button) and are left in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)