### PR TITLE
Use arrows for progress indicators; simplify Overall Progress trend

### DIFF
--- a/LOGIT/Features/Home/SummaryProgressTab.swift
+++ b/LOGIT/Features/Home/SummaryProgressTab.swift
@@ -174,28 +174,28 @@ private func trendColor(_ percent: Double) -> Color {
     trendIsUp(percent) ? .accentColor : .secondaryLabel
 }
 
-/// Continuous arrow angle in degrees (0 = flat/right, positive = up), scaled from the percent and
-/// clamped so big swings still read as "steeply up/down" without spinning past vertical.
-private func trendAngle(_ percent: Double) -> Double {
-    min(max(percent * 6, -62), 80)
-}
-
 private func signedPercent(_ percent: Double, fractionDigits: Int) -> String {
     String(format: "%+.\(fractionDigits)f%%", percent)
 }
 
-/// A right-pointing arrow rotated to the trend angle — the shared glyph for the hero and the
-/// per-muscle rows. Positive angle rotates it up (counter-clockwise).
+/// A strict up / down / steady arrow — the shared glyph for the hero and the per-muscle rows. No
+/// magnitude-scaled rotation: the direction alone is the signal (`arrow.up` up, `arrow.down` down,
+/// `arrow.right` for a flat trend holding steady), with the percent beside it carrying the size.
 private struct TrendArrow: View {
     let percent: Double
     let color: Color
     let size: CGFloat
 
+    private var symbolName: String {
+        if trendIsUp(percent) { return "arrow.up" }
+        if trendIsDown(percent) { return "arrow.down" }
+        return "arrow.right"
+    }
+
     var body: some View {
-        Image(systemName: "arrow.right")
+        Image(systemName: symbolName)
             .font(.system(size: size, weight: .bold))
             .foregroundStyle(color)
-            .rotationEffect(.degrees(-trendAngle(percent)))
     }
 }
 

--- a/LOGIT/Features/Workout/Cells/WorkoutSetGroupCell.swift
+++ b/LOGIT/Features/Workout/Cells/WorkoutSetGroupCell.swift
@@ -594,7 +594,7 @@ private struct SetGroupMetricComparison {
 
 /// The progress-metric badge shown on each set group, styled like the trend pill on the exercise
 /// chart screens: how this session's best compares to the exercise's current best (last month,
-/// excluding this workout) — the percent change with an up/down chevron, or a dash at 0% — with the
+/// excluding this workout) — the percent change with an up/down arrow, or a dash at 0% — with the
 /// chosen metric's name in fine print
 /// beneath it. The metric is switched from the info panel a tap opens (also where it's explained); the badge
 /// itself has no switching gesture. While the displayed metric stands at a personal record, the
@@ -775,7 +775,7 @@ private struct MetricBadgeView: View {
         .animation(MetricPeekController.rollAnimation, value: metric)
     }
 
-    /// Mirrors `TrendIndicatorView` (the trend pill on the chart screens) — chevron weight, percent
+    /// Mirrors `TrendIndicatorView` (the trend pill on the chart screens) — arrow weight, percent
     /// formatting, tint, capsule fill (translucent accent as soon as the trend is positive, never a
     /// border) — with the metric's name in fine print beneath the value. It can't embed that view
     /// directly because the record state swaps the trend row for a trophy and the record value
@@ -854,8 +854,8 @@ private struct MetricBadgeView: View {
     /// Nil for a flat trend — see `pill(accent:)`; the muted percent carries "no change" on its own.
     private func symbolName(for direction: TrendDirection) -> String? {
         switch direction {
-        case .up: return "chevron.up"
-        case .down: return "chevron.down"
+        case .up: return "arrow.up"
+        case .down: return "arrow.down"
         case .flat: return nil
         }
     }

--- a/LOGIT/Features/Workout/WorkoutDetailScreen.swift
+++ b/LOGIT/Features/Workout/WorkoutDetailScreen.swift
@@ -245,7 +245,7 @@ struct WorkoutDetailScreen: View {
         let style = improved > 0
             ? workout.sets.muscleGroupGradientStyle(startPoint: .bottomLeading, endPoint: .topTrailing)
             : AnyShapeStyle(Color.secondary)
-        return ProgressIndicatorPill(symbol: improved > 0 ? "chevron.up" : nil, style: style) {
+        return ProgressIndicatorPill(symbol: improved > 0 ? "arrow.up" : nil, style: style) {
             Text(String(format: NSLocalizedString("improvedCount", comment: ""), improved))
                 .font(.system(.footnote, design: .rounded, weight: .bold))
                 .monospacedDigit()

--- a/LOGIT/SharedUI/Views/IntegerField.swift
+++ b/LOGIT/SharedUI/Views/IntegerField.swift
@@ -156,7 +156,7 @@ enum SetValueComparison: Equatable {
     case declined
 }
 
-/// A small up/down triangle plus the absolute difference versus the previous workout's
+/// A small up/down arrow plus the absolute difference versus the previous workout's
 /// value for a single set field. Positive (improved) uses the exercise's muscle-group
 /// color; negative (declined) is muted gray.
 struct SetValueDeltaLabel: View {
@@ -168,8 +168,8 @@ struct SetValueDeltaLabel: View {
         HStack(spacing: 1) {
             Image(
                 systemName: comparison == .improved
-                    ? "chevron.up"
-                    : "chevron.down"
+                    ? "arrow.up"
+                    : "arrow.down"
             )
             .font(.system(size: 7, weight: .bold))
             Text(text)

--- a/LOGIT/SharedUI/Views/ProgressIndicatorPill.swift
+++ b/LOGIT/SharedUI/Views/ProgressIndicatorPill.swift
@@ -7,9 +7,9 @@
 
 import SwiftUI
 
-/// The app's single progress-indicator pill: an optional leading SF Symbol — a trend chevron, a
+/// The app's single progress-indicator pill: an optional leading SF Symbol — a trend arrow, a
 /// trophy, an arrow, a clock — beside a label, on a translucent capsule tinted with an accent
-/// style. Every trend, record, gain and lapsed pill in the app is built from this so the chevron
+/// style. Every trend, record, gain and lapsed pill in the app is built from this so the symbol
 /// weight, capsule fill and 0.15 tint stay identical everywhere.
 ///
 /// The accent is an `AnyShapeStyle`, so it can be a flat `Color` or a gradient — a single `Color`
@@ -52,7 +52,7 @@ struct ProgressIndicatorPill<Label: View>: View {
         }
     }
 
-    /// The leading SF Symbol — `chevron.up`/`chevron.down` for a trend, `trophy.fill` for a record,
+    /// The leading SF Symbol — `arrow.up`/`arrow.down` for a trend, `trophy.fill` for a record,
     /// `arrow.up` for a gain, `minus` for "no change". Nil draws the label alone: a flat trend shows
     /// no icon so it can't be mistaken for a decline.
     let symbol: String?
@@ -127,10 +127,10 @@ struct ProgressIndicatorPill<Label: View>: View {
 struct ProgressIndicatorPill_Previews: PreviewProvider {
     static var previews: some View {
         VStack(spacing: 12) {
-            ProgressIndicatorPill(symbol: "chevron.up", color: .green) {
+            ProgressIndicatorPill(symbol: "arrow.up", color: .green) {
                 Text("12 %").font(.system(.footnote, design: .rounded, weight: .bold))
             }
-            ProgressIndicatorPill(symbol: "chevron.down", color: .secondary) {
+            ProgressIndicatorPill(symbol: "arrow.down", color: .secondary) {
                 Text("8 %").font(.system(.footnote, design: .rounded, weight: .bold))
             }
             ProgressIndicatorPill(

--- a/LOGIT/SharedUI/Views/TrendIndicatorView.swift
+++ b/LOGIT/SharedUI/Views/TrendIndicatorView.swift
@@ -9,9 +9,9 @@ import SwiftUI
 
 /// Capsule badge showing the percent change of a metric versus the previous period.
 /// An upward trend uses the exercise's muscle-group color; a decline is muted gray with
-/// a down chevron and no change is muted gray with no chevron at all — just the percent —
+/// a down arrow and no change is muted gray with no arrow at all — just the percent —
 /// so a flat result is never mistaken for a decline. The same up/down semantic as the
-/// set-delta chevrons in the workout recorder.
+/// set-delta arrows in the workout recorder.
 struct TrendIndicatorView: View {
     let percentChange: Double
     var positiveColor: Color = .accentColor
@@ -19,7 +19,7 @@ struct TrendIndicatorView: View {
     /// workout stat tiles pass the workout's multi-muscle-group gradient here, which a single
     /// `Color` can't carry. Decline and no change stay muted gray regardless.
     var positiveStyle: AnyShapeStyle? = nil
-    /// While the value stands at a personal record the chevron gives way to a trophy, the percent to
+    /// While the value stands at a personal record the arrow gives way to a trophy, the percent to
     /// "PR", and the pill keeps the positive tint regardless of direction — a record is always a win,
     /// and a percentage beside a record has no baseline to be a percentage *of*.
     var isRecord: Bool = false
@@ -45,13 +45,13 @@ struct TrendIndicatorView: View {
         return positiveStyle ?? AnyShapeStyle(positiveColor)
     }
 
-    /// No chevron for a flat result — the muted gray percent carries the "no change"
+    /// No arrow for a flat result — the muted gray percent carries the "no change"
     /// signal on its own, and an icon here would read like a decline.
     private var symbolName: String? {
         if isRecord { return "trophy.fill" }
         switch direction {
-        case .up: return "chevron.up"
-        case .down: return "chevron.down"
+        case .up: return "arrow.up"
+        case .down: return "arrow.down"
         case .flat: return nil
         }
     }


### PR DESCRIPTION
## What

- **Arrows instead of chevrons for progress, app-wide.** Every up/down progress icon now uses `arrow.up` / `arrow.down` instead of `chevron.up` / `chevron.down` — the trend pill on chart/detail screens, the recorder metric badge, the set-value delta vs. last workout, the "exercises improved" pill on workout detail, and the Highlights record gain on the Summary. A flat result still shows no icon at all, so it can't be mistaken for a decline.
- **Overall Progress tile → strict up / down / steady.** Removed the magnitude-scaled arrow rotation (`trendAngle`). The tile now snaps to a strict direction — `arrow.up` up, `arrow.down` down, `arrow.right` holding steady — and the percentage beside it carries the magnitude. The ±1% "steady" dead-band is unchanged.

Keyboard-toolbar (next/previous field) and navigation disclosure chevrons are intentionally left as chevrons — those aren't progress indication.

## Verification

- `BUILD SUCCEEDED` — iPhone 17 Pro, iOS 26.4.
- Captured the Summary → Progress tab live on the simulator: the Highlights pill reads `↑ 7%` with an arrow, Overall Progress shows a **strict vertical arrow** (no tilt) for "Trending up", and the Chest muscle row plus the teaser pills (`↑ 4%`, `↓ 0.5`) all use the same arrow language.

## Note

"Stays the same" uses a sideways `arrow.right` to keep it in the arrow family — easy to swap for a `minus` or `equal` if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)