### PR TITLE
Show pinned exercises only in the Progress tab

### DIFF
--- a/LOGIT/Features/Home/HomeScreen.swift
+++ b/LOGIT/Features/Home/HomeScreen.swift
@@ -166,8 +166,10 @@ struct HomeScreen: View {
                                 )
                             }
 
-                            exercisesSection
-                                .padding(.horizontal)
+                            if selectedTab == .progress {
+                                exercisesSection
+                                    .padding(.horizontal)
+                            }
 
                             measurementsSection
                                 .padding(.horizontal)


### PR DESCRIPTION
## What

Pinned exercises now appear only under the **Progress** tab of the Summary screen, not under **This Week**.

Previously the pinned-exercises section rendered below *both* tabs — it sat outside the `This Week` / `Progress` conditional in `HomeScreen`. It's now gated on `selectedTab == .progress`, so it sits with the other progress-oriented content (recent highlights + overall strength trend). **This Week** keeps the weekly goal, stat tiles, muscle balance, and records. Measurements are intentionally left unchanged (still shown under both tabs) — the request was specifically about pinned exercises.

## Change

A single conditional in `HomeScreen.swift`:

```swift
if selectedTab == .progress {
    exercisesSection
        .padding(.horizontal)
}
```

## Verification

Ran the `ScenarioScreenshots` UI suite on the iOS 26.4 simulator plus a temporary tab-placement capture (reverted before commit):

- **This Week** (scrolled): Weekly Goal → stats → Muscle Balance → Measurements — **no** Pinned Exercises section. ✅
- **Progress** (scrolled): Highlights → Overall Progress → **Pinned Exercises** → Measurements. ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)