### PR TITLE
Show pinned measurements only in the Progress tab

### DIFF
--- a/LOGIT/Features/Home/HomeScreen.swift
+++ b/LOGIT/Features/Home/HomeScreen.swift
@@ -169,10 +169,10 @@ struct HomeScreen: View {
                             if selectedTab == .progress {
                                 exercisesSection
                                     .padding(.horizontal)
-                            }
 
-                            measurementsSection
-                                .padding(.horizontal)
+                                measurementsSection
+                                    .padding(.horizontal)
+                            }
                             }
 
                         }


### PR DESCRIPTION
## What

Follow-up to #73. The **Measurements** section now appears only under the **Progress** tab of the Summary screen, matching pinned exercises. Both pinned lists (Exercises + Measurements) now live with the progress-oriented content; **This Week** stays focused on the current week (weekly goal, stat tiles, muscle balance).

## Change

`measurementsSection` moves inside the existing `selectedTab == .progress` conditional in `HomeScreen.swift`, alongside `exercisesSection`:

```swift
if selectedTab == .progress {
    exercisesSection
        .padding(.horizontal)

    measurementsSection
        .padding(.horizontal)
}
```

## Verification

`ScenarioScreenshots` UI suite on the iOS 26.4 simulator plus a temporary tab-placement capture (reverted before commit):

- **This Week** (scrolled): Weekly Goal → stats → Muscle Balance — **no** Pinned Exercises **and no** Measurements. ✅
- **Progress** (scrolled): Highlights → Overall Progress → **Pinned Exercises** → **Measurements**. ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)