### PR TITLE
Make the period stat charts scrollable with a moving visible-window average

### DIFF
--- a/LOGIT/Core/Enums/StatPeriod.swift
+++ b/LOGIT/Core/Enums/StatPeriod.swift
@@ -126,3 +126,60 @@ enum StatPeriod: String, CaseIterable, Identifiable {
         }
     }
 }
+
+// MARK: - Scrollable chart geometry
+
+/// The scrollable-timeline math for the period-history charts — the mirror of `ChartRange`'s for the
+/// capability charts, but derived from `range(periodsAgo:)` so a "week" window is exactly the twelve
+/// calendar weeks it shows, not an approximate span. Living here (not per screen) keeps every period
+/// chart scrolling, snapping and framing the current period identically.
+extension StatPeriod {
+    /// The visible window in seconds — exactly the most recent `historyBucketCount` periods, which is
+    /// what `chartXVisibleDomain` expects and the fixed width the chart showed before it scrolled.
+    func visibleDomainSeconds(now: Date = .now) -> Int {
+        let start = range(periodsAgo: historyBucketCount - 1, from: now).lowerBound
+        let end = currentRange(containing: now).upperBound
+        return Int(end.timeIntervalSince(start).rounded(.up))
+    }
+
+    /// The full scrollable domain: from the period containing the first data point through the current
+    /// period's end, but never shorter than one visible window so a young history still fills the chart.
+    func scrollableXDomain(firstDataDate: Date?, now: Date = .now) -> ClosedRange<Date> {
+        let end = currentRange(containing: now).upperBound
+        let windowStart = range(periodsAgo: historyBucketCount - 1, from: now).lowerBound
+        guard let firstDataDate, firstDataDate < windowStart else { return windowStart ... end }
+        return currentRange(containing: firstDataDate).lowerBound ... end
+    }
+
+    /// The initial scroll position (the visible window's left edge) placing the current period at the
+    /// right edge — the chart opens on the most recent periods, the fixed view it replaced.
+    func initialScrollPosition(now: Date = .now) -> Date {
+        let end = currentRange(containing: now).upperBound
+        return Calendar.current.date(byAdding: .second, value: -visibleDomainSeconds(now: now), to: end) ?? end
+    }
+
+    /// What scroll positions snap to: the start of a week / month / year.
+    var scrollSnapComponents: DateComponents {
+        switch self {
+        case .week: return DateComponents(weekday: Calendar.current.firstWeekday)
+        case .month: return DateComponents(day: 1)
+        case .year: return DateComponents(month: 1, day: 1)
+        }
+    }
+
+    /// X-axis mark cadence on the scrollable chart — about six marks across the visible window.
+    var scrollAxisStride: (component: Calendar.Component, count: Int) {
+        switch self {
+        case .week: return (.weekOfYear, 2)
+        case .month: return (.month, 2)
+        case .year: return (.year, 1)
+        }
+    }
+
+    /// The visible window as a date range — `[scrollPosition, scrollPosition + one window]` — for the
+    /// header's moving "average" caption and the visible-window average it labels.
+    func visibleWindowRange(from scrollPosition: Date, now: Date = .now) -> ClosedRange<Date> {
+        let end = Calendar.current.date(byAdding: .second, value: visibleDomainSeconds(now: now), to: scrollPosition) ?? scrollPosition
+        return scrollPosition ... end
+    }
+}

--- a/LOGIT/Features/Exercise/ExerciseDetail/ExerciseSetsScreen.swift
+++ b/LOGIT/Features/Exercise/ExerciseDetail/ExerciseSetsScreen.swift
@@ -23,8 +23,22 @@ struct ExerciseSetsScreen: View {
             VStack(spacing: SECTION_SPACING) {
                 VStack(spacing: 16) {
                     PeriodPicker(selection: $period)
-                    header
-                    chart
+                    PeriodStatChartView(
+                        period: period,
+                        buckets: buckets,
+                        firstDataDate: firstDataDate,
+                        valueLabel: NSLocalizedString("sets", comment: ""),
+                        unit: "",
+                        currentBarStyle: AnyShapeStyle(muscleGroupColor.gradient),
+                        currentLabel: period.currentPeriodLabel,
+                        currentValue: "\(currentCount)",
+                        currentRaw: currentCount,
+                        trailingValueStyle: AnyShapeStyle(muscleGroupColor.gradient),
+                        positiveColor: muscleGroupColor,
+                        formatAverage: { "\($0)" },
+                        displayAverage: { Double($0) },
+                        explanation: NSLocalizedString("averageComparisonInfo", comment: "")
+                    )
                 }
                 .padding(.horizontal)
                 AboutSection(
@@ -51,67 +65,36 @@ struct ExerciseSetsScreen: View {
         }
     }
 
-    // MARK: - Header
-
-    private var header: some View {
-        MetricComparisonView(
-            leading: .init(
-                label: NSLocalizedString("average", comment: ""),
-                value: averageSetCount.map { "\($0)" } ?? "––",
-                unit: "",
-                caption: period.rangeCaption(period.completedHistoryRange())
-            ),
-            trailing: .init(
-                label: period.currentPeriodLabel,
-                // A period count is a real value even at zero ("0 this week"), clearer than a
-                // "––" no-data dash — same rule as the stat tiles.
-                value: "\(currentCount)",
-                unit: "",
-                caption: period.rangeCaption(period.currentRange())
-            ),
-            trailingValueStyle: AnyShapeStyle(muscleGroupColor.gradient),
-            percentChange: percentChange,
-            positiveColor: muscleGroupColor,
-            explanation: NSLocalizedString("averageComparisonInfo", comment: "")
-        )
-        .frame(maxWidth: .infinity, alignment: .leading)
-    }
-
-    // MARK: - Chart
-
-    private var chart: some View {
-        PeriodHistoryChart(
-            buckets: buckets,
-            period: period,
-            valueLabel: NSLocalizedString("sets", comment: ""),
-            currentBarStyle: AnyShapeStyle(muscleGroupColor.gradient),
-            averageLine: averageSetCount.map(Double.init)
-        )
-    }
-
     // MARK: - Data
 
     private var currentCount: Int { setCount(in: period.currentRange()) }
 
-    /// Working-set counts of the completed periods on screen — every history bucket except the
-    /// current, still-growing one, and only periods actually trained (a rest period is "no data"
-    /// for the average, the same rule the trend already uses). The comparison baseline and the
-    /// dashed average line both read from this one value.
-    private var completedSetCounts: [Int] {
-        (1 ..< period.historyBucketCount)
-            .map { setCount(in: period.range(periodsAgo: $0)) }
-            .filter { $0 > 0 }
+    /// Earliest recorded set — the left end of the scrollable domain.
+    private var firstDataDate: Date? {
+        workoutSets.compactMap { $0.workout?.date }.min()
     }
 
-    private var averageSetCount: Int? {
-        guard !completedSetCounts.isEmpty else { return nil }
-        return Int((Double(completedSetCounts.reduce(0, +)) / Double(completedSetCounts.count)).rounded())
+    /// Working-set count per period start, built in one pass so the scrollable chart looks each period
+    /// up instead of re-filtering the sets per bar. Only sets with a recorded entry count, matching
+    /// the weekly tile; keyed the same way `scrollableBuckets` keys its lookups.
+    private var countByPeriodStart: [Date: Int] {
+        var dict: [Date: Int] = [:]
+        for set in workoutSets where set.hasEntry {
+            guard let date = set.workout?.date else { continue }
+            let start = period.currentRange(containing: date).lowerBound
+            dict[start, default: 0] += 1
+        }
+        return dict
     }
 
-    /// The current period against the average of the completed periods shown — nil (pill hidden)
-    /// until both the current period and the history hold data, the same suppression as the tiles.
-    private var percentChange: Double? {
-        PeriodHistoryChart.trendPercentChange(current: currentCount, previous: averageSetCount ?? 0)
+    private var buckets: [PeriodHistoryChart.Bucket] {
+        PeriodHistoryChart.scrollableBuckets(
+            for: period,
+            rawByPeriodStart: countByPeriodStart,
+            firstDataDate: firstDataDate,
+            display: { Double($0) },
+            formatted: { "\($0)" }
+        )
     }
 
     /// Working-set count in the range — only sets with a recorded entry, matching the weekly tile.
@@ -123,10 +106,6 @@ struct ExerciseSetsScreen: View {
             }
             .filter(\.hasEntry)
             .count
-    }
-
-    private var buckets: [PeriodHistoryChart.Bucket] {
-        PeriodHistoryChart.buckets(for: period) { Double(setCount(in: $0)) }
     }
 
     private var muscleGroupColor: Color {

--- a/LOGIT/Features/Exercise/ExerciseDetail/ExerciseVolumeScreen.swift
+++ b/LOGIT/Features/Exercise/ExerciseDetail/ExerciseVolumeScreen.swift
@@ -23,8 +23,24 @@ struct ExerciseVolumeScreen: View {
             VStack(spacing: SECTION_SPACING) {
                 VStack(spacing: 16) {
                     PeriodPicker(selection: $period)
-                    header
-                    chart
+                    PeriodStatChartView(
+                        period: period,
+                        buckets: buckets,
+                        firstDataDate: firstDataDate,
+                        valueLabel: NSLocalizedString("volume", comment: ""),
+                        unit: WeightUnit.used.rawValue,
+                        currentBarStyle: AnyShapeStyle(muscleGroupColor.gradient),
+                        currentLabel: period.currentPeriodLabel,
+                        currentValue: formatWeightForDisplay(currentRawVolume),
+                        currentRaw: currentRawVolume,
+                        trailingValueStyle: AnyShapeStyle(muscleGroupColor.gradient),
+                        positiveColor: muscleGroupColor,
+                        // Volumes run to thousands, so round the mean to a whole unit — the raw
+                        // decimals only wrap the large header number onto a second line.
+                        formatAverage: { "\(Int(convertWeightForDisplayingDecimal($0).rounded()))" },
+                        displayAverage: { Double(Int(convertWeightForDisplayingDecimal($0).rounded())) },
+                        explanation: NSLocalizedString("averageComparisonInfo", comment: "")
+                    )
                 }
                 .padding(.horizontal)
                 AboutSection(
@@ -51,76 +67,36 @@ struct ExerciseVolumeScreen: View {
         }
     }
 
-    // MARK: - Header
-
-    private var header: some View {
-        MetricComparisonView(
-            leading: .init(
-                label: NSLocalizedString("average", comment: ""),
-                value: averageDisplayVolume.map { "\($0)" } ?? "––",
-                unit: WeightUnit.used.rawValue,
-                caption: period.rangeCaption(period.completedHistoryRange())
-            ),
-            trailing: .init(
-                label: period.currentPeriodLabel,
-                // A period sum is a real value even at zero ("0 kg this week"), clearer than a
-                // "––" no-data dash — same rule as the stat tiles.
-                value: formatWeightForDisplay(currentRawVolume),
-                unit: WeightUnit.used.rawValue,
-                caption: period.rangeCaption(period.currentRange())
-            ),
-            trailingValueStyle: AnyShapeStyle(muscleGroupColor.gradient),
-            percentChange: percentChange,
-            positiveColor: muscleGroupColor,
-            explanation: NSLocalizedString("averageComparisonInfo", comment: "")
-        )
-        .frame(maxWidth: .infinity, alignment: .leading)
-    }
-
-    // MARK: - Chart
-
-    private var chart: some View {
-        PeriodHistoryChart(
-            buckets: buckets,
-            period: period,
-            valueLabel: NSLocalizedString("volume", comment: ""),
-            currentBarStyle: AnyShapeStyle(muscleGroupColor.gradient),
-            unit: WeightUnit.used.rawValue,
-            averageLine: averageDisplayVolume.map { Double($0) }
-        )
-    }
-
     // MARK: - Data
 
     private var currentRawVolume: Int { rawVolume(in: period.currentRange()) }
 
-    /// Raw volumes of the completed periods on screen — every history bucket except the current,
-    /// still-growing one, and only periods actually trained (a rest period is "no data" for the
-    /// average, the same rule the trend already uses). The comparison baseline and the dashed
-    /// average line both read from this, so "average" means the same in the header and on the chart.
-    private var completedRawVolumes: [Int] {
-        (1 ..< period.historyBucketCount)
-            .map { rawVolume(in: period.range(periodsAgo: $0)) }
-            .filter { $0 > 0 }
+    /// Earliest recorded set — the left end of the scrollable domain.
+    private var firstDataDate: Date? {
+        workoutSets.compactMap { $0.workout?.date }.min()
     }
 
-    private var averageRawVolume: Int? {
-        guard !completedRawVolumes.isEmpty else { return nil }
-        return completedRawVolumes.reduce(0, +) / completedRawVolumes.count
+    /// Raw volume per period start, built in one pass over the sets so the scrollable chart can look
+    /// each period up instead of re-filtering the sets per bar. Keyed the same way `scrollableBuckets`
+    /// keys its lookups — `currentRange(containing:).lowerBound`.
+    private var rawByPeriodStart: [Date: Int] {
+        var dict: [Date: Int] = [:]
+        for set in workoutSets {
+            guard let date = set.workout?.date else { continue }
+            let start = period.currentRange(containing: date).lowerBound
+            dict[start, default: 0] += getVolume(of: [set], for: exercise)
+        }
+        return dict
     }
 
-    /// The average as a whole display-unit value. Volumes run to thousands, so the mean's fractional
-    /// tail (`formatWeightForDisplay` keeps up to 3 decimals) only wraps the large header number onto
-    /// a second line — round it. Feeds the header and the chart's dashed line so the two stay in step;
-    /// the pill reads `averageRawVolume`, where the ratio is exact.
-    private var averageDisplayVolume: Int? {
-        averageRawVolume.map { Int(convertWeightForDisplayingDecimal($0).rounded()) }
-    }
-
-    /// The current period against the average of the completed periods shown — nil (pill hidden)
-    /// until both the current period and the history hold data, the same suppression as the tiles.
-    private var percentChange: Double? {
-        PeriodHistoryChart.trendPercentChange(current: currentRawVolume, previous: averageRawVolume ?? 0)
+    private var buckets: [PeriodHistoryChart.Bucket] {
+        PeriodHistoryChart.scrollableBuckets(
+            for: period,
+            rawByPeriodStart: rawByPeriodStart,
+            firstDataDate: firstDataDate,
+            display: { convertWeightForDisplayingDecimal($0) },
+            formatted: { formatWeightForDisplay($0) }
+        )
     }
 
     /// Total volume (weight × reps over every set) in the range, in raw storage units.
@@ -130,14 +106,6 @@ struct ExerciseVolumeScreen: View {
             return range.contains(date)
         }
         return getVolume(of: sets, for: exercise)
-    }
-
-    private var buckets: [PeriodHistoryChart.Bucket] {
-        PeriodHistoryChart.buckets(
-            for: period,
-            value: { convertWeightForDisplayingDecimal(rawVolume(in: $0)) },
-            formatted: { formatWeightForDisplay(rawVolume(in: $0)) }
-        )
     }
 
     private var muscleGroupColor: Color {

--- a/LOGIT/Features/Home/SummaryStatScreen.swift
+++ b/LOGIT/Features/Home/SummaryStatScreen.swift
@@ -31,8 +31,22 @@ struct SummaryStatScreen: View {
             VStack(spacing: SECTION_SPACING) {
                 VStack(spacing: 16) {
                     PeriodPicker(selection: $period)
-                    header
-                    chart
+                    PeriodStatChartView(
+                        period: period,
+                        buckets: buckets,
+                        firstDataDate: firstDataDate,
+                        valueLabel: metric.title,
+                        unit: metric.unit,
+                        currentBarStyle: AnyShapeStyle(isDuration ? Color.secondary : Color.accentColor),
+                        currentLabel: period.currentPeriodLabel,
+                        currentValue: metric.formattedValue(fromRaw: currentRaw),
+                        currentRaw: currentRaw,
+                        trailingValueStyle: isDuration ? AnyShapeStyle(Color.label) : AnyShapeStyle(Color.accentColor.gradient),
+                        positiveColor: isDuration ? .secondary : .accentColor,
+                        formatAverage: { metric.formattedAverage(rawAverage: Double($0)) },
+                        displayAverage: { metric.displayValue(fromRaw: $0) },
+                        explanation: NSLocalizedString("averageComparisonInfo", comment: "")
+                    )
                 }
                 .padding(.horizontal)
                 AboutSection(metricTitle: metric.title, text: metric.aboutText)
@@ -51,57 +65,26 @@ struct SummaryStatScreen: View {
         }
     }
 
-    // MARK: - Header
-
-    private var header: some View {
-        HStack(alignment: .bottom) {
-            VStack(alignment: .leading, spacing: 4) {
-                Text(period.currentPeriodLabel)
-                    .font(.footnote)
-                    .fontWeight(.semibold)
-                    .textCase(.uppercase)
-                    .foregroundStyle(.secondary)
-                // A period sum is a real value even at zero ("0 sets this week"), clearer than a
-                // "––" no-data dash — same rule as the stat tiles.
-                UnitView(
-                    value: metric.formattedValue(fromRaw: currentRaw),
-                    unit: metric.unit,
-                    configuration: .large,
-                    unitColor: .secondaryLabel
-                )
-                .foregroundStyle(isDuration ? AnyShapeStyle(Color.label) : AnyShapeStyle(Color.accentColor.gradient))
-            }
-            Spacer()
-            if let percentChange {
-                TrendIndicatorView(
-                    percentChange: percentChange,
-                    positiveColor: isDuration ? .secondary : .accentColor
-                )
-                .animation(.snappy, value: percentChange)
-            }
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-    }
-
-    // MARK: - Chart
-
-    private var chart: some View {
-        PeriodHistoryChart(
-            buckets: buckets,
-            period: period,
-            valueLabel: metric.title,
-            currentBarStyle: AnyShapeStyle(isDuration ? Color.secondary : Color.accentColor),
-            unit: metric.unit
-        )
-    }
-
     // MARK: - Data
 
     private var currentRaw: Int { sum(in: period.currentRange()) }
-    private var previousRaw: Int { sum(in: period.previousRange()) }
 
-    private var percentChange: Double? {
-        PeriodHistoryChart.trendPercentChange(current: currentRaw, previous: previousRaw)
+    /// Earliest recorded workout — the left end of the scrollable domain.
+    private var firstDataDate: Date? {
+        workouts.compactMap { $0.date }.min()
+    }
+
+    /// The metric summed per period start, in one pass over the workouts so the scrollable chart looks
+    /// each period up instead of re-summing per bar. Keyed the same way `scrollableBuckets` keys its
+    /// lookups — `currentRange(containing:).lowerBound`.
+    private var rawByPeriodStart: [Date: Int] {
+        var dict: [Date: Int] = [:]
+        for workout in workouts {
+            guard let date = workout.date else { continue }
+            let start = period.currentRange(containing: date).lowerBound
+            dict[start, default: 0] += metric.rawValue(of: workout)
+        }
+        return dict
     }
 
     private func sum(in range: ClosedRange<Date>) -> Int {
@@ -111,10 +94,12 @@ struct SummaryStatScreen: View {
     }
 
     private var buckets: [PeriodHistoryChart.Bucket] {
-        PeriodHistoryChart.buckets(
+        PeriodHistoryChart.scrollableBuckets(
             for: period,
-            value: { metric.displayValue(fromRaw: sum(in: $0)) },
-            formatted: { metric.formattedValue(fromRaw: sum(in: $0)) }
+            rawByPeriodStart: rawByPeriodStart,
+            firstDataDate: firstDataDate,
+            display: { metric.displayValue(fromRaw: $0) },
+            formatted: { metric.formattedValue(fromRaw: $0) }
         )
     }
 }

--- a/LOGIT/SharedUI/Charts/PeriodHistoryChart.swift
+++ b/LOGIT/SharedUI/Charts/PeriodHistoryChart.swift
@@ -29,6 +29,10 @@ struct PeriodHistoryChart: View {
         /// The value as printed in the selection tooltip ("1,234", "12.5", "8"). Kept apart from
         /// `value` (which only sets the bar's height) so each screen formats it in its own units.
         var formattedValue: String
+        /// The period's value in raw storage units — what the moving visible-window average is taken
+        /// over (so "average" reads in the same units the header formats). Zero for the compact tile,
+        /// which shows no average.
+        var rawValue: Double = 0
     }
 
     let buckets: [Bucket]
@@ -44,78 +48,99 @@ struct PeriodHistoryChart: View {
     /// Whether the x-axis draws its period labels. Off for the compact tile, whose surrounding
     /// header already names the window it shows.
     var showsXAxisLabels: Bool = true
-    /// An optional reference value drawn as a dashed horizontal rule across the plot — the average
-    /// of the periods shown, excluding the current, still-growing one. Nil draws nothing, so the
-    /// Summary stat chart that doesn't pass it is unchanged. In the buckets' own value units.
+    /// An optional reference value drawn as a dashed horizontal rule across the plot — the average of
+    /// the visible periods, excluding the current, still-growing one. Nil draws nothing. In the
+    /// buckets' own value units, so it moves with the header as the chart scrolls.
     var averageLine: Double? = nil
+    /// When bound, the chart scrolls horizontally: `buckets` span the full history, a window of
+    /// `historyBucketCount` periods shows at a time, and this is its left edge (owned by the screen so
+    /// its header can read the visible window). Nil keeps the chart static — the compact muscle tile.
+    var scrollPosition: Binding<Date>? = nil
+    /// The earliest data date — the left end of the scrollable domain. Ignored when static.
+    var firstDataDate: Date? = nil
 
     @State private var selectedDate: Date?
 
     var body: some View {
         let maxValue = buckets.map(\.value).max() ?? 0
-        // At most ~4 axis labels, counted back from the current bucket so "now" is always labeled —
-        // one label per bucket sat shoulder-to-shoulder on the week view.
-        let labelStride = max(1, Int((Double(buckets.count) / 4.0).rounded(.up)))
-        let labeledDates = stride(from: buckets.count - 1, through: 0, by: -labelStride).map { buckets[$0].date }
         let selectedBucket = selectedDate.flatMap { nearestBucket(to: $0) }
-        Chart {
-            if let selectedBucket {
-                RuleMark(x: .value("Selected", selectedBucket.date, unit: period.calendarComponent))
-                    .foregroundStyle(Color.label.opacity(0.35))
-                    .lineStyle(StrokeStyle(lineWidth: 2))
-                    .annotation(
-                        position: annotationPosition(for: selectedBucket),
-                        overflowResolution: .init(x: .fit(to: .chart), y: .fit(to: .chart))
-                    ) {
-                        annotationCard(for: selectedBucket)
-                    }
+        scrollableIfNeeded(
+            Chart {
+                if let selectedBucket {
+                    RuleMark(x: .value("Selected", selectedBucket.date, unit: period.calendarComponent))
+                        .foregroundStyle(Color.label.opacity(0.35))
+                        .lineStyle(StrokeStyle(lineWidth: 2))
+                        .annotation(
+                            position: annotationPosition(for: selectedBucket),
+                            overflowResolution: .init(x: .fit(to: .chart), y: .fit(to: .chart))
+                        ) {
+                            annotationCard(for: selectedBucket)
+                        }
+                }
+                ForEach(buckets) { bucket in
+                    BarMark(
+                        x: .value("Period", bucket.date, unit: period.calendarComponent),
+                        y: .value(valueLabel, bucket.value),
+                        width: .ratio(0.6)
+                    )
+                    .foregroundStyle(barStyle(for: bucket, selected: selectedBucket))
+                    .clipShape(RoundedRectangle(cornerRadius: 3, style: .continuous))
+                    // A tapped bar stays lit; every other bar goes quiet while one is inspected.
+                    .opacity(selectedBucket == nil || selectedBucket?.id == bucket.id ? 1.0 : 0.4)
+                }
+                // The visible window's average, as a dashed reference the current bar reads against —
+                // moving with the header as the chart scrolls. Drawn last so it sits above the bars.
+                if let averageLine {
+                    RuleMark(y: .value(NSLocalizedString("average", comment: ""), averageLine))
+                        .averageLineStyle()
+                }
             }
-            ForEach(buckets) { bucket in
-                BarMark(
-                    x: .value("Period", bucket.date, unit: period.calendarComponent),
-                    y: .value(valueLabel, bucket.value),
-                    width: .ratio(0.6)
-                )
-                .foregroundStyle(barStyle(for: bucket, selected: selectedBucket))
-                .clipShape(RoundedRectangle(cornerRadius: 3, style: .continuous))
-                // A tapped bar stays lit; every other bar goes quiet while one is inspected.
-                .opacity(selectedBucket == nil || selectedBucket?.id == bucket.id ? 1.0 : 0.4)
-            }
-            // The average of the completed periods shown, as a dashed reference the current bar can
-            // be read against. Drawn after the bars so it sits on top; only when a value is supplied.
-            if let averageLine {
-                RuleMark(y: .value(NSLocalizedString("average", comment: ""), averageLine))
-                    .averageLineStyle()
-            }
-        }
-        // ~1/6 headroom above the tallest bar so a peak never touches the ceiling (matches the tiles).
-        .chartYScale(domain: 0 ... max(maxValue * 1.15, 1))
-        .chartXSelection(value: $selectedDate)
-        .chartXAxis {
-            if showsXAxisLabels {
-                AxisMarks(values: labeledDates) { value in
-                    if let date = value.as(Date.self) {
-                        let isCurrent = period.currentRange().contains(date)
-                        AxisGridLine()
-                            .foregroundStyle(Color.gray.opacity(0.4))
-                        // Styling lives on the Text inside the label closure — hierarchical styles on
-                        // the AxisMark itself resolve against the chart's accent on iOS 26 (labels
-                        // turned lime). The current period's label is always the newest (labels stride
-                        // back from it) and sits at the plot edge — hang it trailing off its mark so
-                        // the edge can't clip it.
-                        AxisValueLabel(anchor: isCurrent ? .topTrailing : nil) {
-                            Text(period.axisLabel(for: date))
-                                .font(.caption.weight(isCurrent ? .bold : .semibold))
-                                .foregroundStyle(isCurrent ? Color.label : Color.secondaryLabel)
+            // ~1/6 headroom above the tallest bar so a peak never touches the ceiling (matches tiles).
+            .chartYScale(domain: 0 ... max(maxValue * 1.15, 1))
+            .chartXSelection(value: $selectedDate)
+            .chartXAxis {
+                if showsXAxisLabels {
+                    let axisStride = period.scrollAxisStride
+                    AxisMarks(values: .stride(by: axisStride.component, count: axisStride.count)) { value in
+                        if let date = value.as(Date.self) {
+                            let isCurrent = period.currentRange().contains(date)
+                            AxisGridLine()
+                                .foregroundStyle(Color.gray.opacity(0.4))
+                            // Styling lives on the Text inside the label closure — hierarchical styles
+                            // on the AxisMark resolve against the chart's accent on iOS 26 (labels
+                            // turned lime). The current period hugs the right edge on first load, so
+                            // hang its label trailing off the mark to keep the edge from clipping it.
+                            AxisValueLabel(anchor: isCurrent ? .topTrailing : nil) {
+                                Text(period.axisLabel(for: date))
+                                    .font(.caption.weight(isCurrent ? .bold : .semibold))
+                                    .foregroundStyle(isCurrent ? Color.label : Color.secondaryLabel)
+                            }
                         }
                     }
                 }
             }
-        }
-        .chartYAxis {
-            AxisMarks(values: .automatic(desiredCount: 3))
-        }
+            .chartYAxis {
+                AxisMarks(values: .automatic(desiredCount: 3))
+            }
+        )
         .frame(height: height)
+    }
+
+    /// Wraps the chart in the scrollable-timeline modifiers when a `scrollPosition` is bound — the
+    /// full-detail charts scroll a `historyBucketCount`-wide window through the whole history; the
+    /// compact muscle tile, with no binding, stays static on its fixed recent window.
+    @ViewBuilder
+    private func scrollableIfNeeded(_ chart: some View) -> some View {
+        if let scrollPosition {
+            chart
+                .chartXScale(domain: period.scrollableXDomain(firstDataDate: firstDataDate))
+                .chartScrollableAxes(.horizontal)
+                .chartScrollPosition(x: scrollPosition)
+                .chartXVisibleDomain(length: period.visibleDomainSeconds())
+                .chartScrollTargetBehavior(.valueAligned(matching: period.scrollSnapComponents))
+        } else {
+            chart
+        }
     }
 
     // MARK: - Selection
@@ -134,11 +159,20 @@ struct PeriodHistoryChart: View {
         return AnyShapeStyle(Color.fill)
     }
 
-    /// Hang the card leading when the inspected bar sits in the right third of the chart, trailing in
-    /// the left third, centred otherwise — so an edge bar's card never lays out past the plot.
+    /// Hang the card leading when the inspected bar sits in the right third, trailing in the left
+    /// third, centred otherwise — so an edge bar's card never lays out past the plot. On the
+    /// scrollable charts the thirds are measured within the visible window (the plot scrolls, so
+    /// `fit(to: .chart)` alone would let an edge card lay out into off-viewport periods and clip).
     private func annotationPosition(for bucket: Bucket) -> AnnotationPosition {
-        guard buckets.count > 1, let index = buckets.firstIndex(where: { $0.id == bucket.id }) else { return .top }
-        let fraction = Double(index) / Double(buckets.count - 1)
+        let fraction: Double
+        if let scrollPosition {
+            let windowSeconds = Double(period.visibleDomainSeconds())
+            guard windowSeconds > 0 else { return .top }
+            fraction = bucket.date.timeIntervalSince(scrollPosition.wrappedValue) / windowSeconds
+        } else {
+            guard buckets.count > 1, let index = buckets.firstIndex(where: { $0.id == bucket.id }) else { return .top }
+            fraction = Double(index) / Double(buckets.count - 1)
+        }
         if fraction > 0.66 { return .topLeading }
         if fraction < 0.33 { return .topTrailing }
         return .top
@@ -207,6 +241,42 @@ extension PeriodHistoryChart {
         String(Int(value.rounded()))
     }
 
+    /// Buckets for the whole scrollable history — one per period from the first data point through
+    /// the current period. `rawByPeriodStart` is the data pre-grouped by period start (built in one
+    /// pass by the screen), looked up per period so building N bars stays O(periods) rather than
+    /// re-filtering the data per bar; keys must be `period.currentRange(containing:).lowerBound`, the
+    /// same canonical period start this uses. `display` maps a raw sum to the bar's height, `formatted`
+    /// to its tooltip, and the raw sum rides along for the moving visible-window average.
+    static func scrollableBuckets(
+        for period: StatPeriod,
+        rawByPeriodStart: [Date: Int],
+        firstDataDate: Date?,
+        now: Date = .now,
+        display: (Int) -> Double,
+        formatted: (Int) -> String
+    ) -> [Bucket] {
+        let domain = period.scrollableXDomain(firstDataDate: firstDataDate, now: now)
+        let currentStart = period.currentRange(containing: now).lowerBound
+        var buckets: [Bucket] = []
+        var start = period.currentRange(containing: domain.lowerBound).lowerBound
+        var index = 0
+        while start <= currentStart {
+            let raw = rawByPeriodStart[start] ?? 0
+            buckets.append(Bucket(
+                id: index,
+                date: start,
+                value: display(raw),
+                isCurrent: start == currentStart,
+                formattedValue: formatted(raw),
+                rawValue: Double(raw)
+            ))
+            guard let next = Calendar.current.date(byAdding: period.calendarComponent, value: 1, to: start) else { break }
+            start = period.currentRange(containing: next).lowerBound
+            index += 1
+        }
+        return buckets
+    }
+
     /// The period-over-period trend for a stat header, or nil unless both periods have data — a
     /// freshly started week must not read as a "−100%" collapse (the same suppression rule as the
     /// stat tiles).
@@ -224,6 +294,122 @@ extension ChartContent {
     func averageLineStyle() -> some ChartContent {
         foregroundStyle(Color.secondaryLabel)
             .lineStyle(StrokeStyle(lineWidth: 3, lineCap: .round, dash: [5, 10]))
+    }
+}
+
+/// The shared scrollable header-plus-chart for the period-scoped stat detail screens (exercise
+/// Volume / Sets, the Summary stats). It owns the scroll position — deliberately, so that scrolling
+/// and inspecting re-evaluate only *this* view, never the screen that builds `buckets`; the whole
+/// history is bucketed once per period up in the parent, not on every scroll frame. As the window
+/// scrolls, the header's neutral "Average" side and the dashed line both retarget to the average of
+/// the visible, completed periods, while the tinted "this period" side stays the fixed subject — the
+/// same scoreboard the workout stat screen uses, at week / month / year granularity.
+struct PeriodStatChartView: View {
+    let period: StatPeriod
+    /// The whole history, one bucket per period, built once by the parent.
+    let buckets: [PeriodHistoryChart.Bucket]
+    let firstDataDate: Date?
+    let valueLabel: String
+    let unit: String
+    let currentBarStyle: AnyShapeStyle
+    /// Trailing (subject) side: "This Week" and the current period's value, fixed as the chart scrolls.
+    let currentLabel: String
+    let currentValue: String
+    let currentRaw: Int
+    let trailingValueStyle: AnyShapeStyle
+    let positiveColor: Color
+    var positiveStyle: AnyShapeStyle? = nil
+    /// Raw visible-window average → the header string (each screen rounds / formats in its own units).
+    let formatAverage: (Int) -> String
+    /// Raw visible-window average → the dashed line's height in display units.
+    let displayAverage: (Int) -> Double
+    var explanation: String? = nil
+
+    @State private var scrollPosition: Date
+
+    init(
+        period: StatPeriod,
+        buckets: [PeriodHistoryChart.Bucket],
+        firstDataDate: Date?,
+        valueLabel: String,
+        unit: String,
+        currentBarStyle: AnyShapeStyle,
+        currentLabel: String,
+        currentValue: String,
+        currentRaw: Int,
+        trailingValueStyle: AnyShapeStyle,
+        positiveColor: Color,
+        positiveStyle: AnyShapeStyle? = nil,
+        formatAverage: @escaping (Int) -> String,
+        displayAverage: @escaping (Int) -> Double,
+        explanation: String? = nil
+    ) {
+        self.period = period
+        self.buckets = buckets
+        self.firstDataDate = firstDataDate
+        self.valueLabel = valueLabel
+        self.unit = unit
+        self.currentBarStyle = currentBarStyle
+        self.currentLabel = currentLabel
+        self.currentValue = currentValue
+        self.currentRaw = currentRaw
+        self.trailingValueStyle = trailingValueStyle
+        self.positiveColor = positiveColor
+        self.positiveStyle = positiveStyle
+        self.formatAverage = formatAverage
+        self.displayAverage = displayAverage
+        self.explanation = explanation
+        _scrollPosition = State(initialValue: period.initialScrollPosition())
+    }
+
+    var body: some View {
+        // The completed periods on screen — the current, still-growing one and untrained periods left
+        // out, matching the pill's "both sides need data" rule. O(buckets) per scroll frame; the
+        // buckets themselves are the parent's, unchanged by scrolling.
+        let window = period.visibleWindowRange(from: scrollPosition)
+        let visible = buckets.filter { !$0.isCurrent && $0.rawValue > 0 && window.contains($0.date) }
+        let averageRaw: Int? = visible.isEmpty
+            ? nil
+            : Int((visible.map(\.rawValue).reduce(0, +) / Double(visible.count)).rounded())
+        let percentChange = PeriodHistoryChart.trendPercentChange(current: currentRaw, previous: averageRaw ?? 0)
+        return VStack(spacing: 16) {
+            MetricComparisonView(
+                leading: .init(
+                    label: NSLocalizedString("average", comment: ""),
+                    value: averageRaw.map(formatAverage) ?? "––",
+                    unit: unit,
+                    caption: period.rangeCaption(window)
+                ),
+                trailing: .init(
+                    label: currentLabel,
+                    value: currentValue,
+                    unit: unit,
+                    caption: period.rangeCaption(period.currentRange())
+                ),
+                trailingValueStyle: trailingValueStyle,
+                percentChange: percentChange,
+                positiveColor: positiveColor,
+                positiveStyle: positiveStyle,
+                explanation: explanation
+            )
+            .frame(maxWidth: .infinity, alignment: .leading)
+            PeriodHistoryChart(
+                buckets: buckets,
+                period: period,
+                valueLabel: valueLabel,
+                currentBarStyle: currentBarStyle,
+                unit: unit,
+                averageLine: averageRaw.map(displayAverage),
+                scrollPosition: $scrollPosition,
+                firstDataDate: firstDataDate
+            )
+            // A fresh chart per granularity: switching week/month/year changes the visible-domain
+            // length, which otherwise leaves the scroll offset stale (see the capability charts).
+            .id(period)
+        }
+        .onChange(of: period) {
+            scrollPosition = period.initialScrollPosition()
+        }
     }
 }
 


### PR DESCRIPTION
The period/bar stat charts were fixed to their most recent ~12 periods, while the line capability charts (Weight, e1RM, …) already scrolled. This brings them to the same **scrollable + moving-average** model the workout stat screen uses.

**What changed**
- **Exercise Volume / Sets** and **Summary volume / duration / sets / reps** charts now scroll horizontally back through the whole history.
- The header's neutral **Average** side and the **dashed reference line** retarget to the average of the *visible, completed* periods as you scroll; the tinted **this period** side stays the fixed subject.
- **Hold-to-inspect** (the bar selection from #71) works on the scrollable timeline.
- The **Summary** stat screens — which showed only a value + a vs-previous-period trend — gain the same average-comparison header (fills in the "same thing for the summary screens" request).

**How it's built (no scroll lag)**
- `PeriodHistoryChart` gains an optional `scrollPosition` + `firstDataDate`; the compact muscle-group tile passes neither and stays static (unchanged).
- The whole history is bucketed **once per period** in each screen (a single-pass dict, cheaper than the old per-bar filtering) and handed to a shared `PeriodStatChartView` that owns the scroll position — so scrolling/inspecting re-evaluate only the header, never the buckets.
- `StatPeriod` gains the scroll geometry (domain, visible window, snapping), mirroring `ChartRange`'s.
- The average line's dashed style is the shared `averageLineStyle()` from the earlier PR.

Verified on iPhone 17 Pro / iOS 26.4 (stress = 2 years of data): scrolling back moves the average (e.g. 4564 → 4223 → 3843 kg) and the dashed line; hold-to-select shows the bar tooltip mid-scroll; Summary Duration formats "10h 11m" with neutral styling; week/month/year and the no-data edge (badge/line hidden) all correct.

Follow-up: the line-chart selection lag (issue 3) is a separate area (the capability screens) and comes in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
