### PR TITLE
Fix selection lag on the exercise capability charts

### DIFF
--- a/LOGIT/Features/Exercise/ExerciseDetail/ExerciseE1RMScreen.swift
+++ b/LOGIT/Features/Exercise/ExerciseDetail/ExerciseE1RMScreen.swift
@@ -14,16 +14,32 @@ struct ExerciseE1RMScreen: View {
 
     let exercise: Exercise
     let workoutSets: [WorkoutSet]
+    /// Daily-max sets, grouped once at init. The chart, the header baseline, the y-scale, the domain
+    /// and the selection all read from this — so scrolling or inspecting never regroups every set
+    /// again. (The selection lag came from `firstDataDate` re-grouping all sets once per axis mark,
+    /// every frame.)
+    private let dailyMaxSets: [WorkoutSet]
+    /// Earliest day with data — anchors the scrollable domain and the All range. Derived once from
+    /// `dailyMaxSets`, not recomputed on every scroll/selection frame.
+    private let firstDataDate: Date?
 
     @State private var chartRange: ChartRange = .threeMonths
     @State private var chartScrollPosition: Date = .now
     @State private var selectedDate: Date?
 
+    init(exercise: Exercise, workoutSets: [WorkoutSet]) {
+        self.exercise = exercise
+        self.workoutSets = workoutSets
+        let daily = Self.dailyMaxE1RMSets(in: workoutSets, for: exercise)
+        self.dailyMaxSets = daily
+        self.firstDataDate = daily.first?.workout?.date
+    }
+
     var body: some View {
-        let allDailyMaxSets = allDailyMaxE1RMSets(in: workoutSets)
+        let allDailyMaxSets = dailyMaxSets
         // Determine the snapped selected set only when a selection exists; snap to the nearest datapoint (prefer visible)
         let snappedSelectedSet: WorkoutSet? = selectedDate != nil ? nearestSet(to: selectedDate, in: allDailyMaxSets) : nil
-        let bestVisibleE1RM = bestE1RMInVisibleWindow(workoutSets)
+        let bestVisibleE1RM = bestE1RMInVisibleWindow()
         ScrollView {
             VStack(spacing: SECTION_SPACING) {
                 VStack {
@@ -155,7 +171,7 @@ struct ExerciseE1RMScreen: View {
                         }
                     }
                     .chartXScale(domain: chartRange.xDomain(firstDataDate: firstDataDate))
-                    .chartYScale(domain: 0 ... chartYScaleMax(maxYValue: allTimeE1RMPR(in: workoutSets)))
+                    .chartYScale(domain: 0 ... chartYScaleMax(maxYValue: allTimeE1RMPR))
                     .chartScrollableAxes(.horizontal)
                     .chartScrollPosition(x: $chartScrollPosition)
                     .chartScrollTargetBehavior(
@@ -179,7 +195,7 @@ struct ExerciseE1RMScreen: View {
                         }
                     }
                     .chartYAxis {
-                        let chartYScaleMax = chartYScaleMax(maxYValue: allTimeE1RMPR(in: workoutSets))
+                        let chartYScaleMax = chartYScaleMax(maxYValue: allTimeE1RMPR)
                         AxisMarks(values: [0, chartYScaleMax / 2, chartYScaleMax])
                     }
                     .emptyPlaceholder(allDailyMaxSets) {
@@ -222,7 +238,7 @@ struct ExerciseE1RMScreen: View {
         }
     }
 
-    private func allDailyMaxE1RMSets(in workoutSets: [WorkoutSet]) -> [WorkoutSet] {
+    private static func dailyMaxE1RMSets(in workoutSets: [WorkoutSet], for exercise: Exercise) -> [WorkoutSet] {
         let groupedSets = Dictionary(grouping: workoutSets) {
             Calendar.current.startOfDay(for: $0.workout?.date ?? .now)
         }.sorted { $0.key < $1.key }
@@ -233,11 +249,6 @@ struct ExerciseE1RMScreen: View {
             }
             .filter { $0.estimatedOneRepMax(for: exercise) > 0 }
         return maxSetsPerDay
-    }
-
-    /// Earliest day with a value — anchors the scrollable domain and the All range.
-    private var firstDataDate: Date? {
-        allDailyMaxE1RMSets(in: workoutSets).first?.workout?.date
     }
 
     private var visibleChartDomainInSeconds: Int {
@@ -252,9 +263,9 @@ struct ExerciseE1RMScreen: View {
 
 
 
-    private func allTimeE1RMPR(in workoutSets: [WorkoutSet]) -> Int {
+    private var allTimeE1RMPR: Int {
         convertWeightForDisplaying(
-            workoutSets
+            dailyMaxSets
                 .map {
                     $0.estimatedOneRepMax(for: exercise)
                 }
@@ -265,9 +276,9 @@ struct ExerciseE1RMScreen: View {
     /// The header's left value and the comparison baseline: the best e1RM in the visible window
     /// *other than* the current best, falling back to the most recent day's best before the window
     /// when it holds no other value (see `exerciseOtherBestBaseline`).
-    private func bestE1RMInVisibleWindow(_ workoutSets: [WorkoutSet]) -> Int? {
+    private func bestE1RMInVisibleWindow() -> Int? {
         exerciseOtherBestBaseline(
-            sets: workoutSets,
+            sets: dailyMaxSets,
             windowStart: chartScrollPosition,
             windowEnd: visibleEndDate,
             currentBestDay: bestAnchor?.date

--- a/LOGIT/Features/Exercise/ExerciseDetail/ExerciseRepetitionsScreen.swift
+++ b/LOGIT/Features/Exercise/ExerciseDetail/ExerciseRepetitionsScreen.swift
@@ -13,16 +13,32 @@ struct ExerciseRepetitionsScreen: View {
 
     let exercise: Exercise
     let workoutSets: [WorkoutSet]
+    /// Daily-max sets, grouped once at init. The chart, the header baseline, the y-scale, the domain
+    /// and the selection all read from this — so scrolling or inspecting never regroups every set
+    /// again. (The selection lag came from `firstDataDate` re-grouping all sets once per axis mark,
+    /// every frame.)
+    private let dailyMaxSets: [WorkoutSet]
+    /// Earliest day with data — anchors the scrollable domain and the All range. Derived once from
+    /// `dailyMaxSets`, not recomputed on every scroll/selection frame.
+    private let firstDataDate: Date?
 
     @State private var chartRange: ChartRange = .threeMonths
     @State private var chartScrollPosition: Date = .now
     @State private var selectedDate: Date?
 
+    init(exercise: Exercise, workoutSets: [WorkoutSet]) {
+        self.exercise = exercise
+        self.workoutSets = workoutSets
+        let daily = Self.dailyMaxRepetitionsSets(in: workoutSets, for: exercise)
+        self.dailyMaxSets = daily
+        self.firstDataDate = daily.first?.workout?.date
+    }
+
     var body: some View {
-        let allDailyMaxRepsSets = allDailyMaxRepetitionsSets(in: workoutSets)
+        let allDailyMaxRepsSets = dailyMaxSets
         // Determine the snapped selected set only when a selection exists; snap to the overall nearest datapoint
         let snappedSelectedSet: WorkoutSet? = selectedDate != nil ? nearestSet(to: selectedDate, in: allDailyMaxRepsSets) : nil
-        let bestRepsInVisibleWindow: Int? = bestRepetitionsInVisibleWindow(in: workoutSets)
+        let bestRepsInVisibleWindow: Int? = bestRepetitionsInVisibleWindow()
         ScrollView {
             VStack(spacing: SECTION_SPACING) {
                 VStack {
@@ -155,7 +171,7 @@ struct ExerciseRepetitionsScreen: View {
                 }
             }
             .chartXScale(domain: chartRange.xDomain(firstDataDate: firstDataDate))
-            .chartYScale(domain: 0 ... chartYScaleMax(maxYValue: allTimeRepetitionsPR(in: workoutSets)))
+            .chartYScale(domain: 0 ... chartYScaleMax(maxYValue: allTimeRepetitionsPR))
             .chartScrollableAxes(.horizontal)
             .chartScrollPosition(x: $chartScrollPosition)
             .chartScrollTargetBehavior(
@@ -179,7 +195,7 @@ struct ExerciseRepetitionsScreen: View {
                 }
             }
             .chartYAxis {
-                let chartYScaleMax = chartYScaleMax(maxYValue: allTimeRepetitionsPR(in: workoutSets))
+                let chartYScaleMax = chartYScaleMax(maxYValue: allTimeRepetitionsPR)
                 AxisMarks(values: [0, chartYScaleMax / 2, chartYScaleMax])
             }
             .emptyPlaceholder(allDailyMaxRepsSets) {
@@ -226,7 +242,7 @@ struct ExerciseRepetitionsScreen: View {
 
     // MARK: - Private Methods
 
-    private func allDailyMaxRepetitionsSets(in workoutSets: [WorkoutSet]) -> [WorkoutSet] {
+    private static func dailyMaxRepetitionsSets(in workoutSets: [WorkoutSet], for exercise: Exercise) -> [WorkoutSet] {
         let groupedSets = Dictionary(grouping: workoutSets) {
             Calendar.current.startOfDay(for: $0.workout?.date ?? .now)
         }.sorted { $0.key < $1.key }
@@ -237,11 +253,6 @@ struct ExerciseRepetitionsScreen: View {
             }
             .filter { $0.maximum(.repetitions, for: exercise) > 0 }
         return maxSetsPerDay
-    }
-
-    /// Earliest day with a value — anchors the scrollable domain and the All range.
-    private var firstDataDate: Date? {
-        allDailyMaxRepetitionsSets(in: workoutSets).first?.workout?.date
     }
 
     private var visibleChartDomainInSeconds: Int {
@@ -256,8 +267,8 @@ struct ExerciseRepetitionsScreen: View {
 
 
 
-    private func allTimeRepetitionsPR(in workoutSets: [WorkoutSet]) -> Int {
-        workoutSets
+    private var allTimeRepetitionsPR: Int {
+        dailyMaxSets
             .map {
                 $0.maximum(.repetitions, for: exercise)
             }
@@ -267,9 +278,9 @@ struct ExerciseRepetitionsScreen: View {
     /// The header's left value and the comparison baseline: the best reps in the visible window
     /// *other than* the current best, falling back to the most recent day's best before the window
     /// when it holds no other value (see `exerciseOtherBestBaseline`).
-    private func bestRepetitionsInVisibleWindow(in workoutSets: [WorkoutSet]) -> Int? {
+    private func bestRepetitionsInVisibleWindow() -> Int? {
         exerciseOtherBestBaseline(
-            sets: workoutSets,
+            sets: dailyMaxSets,
             windowStart: chartScrollPosition,
             windowEnd: visibleEndDate,
             currentBestDay: bestAnchor?.date

--- a/LOGIT/Features/Exercise/ExerciseDetail/ExerciseSetVolumeScreen.swift
+++ b/LOGIT/Features/Exercise/ExerciseDetail/ExerciseSetVolumeScreen.swift
@@ -11,16 +11,32 @@ import SwiftUI
 struct ExerciseSetVolumeScreen: View {
     let exercise: Exercise
     let workoutSets: [WorkoutSet]
+    /// Daily-max sets, grouped once at init. The chart, the header baseline, the y-scale, the domain
+    /// and the selection all read from this — so scrolling or inspecting never regroups every set
+    /// again. (The selection lag came from `firstDataDate` re-grouping all sets once per axis mark,
+    /// every frame.)
+    private let dailyMaxSets: [WorkoutSet]
+    /// Earliest day with data — anchors the scrollable domain and the All range. Derived once from
+    /// `dailyMaxSets`, not recomputed on every scroll/selection frame.
+    private let firstDataDate: Date?
 
     @State private var chartRange: ChartRange = .threeMonths
     @State private var chartScrollPosition: Date = .now
     @State private var selectedDate: Date?
 
+    init(exercise: Exercise, workoutSets: [WorkoutSet]) {
+        self.exercise = exercise
+        self.workoutSets = workoutSets
+        let daily = Self.dailyMaxSetVolumeSets(in: workoutSets, for: exercise)
+        self.dailyMaxSets = daily
+        self.firstDataDate = daily.first?.workout?.date
+    }
+
     var body: some View {
-        let allDailyMaxSets = allDailyMaxSetVolumeSets(in: workoutSets)
+        let allDailyMaxSets = dailyMaxSets
         // Determine the snapped selected set only when a selection exists; snap to the nearest datapoint (prefer visible)
         let snappedSelectedSet: WorkoutSet? = selectedDate != nil ? nearestSet(to: selectedDate, in: allDailyMaxSets) : nil
-        let bestVisibleSetVolume = bestSetVolumeInVisibleWindow(workoutSets)
+        let bestVisibleSetVolume = bestSetVolumeInVisibleWindow()
         ScrollView {
             VStack(spacing: SECTION_SPACING) {
                 VStack {
@@ -152,7 +168,7 @@ struct ExerciseSetVolumeScreen: View {
                         }
                     }
                     .chartXScale(domain: chartRange.xDomain(firstDataDate: firstDataDate))
-                    .chartYScale(domain: 0 ... chartYScaleMax(maxYValue: allTimeSetVolumePR(in: workoutSets)))
+                    .chartYScale(domain: 0 ... chartYScaleMax(maxYValue: allTimeSetVolumePR))
                     .chartScrollableAxes(.horizontal)
                     .chartScrollPosition(x: $chartScrollPosition)
                     .chartScrollTargetBehavior(
@@ -176,7 +192,7 @@ struct ExerciseSetVolumeScreen: View {
                         }
                     }
                     .chartYAxis {
-                        let chartYScaleMax = chartYScaleMax(maxYValue: allTimeSetVolumePR(in: workoutSets))
+                        let chartYScaleMax = chartYScaleMax(maxYValue: allTimeSetVolumePR)
                         AxisMarks(values: [0, chartYScaleMax / 2, chartYScaleMax])
                     }
                     .emptyPlaceholder(allDailyMaxSets) {
@@ -219,7 +235,7 @@ struct ExerciseSetVolumeScreen: View {
         }
     }
 
-    private func allDailyMaxSetVolumeSets(in workoutSets: [WorkoutSet]) -> [WorkoutSet] {
+    private static func dailyMaxSetVolumeSets(in workoutSets: [WorkoutSet], for exercise: Exercise) -> [WorkoutSet] {
         let groupedSets = Dictionary(grouping: workoutSets) {
             Calendar.current.startOfDay(for: $0.workout?.date ?? .now)
         }.sorted { $0.key < $1.key }
@@ -230,11 +246,6 @@ struct ExerciseSetVolumeScreen: View {
             }
             .filter { $0.volume(for: exercise) > 0 }
         return maxSetsPerDay
-    }
-
-    /// Earliest day with a value — anchors the scrollable domain and the All range.
-    private var firstDataDate: Date? {
-        allDailyMaxSetVolumeSets(in: workoutSets).first?.workout?.date
     }
 
     private var visibleChartDomainInSeconds: Int {
@@ -249,9 +260,9 @@ struct ExerciseSetVolumeScreen: View {
 
 
 
-    private func allTimeSetVolumePR(in workoutSets: [WorkoutSet]) -> Int {
+    private var allTimeSetVolumePR: Int {
         convertWeightForDisplaying(
-            workoutSets
+            dailyMaxSets
                 .map {
                     $0.volume(for: exercise)
                 }
@@ -262,9 +273,9 @@ struct ExerciseSetVolumeScreen: View {
     /// The header's left value and the comparison baseline: the best single-set volume in the visible
     /// window *other than* the current best, falling back to the most recent day's best before the
     /// window when it holds no other value (see `exerciseOtherBestBaseline`).
-    private func bestSetVolumeInVisibleWindow(_ workoutSets: [WorkoutSet]) -> Int? {
+    private func bestSetVolumeInVisibleWindow() -> Int? {
         exerciseOtherBestBaseline(
-            sets: workoutSets,
+            sets: dailyMaxSets,
             windowStart: chartScrollPosition,
             windowEnd: visibleEndDate,
             currentBestDay: bestAnchor?.date

--- a/LOGIT/Features/Exercise/ExerciseDetail/ExerciseWeightScreen.swift
+++ b/LOGIT/Features/Exercise/ExerciseDetail/ExerciseWeightScreen.swift
@@ -14,16 +14,32 @@ struct ExerciseWeightScreen: View {
 
     let exercise: Exercise
     let workoutSets: [WorkoutSet]
+    /// Daily-max sets, grouped once at init. The chart, the header baseline, the y-scale, the domain
+    /// and the selection all read from this — so scrolling or inspecting never regroups every set
+    /// again. (The selection lag came from `firstDataDate` re-grouping all sets once per axis mark,
+    /// every frame.)
+    private let dailyMaxSets: [WorkoutSet]
+    /// Earliest day with a recorded weight — anchors the scrollable domain and the All range. Derived
+    /// once from `dailyMaxSets`, not recomputed on every scroll/selection frame.
+    private let firstDataDate: Date?
 
     @State private var chartRange: ChartRange = .threeMonths
     @State private var chartScrollPosition: Date = .now
     @State private var selectedDate: Date?
 
+    init(exercise: Exercise, workoutSets: [WorkoutSet]) {
+        self.exercise = exercise
+        self.workoutSets = workoutSets
+        let daily = Self.dailyMaxWeightSets(in: workoutSets, for: exercise)
+        self.dailyMaxSets = daily
+        self.firstDataDate = daily.first?.workout?.date
+    }
+
     var body: some View {
-        let allDailyMaxSets = allDailyMaxWeightSets(in: workoutSets)
+        let allDailyMaxSets = dailyMaxSets
         // Determine the snapped selected set only when a selection exists; snap to the nearest datapoint (prefer visible)
         let snappedSelectedSet: WorkoutSet? = selectedDate != nil ? nearestSet(to: selectedDate, in: allDailyMaxSets) : nil
-        let bestVisibleWeight = bestWeightInVisibleWindow(workoutSets)
+        let bestVisibleWeight = bestWeightInVisibleWindow()
         ScrollView {
             VStack(spacing: SECTION_SPACING) {
                 VStack {
@@ -155,7 +171,7 @@ struct ExerciseWeightScreen: View {
                 }
             }
             .chartXScale(domain: chartRange.xDomain(firstDataDate: firstDataDate))
-            .chartYScale(domain: 0 ... chartYScaleMax(maxYValue: allTimeWeightPR(in: workoutSets)))
+            .chartYScale(domain: 0 ... chartYScaleMax(maxYValue: allTimeWeightPR))
             .chartScrollableAxes(.horizontal)
             .chartScrollPosition(x: $chartScrollPosition)
             .chartScrollTargetBehavior(
@@ -179,7 +195,7 @@ struct ExerciseWeightScreen: View {
                 }
             }
             .chartYAxis {
-                let chartYScaleMax = chartYScaleMax(maxYValue: allTimeWeightPR(in: workoutSets))
+                let chartYScaleMax = chartYScaleMax(maxYValue: allTimeWeightPR)
                 AxisMarks(values: [0, chartYScaleMax / 2, chartYScaleMax])
             }
             .emptyPlaceholder(allDailyMaxSets) {
@@ -222,22 +238,16 @@ struct ExerciseWeightScreen: View {
         }
     }
 
-    private func allDailyMaxWeightSets(in workoutSets: [WorkoutSet]) -> [WorkoutSet] {
+    private static func dailyMaxWeightSets(in workoutSets: [WorkoutSet], for exercise: Exercise) -> [WorkoutSet] {
         let groupedSets = Dictionary(grouping: workoutSets) {
             Calendar.current.startOfDay(for: $0.workout?.date ?? .now)
         }.sorted { $0.key < $1.key }
             .map { $0.1 }
-        let maxSetsPerDay = groupedSets
+        return groupedSets
             .compactMap { setsPerDay -> WorkoutSet? in
-                return setsPerDay.max(by: { $0.maximum(.weight, for: exercise) < $1.maximum(.weight, for: exercise) })
+                setsPerDay.max(by: { $0.maximum(.weight, for: exercise) < $1.maximum(.weight, for: exercise) })
             }
             .filter { $0.maximum(.weight, for: exercise) > 0 }
-        return maxSetsPerDay
-    }
-
-    /// Earliest day with a recorded weight — anchors the scrollable domain and the All range.
-    private var firstDataDate: Date? {
-        allDailyMaxWeightSets(in: workoutSets).first?.workout?.date
     }
 
     private var visibleChartDomainInSeconds: Int {
@@ -248,13 +258,11 @@ struct ExerciseWeightScreen: View {
         exercise.muscleGroup?.color ?? Color.accentColor
     }
 
-    private func allTimeWeightPR(in workoutSets: [WorkoutSet]) -> Int {
+    /// The all-time best max-weight in display units — the y-axis cap. Read from `dailyMaxSets` (each
+    /// day's max already includes that day's best), so it scans days, not every set.
+    private var allTimeWeightPR: Int {
         convertWeightForDisplaying(
-            workoutSets
-                .map {
-                    $0.maximum(.weight, for: exercise)
-                }
-                .max() ?? 0
+            dailyMaxSets.map { $0.maximum(.weight, for: exercise) }.max() ?? 0
         )
     }
 
@@ -262,9 +270,12 @@ struct ExerciseWeightScreen: View {
     /// *other than* the current best, so the pill measures the current best against the rest of the
     /// shown period rather than itself when the peak is in view. Falls back to the most recent day's
     /// best before the window when it holds no other value (see `exerciseOtherBestBaseline`).
-    private func bestWeightInVisibleWindow(_ workoutSets: [WorkoutSet]) -> Int? {
+    /// The header's left value and the pill baseline, read from `dailyMaxSets` (a per-day max is the
+    /// day's best, so the best over the window is the same as over every set) — a day scan, not a
+    /// full-set scan on every scroll/selection frame.
+    private func bestWeightInVisibleWindow() -> Int? {
         exerciseOtherBestBaseline(
-            sets: workoutSets,
+            sets: dailyMaxSets,
             windowStart: chartScrollPosition,
             windowEnd: visibleEndDate,
             currentBestDay: bestAnchor?.date


### PR DESCRIPTION
The scrollable capability charts (**Weight, e1RM, Repetitions, Set Volume**) were laggy when selecting or scrolling on a long history.

**Cause:** every body evaluation — and there's one per drag tick while inspecting — regrouped *all* of the exercise's sets into daily-max sets many times over: once explicitly, then again inside `firstDataDate` (which was called once per axis mark, in the domain, the visible window, …), plus separate full-set scans for the all-time PR (y-axis cap) and the visible-window baseline (header). On a power user's history that's a dozen-plus O(all-sets) regroups per frame.

**Fix:** group the daily-max sets **once in `init`** and store them (plus `firstDataDate` derived from them). The chart, y-scale, domain, axis, header baseline and selection all read the memoized value. The all-time PR and the visible-window baseline now scan the daily maxes instead of every set — a per-day max already holds that day's best, so the results are byte-for-byte identical, just computed on days instead of every set. Net: a per-frame full-set regroup becomes a one-time cost at open.

Pure perf/memoization — no behavior or value changes (verified: each screen keeps its exact metric closure, and the daily-max reduction is mathematically equivalent to the previous all-set scan). `MeasurementDetailScreen` isn't included — its data (measurement entries) is small and it has no such grouping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
