### PR TITLE
Add a comparison header to the measurement detail chart

### DIFF
--- a/LOGIT/Core/Environment/de.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/de.lproj/Localizable.strings
@@ -948,6 +948,7 @@
 "summaryRecordsCountMany" = "%d neue Rekorde";
 "summaryRecordsNone" = "Keine neuen Rekorde";
 "current" = "Aktuell";
+"highest" = "Höchster";
 "pinnedExercises" = "Angeheftete Übungen";
 "general" = "Allgemein";
 "about" = "Über";

--- a/LOGIT/Core/Environment/en.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/en.lproj/Localizable.strings
@@ -952,6 +952,7 @@
 "summaryRecordsCountMany" = "%d New Records";
 "summaryRecordsNone" = "No new records";
 "current" = "Current";
+"highest" = "Highest";
 "pinnedExercises" = "Pinned Exercises";
 "general" = "General";
 "about" = "About";

--- a/LOGIT/Core/Environment/es.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/es.lproj/Localizable.strings
@@ -952,6 +952,7 @@
 "summaryRecordsCountMany" = "%d nuevos récords";
 "summaryRecordsNone" = "Sin nuevos récords";
 "current" = "Actual";
+"highest" = "Máximo";
 "pinnedExercises" = "Ejercicios fijados";
 "general" = "General";
 "about" = "Acerca de";

--- a/LOGIT/Core/Environment/fr.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/fr.lproj/Localizable.strings
@@ -952,6 +952,7 @@
 "summaryRecordsCountMany" = "%d nouveaux records";
 "summaryRecordsNone" = "Aucun nouveau record";
 "current" = "Actuel";
+"highest" = "Maximum";
 "pinnedExercises" = "Exercices épinglés";
 "general" = "Général";
 "about" = "À propos";

--- a/LOGIT/Core/Environment/it.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/it.lproj/Localizable.strings
@@ -952,6 +952,7 @@
 "summaryRecordsCountMany" = "%d nuovi record";
 "summaryRecordsNone" = "Nessun nuovo record";
 "current" = "Attuale";
+"highest" = "Massimo";
 "pinnedExercises" = "Esercizi fissati";
 "general" = "Generale";
 "about" = "Informazioni";

--- a/LOGIT/Core/Environment/ja.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/ja.lproj/Localizable.strings
@@ -952,6 +952,7 @@
 "summaryRecordsCountMany" = "新記録%d件";
 "summaryRecordsNone" = "新記録なし";
 "current" = "現在";
+"highest" = "最高値";
 "pinnedExercises" = "ピン留めした種目";
 "general" = "一般";
 "about" = "情報";

--- a/LOGIT/Core/Environment/ko.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/ko.lproj/Localizable.strings
@@ -952,6 +952,7 @@
 "summaryRecordsCountMany" = "신기록 %d개";
 "summaryRecordsNone" = "신기록 없음";
 "current" = "현재";
+"highest" = "최고";
 "pinnedExercises" = "고정된 운동";
 "general" = "일반";
 "about" = "정보";

--- a/LOGIT/Core/Environment/pt-BR.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/pt-BR.lproj/Localizable.strings
@@ -952,6 +952,7 @@
 "summaryRecordsCountMany" = "%d novos recordes";
 "summaryRecordsNone" = "Nenhum novo recorde";
 "current" = "Atual";
+"highest" = "Máximo";
 "pinnedExercises" = "Exercícios fixados";
 "general" = "Geral";
 "about" = "Sobre";

--- a/LOGIT/Features/Measurement/MeasurementDetailScreen.swift
+++ b/LOGIT/Features/Measurement/MeasurementDetailScreen.swift
@@ -68,31 +68,28 @@ struct MeasurementDetailScreen: View {
 
     @ViewBuilder
     private var chartSection: some View {
-        let snappedSelectedEntry = selectedDate != nil ? nearestEntry(to: selectedDate) : nil
+        // Fetch the entries once for this render — `getMeasurementEntries` hits Core Data, and it was
+        // read ~a dozen times per frame (once per axis mark through `firstDataDate`, plus the y-scale,
+        // the selection and every mark), which churned while scrolling or inspecting.
+        let entries = entries
+        let firstDataDate = entries.last?.date
+        let visibleDomainSeconds = chartRange.visibleDomainSeconds(firstDataDate: firstDataDate)
+        let visibleEnd = Calendar.current.date(byAdding: .second, value: visibleDomainSeconds, to: chartScrollPosition) ?? chartScrollPosition
         let latestEntry = entries.first
+        let snappedSelectedEntry = selectedDate != nil ? nearestEntry(to: selectedDate, in: entries, visibleEnd: visibleEnd) : nil
+        // The highest value in the window on screen — moves as you scroll; the reference the current
+        // measurement is read against in the header.
+        let highestVisible = entries
+            .filter { ($0.date).map { $0 >= chartScrollPosition && $0 <= visibleEnd } ?? false }
+            .map(\.decimalValue)
+            .max()
+        let yMax = chartYScaleMax(in: entries)
 
         VStack {
             RangePicker(selection: $chartRange)
                 .padding(.vertical)
 
-            VStack(alignment: .leading) {
-                Text(NSLocalizedString("latest", comment: ""))
-                    .font(.footnote)
-                    .fontWeight(.medium)
-                    .textCase(.uppercase)
-                    .foregroundStyle(.secondary)
-                if let latestEntry = latestEntry {
-                    UnitView(
-                        value: formatDecimal(latestEntry.decimalValue),
-                        unit: measurementType.unit
-                    )
-                    .foregroundStyle(Color.accentColor.gradient)
-                }
-                Text(chartRange.visibleWindowDescription(from: chartScrollPosition, firstDataDate: firstDataDate))
-                    .fontWeight(.bold)
-                    .foregroundStyle(.secondary)
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
+            comparisonHeader(latest: latestEntry, highestVisible: highestVisible, firstDataDate: firstDataDate)
 
             Chart {
                 if selectedDate != nil, let selectedEntry = snappedSelectedEntry, let sDate = selectedEntry.date {
@@ -199,14 +196,14 @@ struct MeasurementDetailScreen: View {
                 }
             }
             .chartXScale(domain: chartRange.xDomain(firstDataDate: firstDataDate))
-            .chartYScale(domain: 0.0 ... chartYScaleMax)
+            .chartYScale(domain: 0.0 ... yMax)
             .chartScrollableAxes(.horizontal)
             .chartScrollPosition(x: $chartScrollPosition)
             .chartScrollTargetBehavior(
                 .valueAligned(matching: chartRange.scrollSnapComponents)
             )
             .chartXSelection(value: $selectedDate)
-            .chartXVisibleDomain(length: visibleChartDomainInSeconds)
+            .chartXVisibleDomain(length: visibleDomainSeconds)
             .chartXAxis {
                 let axisStride = chartRange.axisStride(firstDataDate: firstDataDate)
                 AxisMarks(
@@ -223,7 +220,7 @@ struct MeasurementDetailScreen: View {
                 }
             }
             .chartYAxis {
-                AxisMarks(values: [0.0, chartYScaleMax / 2.0, chartYScaleMax])
+                AxisMarks(values: [0.0, yMax / 2.0, yMax])
             }
             .emptyPlaceholder(entries) {
                 Text(NSLocalizedString("noData", comment: ""))
@@ -237,6 +234,7 @@ struct MeasurementDetailScreen: View {
 
     @ViewBuilder
     private var entriesListSection: some View {
+        let entries = entries
         VStack(alignment: .leading, spacing: SECTION_HEADER_SPACING) {
             Text(NSLocalizedString("allEntries", comment: "All Entries"))
                 .tileHeaderStyle()
@@ -345,33 +343,55 @@ struct MeasurementDetailScreen: View {
         entries.last?.date
     }
 
-    private var visibleChartDomainInSeconds: Int {
-        chartRange.visibleDomainSeconds(firstDataDate: firstDataDate)
-    }
-
-    private var chartYScaleMax: Double {
+    private func chartYScaleMax(in entries: [MeasurementEntry]) -> Double {
         let maxValue = entries.map { $0.decimalValue }.max() ?? 100
         let yAxisMaxValues: [Double] = [10, 25, 50, 100, 150, 200, 250, 300, 400, 500, 750, 1000]
         return yAxisMaxValues.filter { $0 > maxValue }.min() ?? maxValue
     }
 
-    private var visibleEndDate: Date {
-        Calendar.current.date(byAdding: .second, value: visibleChartDomainInSeconds, to: chartScrollPosition)!
-    }
-
-    private func nearestEntry(to date: Date?) -> MeasurementEntry? {
+    private func nearestEntry(to date: Date?, in entries: [MeasurementEntry], visibleEnd: Date) -> MeasurementEntry? {
         let visibleEntries = entries.filter {
             guard let d = $0.date else { return false }
-            return d >= chartScrollPosition && d <= visibleEndDate
+            return d >= chartScrollPosition && d <= visibleEnd
         }
         let candidates = visibleEntries.isEmpty ? entries : visibleEntries
-        guard !candidates.isEmpty else { return nil }
-        guard let target = date else { return nil }
+        guard !candidates.isEmpty, let target = date else { return nil }
         return candidates.min { a, b in
             let ad = a.date ?? .distantPast
             let bd = b.date ?? .distantPast
             return abs(ad.timeIntervalSince(target)) < abs(bd.timeIntervalSince(target))
         }
+    }
+
+    // MARK: - Comparison header
+
+    /// The scoreboard: the current measurement on the trailing side (the fixed subject), the highest
+    /// value in the visible window on the leading side (the reference — it moves as you scroll), and
+    /// the badge reading one against the other. Neutral, like Duration: a measurement sitting higher or
+    /// lower isn't better or worse on its own.
+    private func comparisonHeader(latest: MeasurementEntry?, highestVisible: Double?, firstDataDate: Date?) -> some View {
+        let percentChange: Double? = {
+            guard let latest, let highest = highestVisible, highest > 0 else { return nil }
+            return (latest.decimalValue - highest) / highest * 100
+        }()
+        return MetricComparisonView(
+            leading: .init(
+                label: NSLocalizedString("highest", comment: ""),
+                value: highestVisible.map(formatDecimal) ?? "––",
+                unit: measurementType.unit,
+                caption: chartRange.visibleWindowDescription(from: chartScrollPosition, firstDataDate: firstDataDate)
+            ),
+            trailing: .init(
+                label: NSLocalizedString("current", comment: ""),
+                value: latest.map { formatDecimal($0.decimalValue) } ?? "––",
+                unit: measurementType.unit,
+                caption: latest?.date.map { $0.formatted(.dateTime.day().month()) }
+            ),
+            trailingValueStyle: AnyShapeStyle(Color.accentColor.gradient),
+            percentChange: percentChange,
+            positiveColor: .secondary
+        )
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 }
 


### PR DESCRIPTION
The measurement detail chart showed only the latest value. It now opens with the same comparison scoreboard the other detail charts use.

**What changed**
- **Current** measurement on the trailing side (the fixed subject), **Highest** value in the visible window on the leading side (the reference — it retargets as you scroll the 3M / 1Y / All timeline), and the badge reading current against that high.
- The badge is **neutral** (like Duration): a body measurement sitting higher or lower isn't better or worse on its own, so it doesn't get a green "good" tint.
- Added a `highest` label string (8 locales).

**Also — a perf fix on this screen:** `getMeasurementEntries` does a Core Data fetch, and it was being read ~a dozen times per body evaluation (once per axis mark through `firstDataDate`, plus the y-scale, the selection and every mark) — so scrolling/inspecting refetched the whole set each frame. It's now fetched once per render and the domain, y-scale, selection and header all read that.

Verified on iPhone 17 Pro / iOS 26.4 (many scenario, seeded bodyweight): Highest 97 kg / Current 79 kg / ↓19% neutral badge, moving across 3M/1Y/All.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
