### PR TITLE
Rework History: week sections, per-section stats, calendar header, filters

### DIFF
--- a/LOGIT/Core/Environment/de.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/de.lproj/Localizable.strings
@@ -1032,3 +1032,8 @@
 "setsPerYearTitle" = "Sätze pro Jahr";
 "twelveMonths" = "12 Monate";
 "sixYears" = "6 Jahre";
+
+// History rework (week/month section recap + filter sheet)
+"monthWorkoutCount" = "%d Workout";
+"filters" = "Filter";
+"fromTemplate" = "Aus Vorlage";

--- a/LOGIT/Core/Environment/en.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/en.lproj/Localizable.strings
@@ -1036,3 +1036,8 @@
 "setsPerYearTitle" = "Sets per Year";
 "twelveMonths" = "12 months";
 "sixYears" = "6 years";
+
+// History rework (week/month section recap + filter sheet)
+"monthWorkoutCount" = "%d workout";
+"filters" = "Filters";
+"fromTemplate" = "From a Template";

--- a/LOGIT/Core/Environment/es.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/es.lproj/Localizable.strings
@@ -1036,3 +1036,8 @@
 "setsPerYearTitle" = "Series por año";
 "twelveMonths" = "12 meses";
 "sixYears" = "6 años";
+
+// History rework (week/month section recap + filter sheet)
+"monthWorkoutCount" = "%d entrenamiento";
+"filters" = "Filtros";
+"fromTemplate" = "Desde una plantilla";

--- a/LOGIT/Core/Environment/fr.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/fr.lproj/Localizable.strings
@@ -1036,3 +1036,8 @@
 "setsPerYearTitle" = "Séries par an";
 "twelveMonths" = "12 mois";
 "sixYears" = "6 ans";
+
+// History rework (week/month section recap + filter sheet)
+"monthWorkoutCount" = "%d séance";
+"filters" = "Filtres";
+"fromTemplate" = "Depuis un modèle";

--- a/LOGIT/Core/Environment/it.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/it.lproj/Localizable.strings
@@ -1036,3 +1036,8 @@
 "setsPerYearTitle" = "Serie all'anno";
 "twelveMonths" = "12 mesi";
 "sixYears" = "6 anni";
+
+// History rework (week/month section recap + filter sheet)
+"monthWorkoutCount" = "%d allenamento";
+"filters" = "Filtri";
+"fromTemplate" = "Da un modello";

--- a/LOGIT/Core/Environment/ja.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/ja.lproj/Localizable.strings
@@ -1036,3 +1036,8 @@
 "setsPerYearTitle" = "年ごとのセット数";
 "twelveMonths" = "12か月";
 "sixYears" = "6年";
+
+// History rework (week/month section recap + filter sheet)
+"monthWorkoutCount" = "%d回";
+"filters" = "フィルタ";
+"fromTemplate" = "テンプレートから";

--- a/LOGIT/Core/Environment/ko.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/ko.lproj/Localizable.strings
@@ -1036,3 +1036,8 @@
 "setsPerYearTitle" = "연도별 세트 수";
 "twelveMonths" = "12개월";
 "sixYears" = "6년";
+
+// History rework (week/month section recap + filter sheet)
+"monthWorkoutCount" = "%d회";
+"filters" = "필터";
+"fromTemplate" = "템플릿에서";

--- a/LOGIT/Core/Environment/pt-BR.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/pt-BR.lproj/Localizable.strings
@@ -1036,3 +1036,8 @@
 "setsPerYearTitle" = "Séries por ano";
 "twelveMonths" = "12 meses";
 "sixYears" = "6 anos";
+
+// History rework (week/month section recap + filter sheet)
+"monthWorkoutCount" = "%d treino";
+"filters" = "Filtros";
+"fromTemplate" = "De um modelo";

--- a/LOGIT/Features/Workout/WorkoutListScreen.swift
+++ b/LOGIT/Features/Workout/WorkoutListScreen.swift
@@ -5,6 +5,7 @@
 //  Created by Lukas Kaibel on 12.12.21.
 //
 
+import CoreData
 import SwiftUI
 
 struct WorkoutListScreen: View {
@@ -15,12 +16,18 @@ struct WorkoutListScreen: View {
     // MARK: - State
 
     @State private var searchedText: String = ""
-    @State private var selectedMuscleGroup: MuscleGroup? = nil
+    @State private var filter = WorkoutFilter()
     /// The workout being added via the editor sheet. Created once on button tap — creating it
     /// inside the sheet's ViewBuilder inserts a fresh orphan workout into the context on every
     /// re-evaluation of the builder, and they all get persisted by the next save.
     @State private var workoutToAdd: Workout?
+    @State private var isShowingFilters = false
     @State private var selectedWorkout: Workout?
+    /// The day tapped in the calendar header — rings it and is scrolled to. Purely a scrubbing aid.
+    @State private var selectedDay: Date?
+    /// Object IDs of the fetched workouts that set at least one personal record, filled lazily while
+    /// the "personal records only" filter is on (nil = not computed yet, so the list waits).
+    @State private var personalRecordWorkoutIDs: Set<NSManagedObjectID>?
 
     // MARK: - Body
 
@@ -28,61 +35,54 @@ struct WorkoutListScreen: View {
         FetchRequestWrapper(
             Workout.self,
             sortDescriptors: [SortDescriptor(\Workout.date, order: .reverse)],
-            predicate: WorkoutPredicateFactory.getWorkouts(
-                nameIncluding: "",
-                withMuscleGroup: selectedMuscleGroup
-            )
+            predicate: workoutPredicate
         ) { allWorkouts in
-            let workouts = FuzzySearchService.shared.searchWorkouts(searchedText, in: allWorkouts)
-            let groupedWorkouts = Dictionary(grouping: workouts, by: { workout in
-                workout.date?.startOfMonth ?? .now
-            }).sorted { $0.key > $1.key }
+            let searched = FuzzySearchService.shared.searchWorkouts(searchedText, in: allWorkouts)
             let isSearching = !searchedText.isEmpty
+            let displayed = displayedWorkouts(from: searched)
+            let isComputingPRs = filter.prsOnly && personalRecordWorkoutIDs == nil
 
-            ScrollView {
-                LazyVStack(spacing: SECTION_SPACING) {
-                    MuscleGroupSelector(selectedMuscleGroup: $selectedMuscleGroup)
-                    if isSearching {
-                        // Flat list when searching - results ordered by relevance
-                        VStack(spacing: 8) {
-                            ForEach(workouts) { workout in
-                                Button {
-                                    selectedWorkout = workout
-                                } label: {
-                                    WorkoutCell(workout: workout)
+            ScrollViewReader { proxy in
+                ScrollView {
+                    LazyVStack(spacing: SECTION_SPACING) {
+                        if isSearching {
+                            // Flat list when searching - results ordered by relevance
+                            workoutList(displayed)
+                        } else if isComputingPRs {
+                            ProgressView()
+                                .frame(maxWidth: .infinity)
+                                .padding(.top, 80)
+                        } else {
+                            if !displayed.isEmpty {
+                                HistoryCalendarView(workouts: displayed, selectedDay: $selectedDay) { day in
+                                    jump(to: day, in: displayed, proxy: proxy)
                                 }
-                                .buttonStyle(TileButtonStyle())
+                                .padding(.horizontal)
+                            }
+                            ForEach(historySections(for: displayed)) { section in
+                                WorkoutHistorySectionView(
+                                    title: section.title,
+                                    workouts: section.workouts,
+                                    selectedWorkout: $selectedWorkout
+                                )
                             }
                         }
-                        .padding(.horizontal)
-                    } else {
-                        // Grouped by month when not searching
-                        ForEach(groupedWorkouts, id: \.0) { key, workouts in
-                            VStack(spacing: SECTION_HEADER_SPACING) {
-                                Text(key.monthDescription)
-                                    .sectionHeaderStyle2()
-                                    .frame(maxWidth: .infinity, alignment: .leading)
-                                VStack(spacing: 8) {
-                                    ForEach(workouts) {
-                                        workout in
-                                        Button {
-                                            selectedWorkout = workout
-                                        } label: {
-                                            WorkoutCell(workout: workout)
-                                        }
-                                        .buttonStyle(TileButtonStyle())
-                                    }
-                                }
+                        EmptyView()
+                            .emptyPlaceholder(displayed) {
+                                Text(NSLocalizedString("noWorkouts", comment: ""))
                             }
-                            .padding(.horizontal)
-                        }
                     }
-                    EmptyView()
-                        .emptyPlaceholder(workouts) {
-                            Text(NSLocalizedString("noWorkouts", comment: ""))
-                        }
+                    .padding(.bottom, SCROLLVIEW_BOTTOM_PADDING)
                 }
-                .padding(.bottom, SCROLLVIEW_BOTTOM_PADDING)
+                .task(id: PersonalRecordFilterKey(on: filter.prsOnly, ids: searched.map { $0.objectID })) {
+                    guard filter.prsOnly else { personalRecordWorkoutIDs = nil; return }
+                    var ids = Set<NSManagedObjectID>()
+                    for workout in searched
+                    where WorkoutProgressReport.compute(for: workout, database: database).prRecords.count > 0 {
+                        ids.insert(workout.objectID)
+                    }
+                    personalRecordWorkoutIDs = ids
+                }
             }
             .searchable(
                 text: $searchedText,
@@ -91,13 +91,25 @@ struct WorkoutListScreen: View {
             .navigationTitle(NSLocalizedString("workoutHistory", comment: ""))
             .navigationBarTitleDisplayMode(.large)
             .toolbar {
-                ToolbarItemGroup(placement: .navigationBarTrailing) {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button {
+                        isShowingFilters = true
+                    } label: {
+                        Image(systemName: filter.isActive
+                            ? "line.3.horizontal.decrease.circle.fill"
+                            : "line.3.horizontal.decrease.circle")
+                    }
+                }
+                ToolbarItem(placement: .topBarTrailing) {
                     Button {
                         workoutToAdd = database.newWorkout()
                     } label: {
                         Image(systemName: "plus")
                     }
                 }
+            }
+            .sheet(isPresented: $isShowingFilters) {
+                WorkoutFilterSheet(filter: $filter)
             }
             .sheet(item: $workoutToAdd) { workout in
                 WorkoutEditorScreen(workout: workout, isAddingNewWorkout: true)
@@ -106,6 +118,405 @@ struct WorkoutListScreen: View {
         .navigationDestination(item: $selectedWorkout) { workout in
             WorkoutDetailScreen(workout: workout, canNavigateToTemplate: true)
         }
+    }
+
+    // MARK: - List
+
+    private func workoutList(_ workouts: [Workout]) -> some View {
+        VStack(spacing: 8) {
+            ForEach(workouts) { workout in
+                Button {
+                    selectedWorkout = workout
+                } label: {
+                    WorkoutCell(workout: workout)
+                }
+                .buttonStyle(TileButtonStyle())
+                .id(workout.objectID)
+            }
+        }
+        .padding(.horizontal)
+    }
+
+    // MARK: - Filtering
+
+    /// The fetch predicate for the muscle-group and template filters (search and the PR filter are
+    /// applied in memory). The factory always returns at least the "exclude current workout" clause.
+    private var workoutPredicate: NSPredicate? {
+        var subpredicates = [NSPredicate]()
+        if let base = WorkoutPredicateFactory.getWorkouts(nameIncluding: "", withMuscleGroup: filter.muscleGroup) {
+            subpredicates.append(base)
+        }
+        if filter.fromTemplate {
+            subpredicates.append(NSPredicate(format: "template != nil"))
+        }
+        return subpredicates.isEmpty ? nil : NSCompoundPredicate(andPredicateWithSubpredicates: subpredicates)
+    }
+
+    private func displayedWorkouts(from workouts: [Workout]) -> [Workout] {
+        guard filter.prsOnly, let ids = personalRecordWorkoutIDs else { return workouts }
+        return workouts.filter { ids.contains($0.objectID) }
+    }
+
+    /// Scrolls the list to the workout on the tapped calendar day and rings that day. A scrubber —
+    /// the list itself is never filtered by the tap.
+    private func jump(to day: Date, in workouts: [Workout], proxy: ScrollViewProxy) {
+        guard let target = workouts.first(where: {
+            guard let date = $0.date else { return false }
+            return Calendar.current.isDate(date, inSameDayAs: day)
+        }) else { return }
+        selectedDay = day
+        withAnimation {
+            proxy.scrollTo(target.objectID, anchor: .top)
+        }
+    }
+
+    // MARK: - Grouping
+
+    /// One dated group in the history list: the current and previous week broken out relative-style,
+    /// then everything older grouped by calendar month.
+    private struct HistorySection: Identifiable {
+        let id: String
+        let title: String
+        let workouts: [Workout]
+    }
+
+    /// Splits the (date-descending) workouts into This Week, Last Week, then month groups. The weeks
+    /// win the overlap: a workout in the current or previous week is never also listed under its
+    /// month, so a month near the top only holds what its earlier days contributed. Empty weeks are
+    /// dropped, like empty months, so the list never opens on a blank "This Week".
+    private func historySections(for workouts: [Workout]) -> [HistorySection] {
+        let calendar = Calendar.current
+        let thisWeekStart = Date.now.startOfWeek
+        let lastWeekStart = calendar.date(byAdding: .weekOfYear, value: -1, to: thisWeekStart) ?? thisWeekStart
+
+        var thisWeek: [Workout] = []
+        var lastWeek: [Workout] = []
+        var older: [Workout] = []
+        for workout in workouts {
+            guard let date = workout.date else { older.append(workout); continue }
+            if date >= thisWeekStart {
+                thisWeek.append(workout)
+            } else if date >= lastWeekStart {
+                lastWeek.append(workout)
+            } else {
+                older.append(workout)
+            }
+        }
+
+        var sections: [HistorySection] = []
+        if !thisWeek.isEmpty {
+            sections.append(HistorySection(id: "thisWeek", title: thisWeekStart.weekDescription, workouts: thisWeek))
+        }
+        if !lastWeek.isEmpty {
+            sections.append(HistorySection(id: "lastWeek", title: lastWeekStart.weekDescription, workouts: lastWeek))
+        }
+        let byMonth = Dictionary(grouping: older) { ($0.date ?? .now).startOfMonth }
+            .sorted { $0.key > $1.key }
+        for (monthStart, monthWorkouts) in byMonth {
+            sections.append(
+                HistorySection(
+                    id: "month-\(monthStart.timeIntervalSinceReferenceDate)",
+                    title: monthStart.monthDescription,
+                    workouts: monthWorkouts
+                )
+            )
+        }
+        return sections
+    }
+}
+
+// MARK: - Filter model
+
+/// The History list's filters. Muscle group and template origin narrow the fetch; personal-records
+/// is judged in memory. `isActive` drives the filled toolbar icon.
+private struct WorkoutFilter: Equatable {
+    var muscleGroup: MuscleGroup?
+    var prsOnly = false
+    var fromTemplate = false
+
+    var isActive: Bool { muscleGroup != nil || prsOnly || fromTemplate }
+}
+
+/// Task identity for the personal-records computation: recompute when the toggle flips or the fetched
+/// set changes, and carry no ids while the filter is off so the work never runs then.
+private struct PersonalRecordFilterKey: Equatable {
+    let on: Bool
+    let ids: [NSManagedObjectID]
+}
+
+// MARK: - History section
+
+/// A single dated group in the history list — a relative week ("This Week", "Last Week") or a
+/// calendar month — headed by its name and a one-line recap of the workouts inside it: how many,
+/// their combined volume, and how many personal records they set. The recap mirrors the cell's own
+/// "date · duration · PR" grammar so the header and the rows read the same way. The cells below are
+/// unchanged.
+private struct WorkoutHistorySectionView: View {
+    @EnvironmentObject private var database: Database
+
+    let title: String
+    let workouts: [Workout]
+    @Binding var selectedWorkout: Workout?
+
+    /// Personal records across the whole section, summed from the same per-workout report the cells
+    /// use so the header can never disagree with the "n PR" on the rows. Filled in `.task` rather
+    /// than `body`, because the report scans each exercise's full history — running it for every
+    /// section on every scroll would be far too heavy — and only for sections that actually appear.
+    @State private var personalRecordCount: Int = 0
+
+    var body: some View {
+        VStack(spacing: SECTION_HEADER_SPACING) {
+            VStack(alignment: .leading, spacing: 3) {
+                Text(title)
+                    .sectionHeaderStyle2()
+                Text(statLine)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .padding(.leading)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            VStack(spacing: 8) {
+                ForEach(workouts) { workout in
+                    Button {
+                        selectedWorkout = workout
+                    } label: {
+                        WorkoutCell(workout: workout)
+                    }
+                    .buttonStyle(TileButtonStyle())
+                    .id(workout.objectID)
+                }
+            }
+        }
+        .padding(.horizontal)
+        .task(id: workouts.map { $0.objectID }) {
+            personalRecordCount = workouts.reduce(0) { partial, workout in
+                partial + WorkoutProgressReport.compute(for: workout, database: database).prRecords.count
+            }
+        }
+    }
+
+    /// "3 workouts · 22k kg · 2 PR" — count always, then volume and PRs only when they have
+    /// something to show, joined the way the cell joins its own metadata.
+    private var statLine: String {
+        var parts: [String] = []
+
+        let countFormat = NSLocalizedString(
+            workouts.count == 1 ? "monthWorkoutCount" : "monthWorkoutsCount",
+            comment: ""
+        )
+        parts.append(String(format: countFormat, workouts.count))
+
+        let volume = convertWeightForDisplaying(getVolume(of: workouts.flatMap { $0.sets }))
+        if volume > 0 {
+            parts.append("\(abbreviatedVolume(volume)) \(WeightUnit.used.rawValue)")
+        }
+
+        if personalRecordCount > 0 {
+            let prFormat = NSLocalizedString(
+                personalRecordCount == 1 ? "personalRecordShortCount" : "personalRecordsShortCount",
+                comment: ""
+            )
+            parts.append(String(format: prFormat, personalRecordCount))
+        }
+
+        return parts.joined(separator: " · ")
+    }
+
+    /// Compact volume for the recap line: "22k" past a thousand (one decimal below ten thousand),
+    /// the plain number under it. Keeps the header short where the full grouped figure would crowd
+    /// the line — the exact totals live on the volume screens.
+    private func abbreviatedVolume(_ value: Int) -> String {
+        guard value >= 1000 else { return "\(value)" }
+        let thousands = Double(value) / 1000
+        if thousands >= 10 {
+            return "\(Int(thousands.rounded()))k"
+        }
+        let formatted = String(format: "%.1f", thousands)
+        return (formatted.hasSuffix(".0") ? String(formatted.dropLast(2)) : formatted) + "k"
+    }
+}
+
+// MARK: - Calendar header
+
+/// A month calendar shown at the top of History — each trained day carries a `MuscleOccurrenceRing`,
+/// the same muscle-group arcs the Weekly Goal calendar draws (sized by that day's set counts), so the
+/// two calendars read alike, but here without the goal's target column and per-week rings. Tapping a
+/// trained day calls `onSelectDate` so the list can jump to it, and rings the day as a scrubbing cue.
+private struct HistoryCalendarView: View {
+    @EnvironmentObject private var muscleGroupService: MuscleGroupService
+
+    let workouts: [Workout]
+    @Binding var selectedDay: Date?
+    let onSelectDate: (Date) -> Void
+
+    @State private var displayedMonth: Date = .now.startOfMonth
+    private let calendar = Calendar.current
+
+    var body: some View {
+        VStack(spacing: 12) {
+            HStack {
+                Button { changeMonth(-1) } label: { Image(systemName: "chevron.left") }
+                Spacer()
+                Text(displayedMonth.formatted(.dateTime.month(.wide).year()))
+                    .font(.headline)
+                Spacer()
+                Button { changeMonth(1) } label: { Image(systemName: "chevron.right") }
+                    .disabled(displayedMonth.startOfMonth >= Date.now.startOfMonth)
+            }
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, CELL_PADDING)
+            HStack(spacing: 0) {
+                ForEach(weekdaySymbols, id: \.self) { symbol in
+                    Text(symbol)
+                        .font(.caption2.weight(.bold))
+                        .foregroundStyle(.tertiary)
+                        .frame(maxWidth: .infinity)
+                }
+            }
+            .padding(.horizontal, CELL_PADDING)
+            ForEach(weeksOfMonth, id: \.self) { week in
+                HStack(spacing: 0) {
+                    ForEach(week, id: \.self) { day in
+                        dayCell(day)
+                    }
+                }
+                .padding(.horizontal, CELL_PADDING)
+            }
+        }
+        .padding(.top, CELL_PADDING)
+        .padding(.bottom, CELL_PADDING / 2)
+        .tileStyle()
+    }
+
+    @ViewBuilder
+    private func dayCell(_ day: Date) -> some View {
+        let inMonth = calendar.isDate(day, equalTo: displayedMonth, toGranularity: .month)
+        let isToday = calendar.isDateInToday(day)
+        let isFuture = day > Date.now && !isToday
+        let occurrences = muscleOccurrences(on: day)
+        let hasWorkout = !occurrences.isEmpty
+        let isSelected = selectedDay.map { calendar.isDate($0, inSameDayAs: day) } ?? false
+        let cell = ZStack {
+            if isToday {
+                Circle()
+                    .strokeBorder(Color.accentColor, lineWidth: 1.7)
+                    .frame(width: 32, height: 32)
+            } else if hasWorkout {
+                MuscleOccurrenceRing(occurrences: occurrences, lineWidth: 4)
+                    .frame(width: 32, height: 32)
+                    .accessibilityHidden(true)
+            }
+            Text("\(calendar.component(.day, from: day))")
+                .font(.system(size: 13, weight: (isToday || hasWorkout) ? .bold : .semibold))
+                .foregroundStyle(dayForeground(inMonth: inMonth, isToday: isToday, isFuture: isFuture, hasWorkout: hasWorkout))
+        }
+        .frame(width: 34, height: 34)
+        .overlay {
+            if isSelected {
+                Circle().strokeBorder(Color.accentColor, lineWidth: 2)
+            }
+        }
+        .frame(maxWidth: .infinity)
+        if hasWorkout {
+            Button { onSelectDate(day) } label: { cell }
+                .buttonStyle(.plain)
+        } else {
+            cell
+        }
+    }
+
+    private func dayForeground(inMonth: Bool, isToday: Bool, isFuture: Bool, hasWorkout: Bool) -> Color {
+        if isToday { return .accentColor }
+        if hasWorkout { return .primary }
+        if !inMonth { return Color.white.opacity(0.18) }
+        if isFuture { return .tertiaryLabel }
+        return .secondaryLabel
+    }
+
+    private func muscleOccurrences(on day: Date) -> [(MuscleGroup, Int)] {
+        let dayWorkouts = workouts.filter {
+            guard !$0.isEmpty, let date = $0.date else { return false }
+            return calendar.isDate(date, inSameDayAs: day)
+        }
+        guard !dayWorkouts.isEmpty else { return [] }
+        return muscleGroupService.getMuscleGroupOccurances(in: dayWorkouts)
+    }
+
+    private var weeksOfMonth: [[Date]] {
+        let monthEnd = displayedMonth.endOfMonth
+        var weeks: [[Date]] = []
+        var cursor = displayedMonth.startOfMonth.startOfWeek
+        while cursor <= monthEnd, weeks.count < 6 {
+            let week = (0 ..< 7).map { calendar.date(byAdding: .day, value: $0, to: cursor) ?? cursor }
+            weeks.append(week)
+            cursor = calendar.date(byAdding: .day, value: 7, to: cursor) ?? cursor
+        }
+        return weeks
+    }
+
+    private var weekdaySymbols: [String] {
+        let symbols = calendar.veryShortWeekdaySymbols
+        let first = calendar.firstWeekday - 1
+        return Array(symbols[first...] + symbols[..<first])
+    }
+
+    private func changeMonth(_ delta: Int) {
+        withAnimation {
+            displayedMonth = (calendar.date(byAdding: .month, value: delta, to: displayedMonth) ?? displayedMonth).startOfMonth
+        }
+    }
+}
+
+// MARK: - Filter sheet
+
+/// The History filters, moved off the list into a sheet so the calendar header can own the top of the
+/// screen: the muscle-group selector (as on the old inline row), plus "personal records only" and
+/// "from a template" toggles. Reached from the filter button beside the title.
+private struct WorkoutFilterSheet: View {
+    @Binding var filter: WorkoutFilter
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: SECTION_SPACING) {
+                    VStack(alignment: .leading, spacing: SECTION_HEADER_SPACING) {
+                        Text(NSLocalizedString("muscleGroup", comment: ""))
+                            .sectionHeaderStyle2()
+                        MuscleGroupSelector(selectedMuscleGroup: $filter.muscleGroup, withAnimation: true)
+                    }
+                    VStack(spacing: 0) {
+                        Toggle(NSLocalizedString("personalRecords", comment: ""), isOn: $filter.prsOnly)
+                            .padding(.vertical, 6)
+                        Divider()
+                        Toggle(NSLocalizedString("fromTemplate", comment: ""), isOn: $filter.fromTemplate)
+                            .padding(.vertical, 6)
+                    }
+                    .tint(.accentColor)
+                    .padding(.horizontal, CELL_PADDING)
+                    .padding(.vertical, 4)
+                    .tileStyle()
+                    .padding(.horizontal)
+                }
+                .padding(.vertical)
+            }
+            .navigationTitle(NSLocalizedString("filters", comment: ""))
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    if filter.isActive {
+                        Button(NSLocalizedString("reset", comment: "")) {
+                            withAnimation { filter = WorkoutFilter() }
+                        }
+                    }
+                }
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button(NSLocalizedString("done", comment: "")) { dismiss() }
+                        .fontWeight(.semibold)
+                }
+            }
+        }
+        .presentationDetents([.medium, .large])
     }
 }
 


### PR DESCRIPTION
Merges the History rework from #49 (branch `claude/priceless-curran-624042`, authored 2026-07-04) onto current `main`, adjusted to fit the post-5.0 UI. **Supersedes #49.**

Touches only `WorkoutListScreen.swift` and the eight `Localizable.strings` files.

## Feature (from #49)
- **Week sections** — the top of the list breaks into **This Week** / **Last Week** before the month groups. Weeks win the overlap, so a month only holds the days its weeks didn't claim.
- **Per-section recap** — each header gets a one-line `N workouts · Xk kg · N PR` in the cell's own metadata grammar. PR counts reuse `WorkoutProgressReport`, computed lazily per visible section.
- **Calendar header** — a muscle-tinted month calendar; tapping a trained day scrolls the list to it and rings the day.
- **Filter sheet** — muscle group, Personal records only, From a template, behind a toolbar button that fills when a filter is active.
- Adds `monthWorkoutCount`, `filters`, `fromTemplate` across all eight languages.

## Adjustments for the current UI (the branch predated the 5.0 wave)
- **Calendar now draws `MuscleOccurrenceRing`** per trained day — the shared arc ring the Weekly Goal calendar adopted after this branch forked — instead of the branch's older solid-fill dominant-muscle dot, so the two calendars read alike.
- **Preserves `main`'s `workoutToAdd` / `.sheet(item:)` add-workout flow** (the fix from #59) rather than the branch's `isShowingAddWorkout` + `newWorkout()`-in-builder, which reintroduced the CloudKit orphan-workout data loss that #59 fixed.
- Re-applied the three new localization keys (the files had grown past the branch's anchors); confirmed no duplicate keys.

## Verification
- App scheme builds cleanly (no new warnings in the changed file).
- Ran the `ScenarioScreenshots` suite on the iOS 26.4 simulator across **empty / one / many**, plus the week+month sections with recap lines, the ring calendar, and the filter sheet + applied PR filter — all render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)