### PR TITLE
Show the rest-timer countdown in the compact Dynamic Island

### DIFF
--- a/LOGIT/App/LOGITApp.swift
+++ b/LOGIT/App/LOGITApp.swift
@@ -215,6 +215,19 @@ struct LOGIT: App {
                         try? await Task.sleep(nanoseconds: 600_000_000)
                         showWorkoutRecorder()
                     }
+                    #if DEBUG
+                    // Live Activity verification hook: deterministically start a rest timer so the
+                    // running-chrono Dynamic Island (compact/minimal) can be reproduced from the CLI.
+                    // Lives here (not in the recorder view) so it fires regardless of what is on screen.
+                    if ProcessInfo.processInfo.arguments.contains("-UITEST_START_REST_TIMER"),
+                       let restTimerSet = workoutRecorder.workout?.sets.first {
+                        try? await Task.sleep(nanoseconds: 800_000_000)
+                        workoutRecorder.activeRestTimerSet = restTimerSet
+                        chronograph.mode = .timer
+                        chronograph.setSeconds(90)
+                        chronograph.start()
+                    }
+                    #endif
                     // Fastlane screenshot trigger for the Live Activity
                     // marketing view. Swaps the whole screen for a
                     // Lock Screen-style composition of two Live Activity

--- a/LOGITWidgetExtension/WorkoutLiveActivityWidget.swift
+++ b/LOGITWidgetExtension/WorkoutLiveActivityWidget.swift
@@ -1735,6 +1735,24 @@ private struct WorkoutCompactIslandTrailingContent: View {
     }
 }
 
+/// Reserves horizontal space for a live `Text(timerInterval:)`. In the compact Dynamic Island a bare
+/// `Text(timerInterval:)` under the trailing region's `fixedSize` does not lay out to a visible width,
+/// so the running countdown/stopwatch disappears while the leading icon (a normally-sized `Image`)
+/// still shows. A hidden monospaced `mm:ss` sizer pins the width; the live timer is drawn
+/// trailing-aligned over it.
+private struct WorkoutLiveActivityReservedTimerText: View {
+    let range: ClosedRange<Date>
+    let countsDown: Bool
+
+    var body: some View {
+        Text(verbatim: "00:00")
+            .hidden()
+            .overlay(alignment: .trailing) {
+                Text(timerInterval: range, countsDown: countsDown, showsHours: false)
+            }
+    }
+}
+
 /// In Live Activities the widget extension is only woken at Activity update points, so `TimelineView(.periodic)`
 /// does not drive continuous refreshes. Use `Text(timerInterval:countsDown:showsHours:)` which is rendered by the
 /// OS and advances in place for both the compact Dynamic Island and minimal.
@@ -1755,20 +1773,18 @@ private struct WorkoutCompactIslandChronoLabel: View {
         switch chip.phase {
         case .timerRunning:
             if let end = chip.timerEndDate {
-                Text(
-                    timerInterval: workoutLiveActivityCountdownRange(endingAt: end),
-                    countsDown: true,
-                    showsHours: false
+                WorkoutLiveActivityReservedTimerText(
+                    range: workoutLiveActivityCountdownRange(endingAt: end),
+                    countsDown: true
                 )
             } else {
                 Text("0:00").opacity(0)
             }
         case .stopwatchRunning:
             if let start = chip.stopwatchStartDate {
-                Text(
-                    timerInterval: workoutLiveActivityStopwatchRange(startingAt: start),
-                    countsDown: false,
-                    showsHours: false
+                WorkoutLiveActivityReservedTimerText(
+                    range: workoutLiveActivityStopwatchRange(startingAt: start),
+                    countsDown: false
                 )
             } else {
                 Text("0:00").opacity(0)


### PR DESCRIPTION
## Problem
In the compact Dynamic Island, the running rest-timer showed only the **timer icon** on the left (`compactLeading`) — the **counting-down `m:ss`** on the right (`compactTrailing`) was missing.

## Cause
The trailing label wrapped the running `Text(timerInterval:)` in `.frame(maxWidth: .infinity, alignment: .trailing).fixedSize(horizontal: true, vertical: false)`. A `Text(timerInterval:)` is an OS-driven live timer, and under `fixedSize` in that narrow region it doesn't lay out to a visible width — so the digits vanish. The leading `Image` and the non-timer `else` branch (plain elapsed-time `Text`) have normal intrinsic sizes, so only the running countdown disappeared.

## Fix
Reserve a concrete width with a hidden `00:00` sizer and draw the live timer trailing-aligned over it (`WorkoutLiveActivityReservedTimerText`). Applied to both the countdown and stopwatch cases, so it fixes the compact **and** minimal presentations.

## Verification
- App + widget build cleanly.
- Confirmed the app reaches the triggering state (active workout + running rest timer → Live Activity active).
- ⚠️ Could **not** capture the Dynamic Island itself in the agent sandbox — the Simulator there doesn't composite the Live Activity DI into `simctl`/`XCUIScreen` screenshots, and device/screen-recording routes were permission-blocked. Please eyeball the DI on-device to confirm the countdown now renders.

## Note
Includes a small `#if DEBUG` `-UITEST_START_REST_TIMER` launch hook (in `LOGITApp`) to jump straight to the running-timer Live Activity state on the sim. Safe to drop if unwanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)