### PR TITLE
Fix exercise capability chart scroll/selection lag with a shared chart view

### DIFF
--- a/LOGIT.xcodeproj/project.pbxproj
+++ b/LOGIT.xcodeproj/project.pbxproj
@@ -231,6 +231,7 @@
 		8E306606440725A568FE5F1A /* ExerciseMergeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF0CFD6EDA94DA1792A2CA82 /* ExerciseMergeService.swift */; };
 		8F4A3C022E5A9B0100D4E5F2 /* SetVolumeBarChart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F4A3C012E5A9B0100D4E5F1 /* SetVolumeBarChart.swift */; };
 		9392C43C9501E6676A02488A /* WorkoutLiveActivitySnapshotBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B6F634C95B552C305EA0055 /* WorkoutLiveActivitySnapshotBuilder.swift */; };
+		99A5C6A814E6BD98F45BDFF1 /* CapabilityChartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BEA94B4E4E01D1D9185359 /* CapabilityChartView.swift */; };
 		9C03B11C8A034786C5544D2E /* ScreenshotFixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = C05F3FE01CADB8E0526C799F /* ScreenshotFixtures.swift */; };
 		9D2E7A022F30AA0100C1D2E2 /* DemoWorkoutSeeder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D2E7A012F30AA0100C1D2E1 /* DemoWorkoutSeeder.swift */; };
 		9F68D70717290138E369B178 /* ExerciseMergingSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E384D0F4B54340F910F6813 /* ExerciseMergingSheet.swift */; };
@@ -599,6 +600,7 @@
 		A95CC85E7895692DD1082ACD /* LiveActivityShowcaseView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LiveActivityShowcaseView.swift; sourceTree = "<group>"; };
 		ADFEC5772AE8932AA1089603 /* SummaryRecords.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryRecords.swift; sourceTree = "<group>"; };
 		AF0CFD6EDA94DA1792A2CA82 /* ExerciseMergeService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ExerciseMergeService.swift; sourceTree = "<group>"; };
+		B5BEA94B4E4E01D1D9185359 /* CapabilityChartView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CapabilityChartView.swift; sourceTree = "<group>"; };
 		BA2F6D7984C9394E060503E7 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		BBBF6087BB65A5971FB5F866 /* BodyMapFigure.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BodyMapFigure.swift; sourceTree = "<group>"; };
 		BEA597E1519E8F6D2CBC8F9E /* PeriodPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeriodPicker.swift; sourceTree = "<group>"; };
@@ -1189,6 +1191,7 @@
 				E1E1E1000000000000000F13 /* TileBarChartStyle.swift */,
 				E1E1E1000000000000000F14 /* TileSparklineStyle.swift */,
 				F3C48765200C9745764F2EAA /* PeriodHistoryChart.swift */,
+				B5BEA94B4E4E01D1D9185359 /* CapabilityChartView.swift */,
 			);
 			path = Charts;
 			sourceTree = "<group>";
@@ -1802,6 +1805,7 @@
 				28E43ABE4881F802FBBACCE9 /* RangePicker.swift in Sources */,
 				5F6C92E180BAAEC435086790 /* PeriodHistoryChart.swift in Sources */,
 				A10F7CBC23FBD8F36CC4A1D6 /* TestScenarios.swift in Sources */,
+				99A5C6A814E6BD98F45BDFF1 /* CapabilityChartView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/LOGIT/Features/Exercise/ExerciseDetail/ExerciseE1RMScreen.swift
+++ b/LOGIT/Features/Exercise/ExerciseDetail/ExerciseE1RMScreen.swift
@@ -8,203 +8,54 @@
 import Charts
 import SwiftUI
 
+/// Estimated one-rep max per day for a single exercise — the detail screen behind the e1RM tile.
+/// Structurally the twin of `ExerciseWeightScreen`; only the per-set metric and its formatting differ.
+/// The chart, scrolling, selection and header all live in the shared `CapabilityChartView`.
 struct ExerciseE1RMScreen: View {
-    private let yAxisMaxValuesKG = [10, 25, 50, 100, 150, 200, 300, 400, 500, 600, 700, 800, 900, 1000]
-    private let yAxisMaxValuesLBS = [25, 55, 110, 225, 335, 445, 665, 885, 1105, 1325, 1545, 1765, 1985, 2205]
+    private static let yAxisMaxValuesKG = [10, 25, 50, 100, 150, 200, 300, 400, 500, 600, 700, 800, 900, 1000]
+    private static let yAxisMaxValuesLBS = [25, 55, 110, 225, 335, 445, 665, 885, 1105, 1325, 1545, 1765, 1985, 2205]
 
     let exercise: Exercise
     let workoutSets: [WorkoutSet]
-    /// Daily-max sets, grouped once at init. The chart, the header baseline, the y-scale, the domain
-    /// and the selection all read from this — so scrolling or inspecting never regroups every set
-    /// again. (The selection lag came from `firstDataDate` re-grouping all sets once per axis mark,
-    /// every frame.)
-    private let dailyMaxSets: [WorkoutSet]
-    /// Earliest day with data — anchors the scrollable domain and the All range. Derived once from
-    /// `dailyMaxSets`, not recomputed on every scroll/selection frame.
-    private let firstDataDate: Date?
 
-    @State private var chartRange: ChartRange = .threeMonths
-    @State private var chartScrollPosition: Date = .now
-    @State private var selectedDate: Date?
+    private let points: [CapabilityChartView.Point]
+    private let firstDataDate: Date?
+    private let bestAnchor: (value: Int, date: Date?, isLapsed: Bool)?
+    private let yScaleMax: Int
 
     init(exercise: Exercise, workoutSets: [WorkoutSet]) {
         self.exercise = exercise
         self.workoutSets = workoutSets
         let daily = Self.dailyMaxE1RMSets(in: workoutSets, for: exercise)
-        self.dailyMaxSets = daily
         self.firstDataDate = daily.first?.workout?.date
+        self.points = daily.enumerated().map { index, set in
+            let raw = set.estimatedOneRepMax(for: exercise)
+            return CapabilityChartView.Point(
+                id: index,
+                date: set.workout?.date ?? .now,
+                value: convertWeightForDisplayingDecimal(raw),
+                raw: raw,
+                formatted: formatEstimatedOneRepMax(raw)
+            )
+        }
+        let pr = convertWeightForDisplaying(daily.map { $0.estimatedOneRepMax(for: exercise) }.max() ?? 0)
+        self.yScaleMax = Self.chartYScaleMax(maxYValue: pr)
+        self.bestAnchor = Self.bestAnchor(for: exercise, in: workoutSets)
     }
 
     var body: some View {
-        let allDailyMaxSets = dailyMaxSets
-        // Determine the snapped selected set only when a selection exists; snap to the nearest datapoint (prefer visible)
-        let snappedSelectedSet: WorkoutSet? = selectedDate != nil ? nearestSet(to: selectedDate, in: allDailyMaxSets) : nil
-        let bestVisibleE1RM = bestE1RMInVisibleWindow()
         ScrollView {
             VStack(spacing: SECTION_SPACING) {
-                VStack {
-                    RangePicker(selection: $chartRange)
-                    .padding(.vertical)
-                    .padding(.horizontal)
-                    MetricComparisonView(
-                        leading: .init(
-                            label: NSLocalizedString("previousBest", comment: ""),
-                            value: bestVisibleE1RM.map(formatEstimatedOneRepMax) ?? "––",
-                            unit: WeightUnit.used.rawValue,
-                            caption: chartRange.visibleWindowDescription(from: chartScrollPosition, firstDataDate: firstDataDate)
-                        ),
-                        trailing: .init(
-                            label: NSLocalizedString(bestAnchor?.isLapsed == true ? "lastBest" : "currentBest", comment: ""),
-                            value: bestAnchor.map { formatEstimatedOneRepMax($0.value) } ?? "––",
-                            unit: WeightUnit.used.rawValue,
-                            caption: bestAnchor?.date.map { $0.formatted(.dateTime.day().month()) }
-                        ),
-                        trailingValueStyle: AnyShapeStyle(exerciseMuscleGroupColor.gradient),
-                        percentChange: bestAnchor?.isLapsed == true ? nil : headerTrendPercentage(visibleBest: bestVisibleE1RM),
-                        positiveColor: exerciseMuscleGroupColor,
-                        explanation: NSLocalizedString("currentBestComparisonInfo", comment: "")
-                    )
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(.horizontal)
-                    Chart {
-                        // Show selection only when a selection exists, snapped to the nearest datapoint
-                        if selectedDate != nil, let selectedSet = snappedSelectedSet, let sDate = selectedSet.workout?.date {
-                            let snapped = Calendar.current.startOfDay(for: sDate)
-                            let valueDisplayed = formatEstimatedOneRepMax(selectedSet.estimatedOneRepMax(for: exercise))
-                            RuleMark(x: .value("Selected", snapped, unit: .day))
-                                .foregroundStyle(exerciseMuscleGroupColor.opacity(0.35))
-                                .lineStyle(StrokeStyle(lineWidth: 2))
-                                .annotation(position: .top, overflowResolution: .init(x: .fit(to: .chart), y: .fit(to: .chart))) {
-                                    VStack(alignment: .leading) {
-                                        UnitView(
-                                            value: "\(valueDisplayed)",
-                                            unit: WeightUnit.used.rawValue
-                                        )
-                                        .foregroundStyle(exerciseMuscleGroupColor.gradient)
-                                        Text(snapped.formatted(.dateTime.day().month()))
-                                            .fontWeight(.bold)
-                                            .fontDesign(.rounded)
-                                            .foregroundStyle(.secondary)
-                                    }
-                                    .padding(.horizontal, 10)
-                                    .padding(.vertical, 8)
-                                    .background(RoundedRectangle(cornerRadius: 10).fill(Color.secondaryBackground))
-                                }
-                        }
-                        if let firstEntry = allDailyMaxSets.first {
-                            LineMark(
-                                x: .value("Date", Date.distantPast, unit: .day),
-                                y: .value("Max e1RM on day", convertWeightForDisplayingDecimal(firstEntry.estimatedOneRepMax(for: exercise)))
-                            )
-                            .interpolationMethod(.monotone)
-                            .foregroundStyle(exerciseMuscleGroupColor.gradient)
-                            .lineStyle(StrokeStyle(lineWidth: 5))
-                            .opacity(snappedSelectedSet == nil ? 1.0 : 0.3)
-                            AreaMark(
-                                x: .value("Date", Date.distantPast, unit: .day),
-                                y: .value("Max e1RM on day", convertWeightForDisplayingDecimal(firstEntry.estimatedOneRepMax(for: exercise)))
-                            )
-                            .interpolationMethod(.monotone)
-                            .foregroundStyle(Gradient(colors: [
-                                exerciseMuscleGroupColor.opacity(0.5),
-                                exerciseMuscleGroupColor.opacity(0.2),
-                                exerciseMuscleGroupColor.opacity(0.05),
-                            ]))
-                            .opacity(snappedSelectedSet == nil ? 1.0 : 0.3)
-                        }
-                        ForEach(allDailyMaxSets) { workoutSet in
-                            LineMark(
-                                x: .value("Date", workoutSet.workout?.date ?? .now, unit: .day),
-                                y: .value("Max e1RM on day", convertWeightForDisplayingDecimal(workoutSet.estimatedOneRepMax(for: exercise)))
-                            )
-                            .interpolationMethod(.monotone)
-                            .foregroundStyle(exerciseMuscleGroupColor.gradient)
-                            .lineStyle(StrokeStyle(lineWidth: 5))
-                            .symbol {
-                                Circle()
-                                    .frame(width: 10, height: 10)
-                                    .foregroundStyle(
-                                        exerciseMuscleGroupColor.gradient
-                                            .opacity({
-                                                guard let s = snappedSelectedSet?.workout?.date else { return 1.0 }
-                                                return Calendar.current.isDate(workoutSet.workout?.date ?? .distantPast, inSameDayAs: s) ? 1.0 : 0.3
-                                            }())
-                                    )
-                                    .overlay {
-                                        Circle()
-                                            .frame(width: 4, height: 4)
-                                            .foregroundStyle(Color.black)
-                                    }
-                                    .background(Circle().fill(Color.black))
-                            }
-                            .opacity({
-                                guard let s = snappedSelectedSet?.workout?.date else { return 1.0 }
-                                return Calendar.current.isDate(workoutSet.workout?.date ?? .distantPast, inSameDayAs: s) ? 1.0 : 0.3
-                            }())
-                            AreaMark(
-                                x: .value("Date", workoutSet.workout?.date ?? .now, unit: .day),
-                                y: .value("Max e1RM on day", convertWeightForDisplayingDecimal(workoutSet.estimatedOneRepMax(for: exercise)))
-                            )
-                            .interpolationMethod(.monotone)
-                            .foregroundStyle(Gradient(colors: [
-                                exerciseMuscleGroupColor.opacity(0.5),
-                                exerciseMuscleGroupColor.opacity(0.2),
-                                exerciseMuscleGroupColor.opacity(0.05),
-                            ]))
-                            .opacity(selectedDate == nil ? 1.0 : 0.0)
-                        }
-                        if selectedDate == nil, let lastSet = allDailyMaxSets.last, let lastDate = lastSet.workout?.date, !Calendar.current.isDateInToday(lastDate) {
-                            let e1RMDisplayed = convertWeightForDisplayingDecimal(lastSet.estimatedOneRepMax(for: exercise))
-                            RuleMark(
-                                xStart: .value("Start", lastDate),
-                                xEnd: .value("End", Date()),
-                                y: .value("Max e1RM on day", e1RMDisplayed)
-                            )
-                            .foregroundStyle(exerciseMuscleGroupColor.opacity(0.45))
-                            .lineStyle(
-                                StrokeStyle(
-                                    lineWidth: 5,
-                                    lineCap: .round,
-                                    dash: [5, 10]
-                                )
-                            )
-                        }
-                    }
-                    .chartXScale(domain: chartRange.xDomain(firstDataDate: firstDataDate))
-                    .chartYScale(domain: 0 ... chartYScaleMax(maxYValue: allTimeE1RMPR))
-                    .chartScrollableAxes(.horizontal)
-                    .chartScrollPosition(x: $chartScrollPosition)
-                    .chartScrollTargetBehavior(
-                        .valueAligned(matching: chartRange.scrollSnapComponents)
-                    )
-                    .chartXSelection(value: $selectedDate)
-                    .chartXVisibleDomain(length: visibleChartDomainInSeconds)
-                    .chartXAxis {
-                        let axisStride = chartRange.axisStride(firstDataDate: firstDataDate)
-                        AxisMarks(
-                            position: .bottom,
-                            values: .stride(by: axisStride.component, count: axisStride.count)
-                        ) { value in
-                            if let date = value.as(Date.self) {
-                                AxisGridLine()
-                                    .foregroundStyle(Color.gray.opacity(0.5))
-                                AxisValueLabel(chartRange.axisLabel(for: date, firstDataDate: firstDataDate))
-                                    .foregroundStyle(chartRange.isCurrentAxisMark(date, firstDataDate: firstDataDate) ? Color.primary : .secondary)
-                                    .font(.caption.weight(.bold))
-                            }
-                        }
-                    }
-                    .chartYAxis {
-                        let chartYScaleMax = chartYScaleMax(maxYValue: allTimeE1RMPR)
-                        AxisMarks(values: [0, chartYScaleMax / 2, chartYScaleMax])
-                    }
-                    .emptyPlaceholder(allDailyMaxSets) {
-                        Text(NSLocalizedString("noData", comment: ""))
-                    }
-                    .frame(height: 300)
-                    .padding(.leading)
-                    .padding(.trailing, 5)
-                }
+                CapabilityChartView(
+                    points: points,
+                    firstDataDate: firstDataDate,
+                    bestAnchor: bestAnchor,
+                    yScaleMax: yScaleMax,
+                    color: exerciseMuscleGroupColor,
+                    unit: WeightUnit.used.rawValue,
+                    valueLabel: NSLocalizedString("estimatedOneRepMax", comment: ""),
+                    formatValue: { formatEstimatedOneRepMax($0) }
+                )
 
                 // MARK: - About Section
                 AboutSection(
@@ -229,13 +80,12 @@ struct ExerciseE1RMScreen: View {
                 }
             }
         }
-        .onAppear {
-            chartScrollPosition = chartRange.initialScrollPosition(firstDataDate: firstDataDate)
-        }
-        .onChange(of: chartRange) {
-            // Re-initialize scroll position when switching ranges to avoid desync with visible window
-            chartScrollPosition = chartRange.initialScrollPosition(firstDataDate: firstDataDate)
-        }
+    }
+
+    // MARK: - Data
+
+    private var exerciseMuscleGroupColor: Color {
+        exercise.muscleGroup?.color ?? Color.accentColor
     }
 
     private static func dailyMaxE1RMSets(in workoutSets: [WorkoutSet], for exercise: Exercise) -> [WorkoutSet] {
@@ -243,49 +93,14 @@ struct ExerciseE1RMScreen: View {
             Calendar.current.startOfDay(for: $0.workout?.date ?? .now)
         }.sorted { $0.key < $1.key }
             .map { $0.1 }
-        let maxSetsPerDay = groupedSets
+        return groupedSets
             .compactMap { setsPerDay -> WorkoutSet? in
-                return setsPerDay.max(by: { $0.estimatedOneRepMax(for: exercise) < $1.estimatedOneRepMax(for: exercise) })
+                setsPerDay.max(by: { $0.estimatedOneRepMax(for: exercise) < $1.estimatedOneRepMax(for: exercise) })
             }
             .filter { $0.estimatedOneRepMax(for: exercise) > 0 }
-        return maxSetsPerDay
     }
 
-    private var visibleChartDomainInSeconds: Int {
-        chartRange.visibleDomainSeconds(firstDataDate: firstDataDate)
-    }
-
-
-    private var exerciseMuscleGroupColor: Color {
-        exercise.muscleGroup?.color ?? Color.accentColor
-    }
-
-
-
-
-    private var allTimeE1RMPR: Int {
-        convertWeightForDisplaying(
-            dailyMaxSets
-                .map {
-                    $0.estimatedOneRepMax(for: exercise)
-                }
-                .max() ?? 0
-        )
-    }
-
-    /// The header's left value and the comparison baseline: the best e1RM in the visible window
-    /// *other than* the current best, falling back to the most recent day's best before the window
-    /// when it holds no other value (see `exerciseOtherBestBaseline`).
-    private func bestE1RMInVisibleWindow() -> Int? {
-        exerciseOtherBestBaseline(
-            sets: dailyMaxSets,
-            windowStart: chartScrollPosition,
-            windowEnd: visibleEndDate,
-            currentBestDay: bestAnchor?.date
-        ) { $0.estimatedOneRepMax(for: exercise) }
-    }
-
-    private func chartYScaleMax(maxYValue: Int) -> Int {
+    private static func chartYScaleMax(maxYValue: Int) -> Int {
         let values = WeightUnit.used == .kg ? yAxisMaxValuesKG : yAxisMaxValuesLBS
         let nextBiggerYAxisMaxValue = values.filter { $0 > maxYValue }.min()
         return nextBiggerYAxisMaxValue ?? maxYValue
@@ -295,7 +110,7 @@ struct ExerciseE1RMScreen: View {
     /// (highest e1RM in the last four weeks) and the day it was reached. When the current-best window
     /// is empty (untrained for over a month) it falls back to the "last best" — the best on the most
     /// recent session — which flips the label to "Last Best" and drops the comparison pill.
-    private var bestAnchor: (value: Int, date: Date?, isLapsed: Bool)? {
+    private static func bestAnchor(for exercise: Exercise, in workoutSets: [WorkoutSet]) -> (value: Int, date: Date?, isLapsed: Bool)? {
         if let best = exercise.currentBestSet(for: .estimatedOneRepMax, in: workoutSets) {
             return (best.estimatedOneRepMax(for: exercise), best.workout?.date, false)
         }
@@ -304,36 +119,6 @@ struct ExerciseE1RMScreen: View {
         }
         return nil
     }
-
-    /// The header pill: the current best measured against the best in the shown window. Nil when
-    /// either side is empty, so the pill drops out only when there is genuinely nothing to compare.
-    private func headerTrendPercentage(visibleBest: Int?) -> Double? {
-        guard let current = bestAnchor?.value, current > 0,
-              let visible = visibleBest, visible > 0 else { return nil }
-        return (Double(current) - Double(visible)) / Double(visible) * 100
-    }
-
-    // MARK: - Selection helpers
-
-    private var visibleEndDate: Date {
-        Calendar.current.date(byAdding: .second, value: visibleChartDomainInSeconds, to: chartScrollPosition)!
-    }
-
-    private func nearestSet(to date: Date?, in sets: [WorkoutSet]) -> WorkoutSet? {
-        let visibleSets = sets.filter {
-            guard let d = $0.workout?.date else { return false }
-            return d >= chartScrollPosition && d <= visibleEndDate
-        }
-        let candidates = visibleSets.isEmpty ? sets : visibleSets
-        guard !candidates.isEmpty else { return nil }
-        guard let target = date else { return nil }
-        return candidates.min { a, b in
-            let ad = a.workout?.date ?? .distantPast
-            let bd = b.workout?.date ?? .distantPast
-            return abs(ad.timeIntervalSince(target)) < abs(bd.timeIntervalSince(target))
-        }
-    }
-
 }
 
 private struct PreviewWrapperView: View {

--- a/LOGIT/Features/Exercise/ExerciseDetail/ExerciseRepetitionsScreen.swift
+++ b/LOGIT/Features/Exercise/ExerciseDetail/ExerciseRepetitionsScreen.swift
@@ -8,204 +8,54 @@
 import Charts
 import SwiftUI
 
+/// Max repetitions per day for a single exercise — the detail screen behind the Repetitions tile.
+/// Structurally the twin of `ExerciseWeightScreen`; reps are a bare count (no weight-unit conversion),
+/// and the screen stays free. The chart, scrolling, selection and header live in `CapabilityChartView`.
 struct ExerciseRepetitionsScreen: View {
-    private let yAxisMaxValues = [10, 20, 50, 100, 200]
+    private static let yAxisMaxValues = [10, 20, 50, 100, 200]
 
     let exercise: Exercise
     let workoutSets: [WorkoutSet]
-    /// Daily-max sets, grouped once at init. The chart, the header baseline, the y-scale, the domain
-    /// and the selection all read from this — so scrolling or inspecting never regroups every set
-    /// again. (The selection lag came from `firstDataDate` re-grouping all sets once per axis mark,
-    /// every frame.)
-    private let dailyMaxSets: [WorkoutSet]
-    /// Earliest day with data — anchors the scrollable domain and the All range. Derived once from
-    /// `dailyMaxSets`, not recomputed on every scroll/selection frame.
-    private let firstDataDate: Date?
 
-    @State private var chartRange: ChartRange = .threeMonths
-    @State private var chartScrollPosition: Date = .now
-    @State private var selectedDate: Date?
+    private let points: [CapabilityChartView.Point]
+    private let firstDataDate: Date?
+    private let bestAnchor: (value: Int, date: Date?, isLapsed: Bool)?
+    private let yScaleMax: Int
 
     init(exercise: Exercise, workoutSets: [WorkoutSet]) {
         self.exercise = exercise
         self.workoutSets = workoutSets
         let daily = Self.dailyMaxRepetitionsSets(in: workoutSets, for: exercise)
-        self.dailyMaxSets = daily
         self.firstDataDate = daily.first?.workout?.date
+        self.points = daily.enumerated().map { index, set in
+            let raw = set.maximum(.repetitions, for: exercise)
+            return CapabilityChartView.Point(
+                id: index,
+                date: set.workout?.date ?? .now,
+                value: Double(raw),
+                raw: raw,
+                formatted: String(raw)
+            )
+        }
+        let pr = daily.map { $0.maximum(.repetitions, for: exercise) }.max() ?? 0
+        self.yScaleMax = Self.chartYScaleMax(maxYValue: pr)
+        self.bestAnchor = Self.bestAnchor(for: exercise, in: workoutSets)
     }
 
     var body: some View {
-        let allDailyMaxRepsSets = dailyMaxSets
-        // Determine the snapped selected set only when a selection exists; snap to the overall nearest datapoint
-        let snappedSelectedSet: WorkoutSet? = selectedDate != nil ? nearestSet(to: selectedDate, in: allDailyMaxRepsSets) : nil
-        let bestRepsInVisibleWindow: Int? = bestRepetitionsInVisibleWindow()
         ScrollView {
             VStack(spacing: SECTION_SPACING) {
-                VStack {
-                    RangePicker(selection: $chartRange)
-            .padding(.vertical)
-            .padding(.horizontal)
-            MetricComparisonView(
-                leading: .init(
-                    label: NSLocalizedString("previousBest", comment: ""),
-                    value: bestRepsInVisibleWindow.map { String($0) } ?? "––",
+                CapabilityChartView(
+                    points: points,
+                    firstDataDate: firstDataDate,
+                    bestAnchor: bestAnchor,
+                    yScaleMax: yScaleMax,
+                    color: exerciseMuscleGroupColor,
                     unit: NSLocalizedString("rps", comment: ""),
-                    caption: chartRange.visibleWindowDescription(from: chartScrollPosition, firstDataDate: firstDataDate)
-                ),
-                trailing: .init(
-                    label: NSLocalizedString(bestAnchor?.isLapsed == true ? "lastBest" : "currentBest", comment: ""),
-                    value: bestAnchor.map { String($0.value) } ?? "––",
-                    unit: NSLocalizedString("rps", comment: ""),
-                    caption: bestAnchor?.date.map { $0.formatted(.dateTime.day().month()) }
-                ),
-                trailingValueStyle: AnyShapeStyle(exerciseMuscleGroupColor.gradient),
-                percentChange: bestAnchor?.isLapsed == true ? nil : headerTrendPercentage(visibleBest: bestRepsInVisibleWindow),
-                positiveColor: exerciseMuscleGroupColor,
-                explanation: NSLocalizedString("currentBestComparisonInfo", comment: "")
-            )
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.horizontal)
-            Chart {
-                // Always show a selection for the closest visible datapoint (fallback to closest overall)
-                // Show selection only when a selection exists, snapped to the nearest datapoint
-                if selectedDate != nil, let selectedSet = snappedSelectedSet, let sDate = selectedSet.workout?.date {
-                    let snapped = Calendar.current.startOfDay(for: sDate)
-                    let valueDisplayed = selectedSet.maximum(.repetitions, for: exercise)
-                    RuleMark(x: .value("Selected", snapped, unit: .day))
-                        .foregroundStyle(exerciseMuscleGroupColor.opacity(0.35))
-                        .lineStyle(StrokeStyle(lineWidth: 2))
-                        .annotation(position: .top, overflowResolution: .init(x: .fit(to: .chart), y: .fit(to: .chart))) {
-                            VStack(alignment: .leading) {
-                                UnitView(
-                                    value: "\(valueDisplayed)",
-                                    unit: NSLocalizedString("rps", comment: "")
-                                )
-                                .foregroundStyle(exerciseMuscleGroupColor.gradient)
-                                Text(snapped.formatted(.dateTime.day().month()))
-                                    .fontWeight(.bold)
-                                    .fontDesign(.rounded)
-                                    .foregroundStyle(.secondary)
-                            }
-                            .padding(.horizontal, 10)
-                            .padding(.vertical, 8)
-                            .background(RoundedRectangle(cornerRadius: 10).fill(Color.secondaryBackground))
-                        }
-                }
-                if let firstEntry = allDailyMaxRepsSets.first {
-                    LineMark(
-                        x: .value("Date", Date.distantPast, unit: .day),
-                        y: .value("Max repetitions on day", firstEntry.maximum(.repetitions, for: exercise))
-                    )
-                    .interpolationMethod(.monotone)
-                    .foregroundStyle(exerciseMuscleGroupColor.gradient)
-                    .lineStyle(StrokeStyle(lineWidth: 5))
-                    .opacity(snappedSelectedSet == nil ? 1.0 : 0.3)
-                    AreaMark(
-                        x: .value("Date", Date.distantPast, unit: .day),
-                        y: .value("Max repetitions on day", firstEntry.maximum(.repetitions, for: exercise))
-                    )
-                    .interpolationMethod(.monotone)
-                    .foregroundStyle(Gradient(colors: [
-                        exerciseMuscleGroupColor.opacity(0.5),
-                        exerciseMuscleGroupColor.opacity(0.2),
-                        exerciseMuscleGroupColor.opacity(0.05),
-                    ]))
-                    .opacity(snappedSelectedSet == nil ? 1.0 : 0.3)
-                }
-                ForEach(allDailyMaxRepsSets) { workoutSet in
-                    LineMark(
-                        x: .value("Date", workoutSet.workout?.date ?? .now, unit: .day),
-                        y: .value("Max repetitions on day", workoutSet.maximum(.repetitions, for: exercise))
-                    )
-                    .interpolationMethod(.monotone)
-                    .foregroundStyle(exerciseMuscleGroupColor.gradient)
-                    .lineStyle(StrokeStyle(lineWidth: 5))
-                    .opacity({
-                        guard let s = snappedSelectedSet?.workout?.date else { return 1.0 }
-                        return Calendar.current.isDate(workoutSet.workout?.date ?? .distantPast, inSameDayAs: s) ? 1.0 : 0.3
-                    }())
-                    .symbol {
-                        Circle()
-                            .frame(width: 10, height: 10)
-                            .foregroundStyle(
-                                exerciseMuscleGroupColor.gradient
-                                    .opacity({
-                                        guard let s = snappedSelectedSet?.workout?.date else { return 1.0 }
-                                        return Calendar.current.isDate(workoutSet.workout?.date ?? .distantPast, inSameDayAs: s) ? 1.0 : 0.3
-                                    }())
-                            )
-                            .overlay {
-                                Circle()
-                                    .frame(width: 4, height: 4)
-                                    .foregroundStyle(Color.black)
-                            }
-                            .background(Circle().fill(Color.black))
-                    }
-                    AreaMark(
-                        x: .value("Date", workoutSet.workout?.date ?? .now, unit: .day),
-                        y: .value("Max repetitions on day", workoutSet.maximum(.repetitions, for: exercise))
-                    )
-                    .interpolationMethod(.monotone)
-                    .foregroundStyle(Gradient(colors: [
-                        exerciseMuscleGroupColor.opacity(0.5),
-                        exerciseMuscleGroupColor.opacity(0.2),
-                        exerciseMuscleGroupColor.opacity(0.05),
-                    ]))
-                    .opacity(selectedDate == nil ? 1.0 : 0.0)
-                }
-                if selectedDate == nil, let lastSet = allDailyMaxRepsSets.last, let lastDate = lastSet.workout?.date, !Calendar.current.isDateInToday(lastDate) {
-                    let repetitionsDisplayed = lastSet.maximum(.repetitions, for: exercise)
-                    RuleMark(
-                        xStart: .value("Start", lastDate),
-                        xEnd: .value("End", Date()),
-                        y: .value("Max repetitions on day", repetitionsDisplayed)
-                    )
-                    .foregroundStyle(exerciseMuscleGroupColor.opacity(0.45))
-                    .lineStyle(
-                        StrokeStyle(
-                            lineWidth: 5,
-                            lineCap: .round,
-                            dash: [5, 10]
-                        )
-                    )
-                }
-            }
-            .chartXScale(domain: chartRange.xDomain(firstDataDate: firstDataDate))
-            .chartYScale(domain: 0 ... chartYScaleMax(maxYValue: allTimeRepetitionsPR))
-            .chartScrollableAxes(.horizontal)
-            .chartScrollPosition(x: $chartScrollPosition)
-            .chartScrollTargetBehavior(
-                        .valueAligned(matching: chartRange.scrollSnapComponents)
-                    )
-            .chartXSelection(value: $selectedDate)
-            .chartXVisibleDomain(length: visibleChartDomainInSeconds)
-            .chartXAxis {
-                let axisStride = chartRange.axisStride(firstDataDate: firstDataDate)
-                AxisMarks(
-                    position: .bottom,
-                    values: .stride(by: axisStride.component, count: axisStride.count)
-                ) { value in
-                    if let date = value.as(Date.self) {
-                        AxisGridLine()
-                            .foregroundStyle(Color.gray.opacity(0.5))
-                        AxisValueLabel(chartRange.axisLabel(for: date, firstDataDate: firstDataDate))
-                            .foregroundStyle(chartRange.isCurrentAxisMark(date, firstDataDate: firstDataDate) ? Color.primary : .secondary)
-                            .font(.caption.weight(.bold))
-                    }
-                }
-            }
-            .chartYAxis {
-                let chartYScaleMax = chartYScaleMax(maxYValue: allTimeRepetitionsPR)
-                AxisMarks(values: [0, chartYScaleMax / 2, chartYScaleMax])
-            }
-            .emptyPlaceholder(allDailyMaxRepsSets) {
-                Text(NSLocalizedString("noData", comment: ""))
-            }
-                .frame(height: 300)
-                .padding(.leading)
-                .padding(.trailing, 5)
-                }
-                
+                    valueLabel: NSLocalizedString("repetitions", comment: ""),
+                    formatValue: { String($0) }
+                )
+
                 // MARK: - About Section
                 AboutSection(
                     metricTitle: NSLocalizedString("repetitions", comment: ""),
@@ -231,63 +81,27 @@ struct ExerciseRepetitionsScreen: View {
                 }
             }
         }
-        .onAppear {
-            chartScrollPosition = chartRange.initialScrollPosition(firstDataDate: firstDataDate)
-        }
-        .onChange(of: chartRange) {
-            // Re-initialize scroll position when switching ranges to avoid desync with visible window
-            chartScrollPosition = chartRange.initialScrollPosition(firstDataDate: firstDataDate)
-        }
     }
 
-    // MARK: - Private Methods
+    // MARK: - Data
+
+    private var exerciseMuscleGroupColor: Color {
+        exercise.muscleGroup?.color ?? Color.accentColor
+    }
 
     private static func dailyMaxRepetitionsSets(in workoutSets: [WorkoutSet], for exercise: Exercise) -> [WorkoutSet] {
         let groupedSets = Dictionary(grouping: workoutSets) {
             Calendar.current.startOfDay(for: $0.workout?.date ?? .now)
         }.sorted { $0.key < $1.key }
             .map { $0.1 }
-        let maxSetsPerDay = groupedSets
+        return groupedSets
             .compactMap { setsPerDay -> WorkoutSet? in
-                return setsPerDay.max(by: { $0.maximum(.repetitions, for: exercise) < $1.maximum(.repetitions, for: exercise) })
+                setsPerDay.max(by: { $0.maximum(.repetitions, for: exercise) < $1.maximum(.repetitions, for: exercise) })
             }
             .filter { $0.maximum(.repetitions, for: exercise) > 0 }
-        return maxSetsPerDay
     }
 
-    private var visibleChartDomainInSeconds: Int {
-        chartRange.visibleDomainSeconds(firstDataDate: firstDataDate)
-    }
-
-
-    private var exerciseMuscleGroupColor: Color {
-        exercise.muscleGroup?.color ?? Color.accentColor
-    }
-
-
-
-
-    private var allTimeRepetitionsPR: Int {
-        dailyMaxSets
-            .map {
-                $0.maximum(.repetitions, for: exercise)
-            }
-            .max() ?? 0
-    }
-
-    /// The header's left value and the comparison baseline: the best reps in the visible window
-    /// *other than* the current best, falling back to the most recent day's best before the window
-    /// when it holds no other value (see `exerciseOtherBestBaseline`).
-    private func bestRepetitionsInVisibleWindow() -> Int? {
-        exerciseOtherBestBaseline(
-            sets: dailyMaxSets,
-            windowStart: chartScrollPosition,
-            windowEnd: visibleEndDate,
-            currentBestDay: bestAnchor?.date
-        ) { $0.maximum(.repetitions, for: exercise) }
-    }
-
-    private func chartYScaleMax(maxYValue: Int) -> Int {
+    private static func chartYScaleMax(maxYValue: Int) -> Int {
         let nextBiggerYAxisMaxValue = yAxisMaxValues.filter { $0 > maxYValue }.min()
         return nextBiggerYAxisMaxValue ?? maxYValue
     }
@@ -296,7 +110,7 @@ struct ExerciseRepetitionsScreen: View {
     /// (highest reps in the last four weeks) and the day it was reached. When the current-best window
     /// is empty (untrained for over a month) it falls back to the "last best" — the best on the most
     /// recent session — which flips the label to "Last Best" and drops the comparison pill.
-    private var bestAnchor: (value: Int, date: Date?, isLapsed: Bool)? {
+    private static func bestAnchor(for exercise: Exercise, in workoutSets: [WorkoutSet]) -> (value: Int, date: Date?, isLapsed: Bool)? {
         if let best = exercise.currentBestSet(for: .repetitions, in: workoutSets) {
             return (best.maximum(.repetitions, for: exercise), best.workout?.date, false)
         }
@@ -305,36 +119,6 @@ struct ExerciseRepetitionsScreen: View {
         }
         return nil
     }
-
-    /// The header pill: the current best measured against the best in the shown window. Nil when
-    /// either side is empty, so the pill drops out only when there is genuinely nothing to compare.
-    private func headerTrendPercentage(visibleBest: Int?) -> Double? {
-        guard let current = bestAnchor?.value, current > 0,
-              let visible = visibleBest, visible > 0 else { return nil }
-        return (Double(current) - Double(visible)) / Double(visible) * 100
-    }
-
-    // MARK: - Selection helpers
-
-    private var visibleEndDate: Date {
-        Calendar.current.date(byAdding: .second, value: visibleChartDomainInSeconds, to: chartScrollPosition)!
-    }
-
-    private func nearestSet(to date: Date?, in sets: [WorkoutSet]) -> WorkoutSet? {
-        let visibleSets = sets.filter {
-            guard let d = $0.workout?.date else { return false }
-            return d >= chartScrollPosition && d <= visibleEndDate
-        }
-        let candidates = visibleSets.isEmpty ? sets : visibleSets
-        guard !candidates.isEmpty else { return nil }
-        let target = date ?? chartScrollPosition.addingTimeInterval(Double(visibleChartDomainInSeconds) / 2.0)
-        return candidates.min { a, b in
-            let ad = a.workout?.date ?? .distantPast
-            let bd = b.workout?.date ?? .distantPast
-            return abs(ad.timeIntervalSince(target)) < abs(bd.timeIntervalSince(target))
-        }
-    }
-
 }
 
 private struct PreviewWrapperView: View {

--- a/LOGIT/Features/Exercise/ExerciseDetail/ExerciseSetVolumeScreen.swift
+++ b/LOGIT/Features/Exercise/ExerciseDetail/ExerciseSetVolumeScreen.swift
@@ -8,200 +8,51 @@
 import Charts
 import SwiftUI
 
+/// Best single-set volume (weight × reps) per day for a single exercise — the detail screen behind the
+/// Set Volume tile. Structurally the twin of `ExerciseWeightScreen`; the chart, scrolling, selection
+/// and header all live in the shared `CapabilityChartView`.
 struct ExerciseSetVolumeScreen: View {
     let exercise: Exercise
     let workoutSets: [WorkoutSet]
-    /// Daily-max sets, grouped once at init. The chart, the header baseline, the y-scale, the domain
-    /// and the selection all read from this — so scrolling or inspecting never regroups every set
-    /// again. (The selection lag came from `firstDataDate` re-grouping all sets once per axis mark,
-    /// every frame.)
-    private let dailyMaxSets: [WorkoutSet]
-    /// Earliest day with data — anchors the scrollable domain and the All range. Derived once from
-    /// `dailyMaxSets`, not recomputed on every scroll/selection frame.
-    private let firstDataDate: Date?
 
-    @State private var chartRange: ChartRange = .threeMonths
-    @State private var chartScrollPosition: Date = .now
-    @State private var selectedDate: Date?
+    private let points: [CapabilityChartView.Point]
+    private let firstDataDate: Date?
+    private let bestAnchor: (value: Int, date: Date?, isLapsed: Bool)?
+    private let yScaleMax: Int
 
     init(exercise: Exercise, workoutSets: [WorkoutSet]) {
         self.exercise = exercise
         self.workoutSets = workoutSets
         let daily = Self.dailyMaxSetVolumeSets(in: workoutSets, for: exercise)
-        self.dailyMaxSets = daily
         self.firstDataDate = daily.first?.workout?.date
+        self.points = daily.enumerated().map { index, set in
+            let raw = set.volume(for: exercise)
+            return CapabilityChartView.Point(
+                id: index,
+                date: set.workout?.date ?? .now,
+                value: convertWeightForDisplayingDecimal(raw),
+                raw: raw,
+                formatted: formatWeightForDisplay(raw)
+            )
+        }
+        let pr = convertWeightForDisplaying(daily.map { $0.volume(for: exercise) }.max() ?? 0)
+        self.yScaleMax = Self.chartYScaleMax(maxYValue: pr)
+        self.bestAnchor = Self.bestAnchor(for: exercise, in: workoutSets)
     }
 
     var body: some View {
-        let allDailyMaxSets = dailyMaxSets
-        // Determine the snapped selected set only when a selection exists; snap to the nearest datapoint (prefer visible)
-        let snappedSelectedSet: WorkoutSet? = selectedDate != nil ? nearestSet(to: selectedDate, in: allDailyMaxSets) : nil
-        let bestVisibleSetVolume = bestSetVolumeInVisibleWindow()
         ScrollView {
             VStack(spacing: SECTION_SPACING) {
-                VStack {
-                    RangePicker(selection: $chartRange)
-                    .padding(.vertical)
-                    .padding(.horizontal)
-                    MetricComparisonView(
-                        leading: .init(
-                            label: NSLocalizedString("previousBest", comment: ""),
-                            value: bestVisibleSetVolume.map(formatWeightForDisplay) ?? "––",
-                            unit: WeightUnit.used.rawValue,
-                            caption: chartRange.visibleWindowDescription(from: chartScrollPosition, firstDataDate: firstDataDate)
-                        ),
-                        trailing: .init(
-                            label: NSLocalizedString(bestAnchor?.isLapsed == true ? "lastBest" : "currentBest", comment: ""),
-                            value: bestAnchor.map { formatWeightForDisplay($0.value) } ?? "––",
-                            unit: WeightUnit.used.rawValue,
-                            caption: bestAnchor?.date.map { $0.formatted(.dateTime.day().month()) }
-                        ),
-                        trailingValueStyle: AnyShapeStyle(exerciseMuscleGroupColor.gradient),
-                        percentChange: bestAnchor?.isLapsed == true ? nil : headerTrendPercentage(visibleBest: bestVisibleSetVolume),
-                        positiveColor: exerciseMuscleGroupColor,
-                        explanation: NSLocalizedString("currentBestComparisonInfo", comment: "")
-                    )
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(.horizontal)
-                    Chart {
-                        // Show selection only when a selection exists, snapped to the nearest datapoint
-                        if selectedDate != nil, let selectedSet = snappedSelectedSet, let sDate = selectedSet.workout?.date {
-                            let snapped = Calendar.current.startOfDay(for: sDate)
-                            let valueDisplayed = formatWeightForDisplay(selectedSet.volume(for: exercise))
-                            RuleMark(x: .value("Selected", snapped, unit: .day))
-                                .foregroundStyle(exerciseMuscleGroupColor.opacity(0.35))
-                                .lineStyle(StrokeStyle(lineWidth: 2))
-                                .annotation(position: .top, overflowResolution: .init(x: .fit(to: .chart), y: .fit(to: .chart))) {
-                                    VStack(alignment: .leading) {
-                                        UnitView(
-                                            value: "\(valueDisplayed)",
-                                            unit: WeightUnit.used.rawValue
-                                        )
-                                        .foregroundStyle(exerciseMuscleGroupColor.gradient)
-                                        Text(snapped.formatted(.dateTime.day().month()))
-                                            .fontWeight(.bold)
-                                            .fontDesign(.rounded)
-                                            .foregroundStyle(.secondary)
-                                    }
-                                    .padding(.horizontal, 10)
-                                    .padding(.vertical, 8)
-                                    .background(RoundedRectangle(cornerRadius: 10).fill(Color.secondaryBackground))
-                                }
-                        }
-                        if let firstEntry = allDailyMaxSets.first {
-                            LineMark(
-                                x: .value("Date", Date.distantPast, unit: .day),
-                                y: .value("Max set volume on day", convertWeightForDisplayingDecimal(firstEntry.volume(for: exercise)))
-                            )
-                            .interpolationMethod(.monotone)
-                            .foregroundStyle(exerciseMuscleGroupColor.gradient)
-                            .lineStyle(StrokeStyle(lineWidth: 5))
-                            .opacity(snappedSelectedSet == nil ? 1.0 : 0.3)
-                            AreaMark(
-                                x: .value("Date", Date.distantPast, unit: .day),
-                                y: .value("Max set volume on day", convertWeightForDisplayingDecimal(firstEntry.volume(for: exercise)))
-                            )
-                            .interpolationMethod(.monotone)
-                            .foregroundStyle(Gradient(colors: [
-                                exerciseMuscleGroupColor.opacity(0.5),
-                                exerciseMuscleGroupColor.opacity(0.2),
-                                exerciseMuscleGroupColor.opacity(0.05),
-                            ]))
-                            .opacity(snappedSelectedSet == nil ? 1.0 : 0.3)
-                        }
-                        ForEach(allDailyMaxSets) { workoutSet in
-                            LineMark(
-                                x: .value("Date", workoutSet.workout?.date ?? .now, unit: .day),
-                                y: .value("Max set volume on day", convertWeightForDisplayingDecimal(workoutSet.volume(for: exercise)))
-                            )
-                            .interpolationMethod(.monotone)
-                            .foregroundStyle(exerciseMuscleGroupColor.gradient)
-                            .lineStyle(StrokeStyle(lineWidth: 5))
-                            .symbol {
-                                Circle()
-                                    .frame(width: 10, height: 10)
-                                    .foregroundStyle(
-                                        exerciseMuscleGroupColor.gradient
-                                            .opacity({
-                                                guard let s = snappedSelectedSet?.workout?.date else { return 1.0 }
-                                                return Calendar.current.isDate(workoutSet.workout?.date ?? .distantPast, inSameDayAs: s) ? 1.0 : 0.3
-                                            }())
-                                    )
-                                    .overlay {
-                                        Circle()
-                                            .frame(width: 4, height: 4)
-                                            .foregroundStyle(Color.black)
-                                    }
-                                    .background(Circle().fill(Color.black))
-                            }
-                            .opacity({
-                                guard let s = snappedSelectedSet?.workout?.date else { return 1.0 }
-                                return Calendar.current.isDate(workoutSet.workout?.date ?? .distantPast, inSameDayAs: s) ? 1.0 : 0.3
-                            }())
-                            AreaMark(
-                                x: .value("Date", workoutSet.workout?.date ?? .now, unit: .day),
-                                y: .value("Max set volume on day", convertWeightForDisplayingDecimal(workoutSet.volume(for: exercise)))
-                            )
-                            .interpolationMethod(.monotone)
-                            .foregroundStyle(Gradient(colors: [
-                                exerciseMuscleGroupColor.opacity(0.5),
-                                exerciseMuscleGroupColor.opacity(0.2),
-                                exerciseMuscleGroupColor.opacity(0.05),
-                            ]))
-                            .opacity(selectedDate == nil ? 1.0 : 0.0)
-                        }
-                        if selectedDate == nil, let lastSet = allDailyMaxSets.last, let lastDate = lastSet.workout?.date, !Calendar.current.isDateInToday(lastDate) {
-                            let setVolumeDisplayed = convertWeightForDisplayingDecimal(lastSet.volume(for: exercise))
-                            RuleMark(
-                                xStart: .value("Start", lastDate),
-                                xEnd: .value("End", Date()),
-                                y: .value("Max set volume on day", setVolumeDisplayed)
-                            )
-                            .foregroundStyle(exerciseMuscleGroupColor.opacity(0.45))
-                            .lineStyle(
-                                StrokeStyle(
-                                    lineWidth: 5,
-                                    lineCap: .round,
-                                    dash: [5, 10]
-                                )
-                            )
-                        }
-                    }
-                    .chartXScale(domain: chartRange.xDomain(firstDataDate: firstDataDate))
-                    .chartYScale(domain: 0 ... chartYScaleMax(maxYValue: allTimeSetVolumePR))
-                    .chartScrollableAxes(.horizontal)
-                    .chartScrollPosition(x: $chartScrollPosition)
-                    .chartScrollTargetBehavior(
-                        .valueAligned(matching: chartRange.scrollSnapComponents)
-                    )
-                    .chartXSelection(value: $selectedDate)
-                    .chartXVisibleDomain(length: visibleChartDomainInSeconds)
-                    .chartXAxis {
-                        let axisStride = chartRange.axisStride(firstDataDate: firstDataDate)
-                        AxisMarks(
-                            position: .bottom,
-                            values: .stride(by: axisStride.component, count: axisStride.count)
-                        ) { value in
-                            if let date = value.as(Date.self) {
-                                AxisGridLine()
-                                    .foregroundStyle(Color.gray.opacity(0.5))
-                                AxisValueLabel(chartRange.axisLabel(for: date, firstDataDate: firstDataDate))
-                                    .foregroundStyle(chartRange.isCurrentAxisMark(date, firstDataDate: firstDataDate) ? Color.primary : .secondary)
-                                    .font(.caption.weight(.bold))
-                            }
-                        }
-                    }
-                    .chartYAxis {
-                        let chartYScaleMax = chartYScaleMax(maxYValue: allTimeSetVolumePR)
-                        AxisMarks(values: [0, chartYScaleMax / 2, chartYScaleMax])
-                    }
-                    .emptyPlaceholder(allDailyMaxSets) {
-                        Text(NSLocalizedString("noData", comment: ""))
-                    }
-                    .frame(height: 300)
-                    .padding(.leading)
-                    .padding(.trailing, 5)
-                }
+                CapabilityChartView(
+                    points: points,
+                    firstDataDate: firstDataDate,
+                    bestAnchor: bestAnchor,
+                    yScaleMax: yScaleMax,
+                    color: exerciseMuscleGroupColor,
+                    unit: WeightUnit.used.rawValue,
+                    valueLabel: NSLocalizedString("setVolume", comment: ""),
+                    formatValue: { formatWeightForDisplay($0) }
+                )
 
                 // MARK: - About Section
                 AboutSection(
@@ -226,13 +77,12 @@ struct ExerciseSetVolumeScreen: View {
                 }
             }
         }
-        .onAppear {
-            chartScrollPosition = chartRange.initialScrollPosition(firstDataDate: firstDataDate)
-        }
-        .onChange(of: chartRange) {
-            // Re-initialize scroll position when switching ranges to avoid desync with visible window
-            chartScrollPosition = chartRange.initialScrollPosition(firstDataDate: firstDataDate)
-        }
+    }
+
+    // MARK: - Data
+
+    private var exerciseMuscleGroupColor: Color {
+        exercise.muscleGroup?.color ?? Color.accentColor
     }
 
     private static func dailyMaxSetVolumeSets(in workoutSets: [WorkoutSet], for exercise: Exercise) -> [WorkoutSet] {
@@ -240,52 +90,17 @@ struct ExerciseSetVolumeScreen: View {
             Calendar.current.startOfDay(for: $0.workout?.date ?? .now)
         }.sorted { $0.key < $1.key }
             .map { $0.1 }
-        let maxSetsPerDay = groupedSets
+        return groupedSets
             .compactMap { setsPerDay -> WorkoutSet? in
-                return setsPerDay.max(by: { $0.volume(for: exercise) < $1.volume(for: exercise) })
+                setsPerDay.max(by: { $0.volume(for: exercise) < $1.volume(for: exercise) })
             }
             .filter { $0.volume(for: exercise) > 0 }
-        return maxSetsPerDay
     }
 
-    private var visibleChartDomainInSeconds: Int {
-        chartRange.visibleDomainSeconds(firstDataDate: firstDataDate)
-    }
-
-
-    private var exerciseMuscleGroupColor: Color {
-        exercise.muscleGroup?.color ?? Color.accentColor
-    }
-
-
-
-
-    private var allTimeSetVolumePR: Int {
-        convertWeightForDisplaying(
-            dailyMaxSets
-                .map {
-                    $0.volume(for: exercise)
-                }
-                .max() ?? 0
-        )
-    }
-
-    /// The header's left value and the comparison baseline: the best single-set volume in the visible
-    /// window *other than* the current best, falling back to the most recent day's best before the
-    /// window when it holds no other value (see `exerciseOtherBestBaseline`).
-    private func bestSetVolumeInVisibleWindow() -> Int? {
-        exerciseOtherBestBaseline(
-            sets: dailyMaxSets,
-            windowStart: chartScrollPosition,
-            windowEnd: visibleEndDate,
-            currentBestDay: bestAnchor?.date
-        ) { $0.volume(for: exercise) }
-    }
-
-    /// Set volume has no practical upper bound, so unlike the weight and e1RM screens (which pick
-    /// from a fixed list of axis caps) the cap is the PR rounded up to a clean half-magnitude step
-    /// — keeping the mid axis mark (cap / 2) a round number too.
-    private func chartYScaleMax(maxYValue: Int) -> Int {
+    /// Set volume has no practical upper bound, so unlike the weight and e1RM screens (which pick from a
+    /// fixed list of axis caps) the cap is the PR rounded up to a clean half-magnitude step — keeping
+    /// the mid axis mark (cap / 2) a round number too.
+    private static func chartYScaleMax(maxYValue: Int) -> Int {
         guard maxYValue > 0 else { return 10 }
         let magnitude = pow(10.0, floor(log10(Double(maxYValue))))
         let step = magnitude / 2
@@ -294,9 +109,9 @@ struct ExerciseSetVolumeScreen: View {
 
     /// The fixed right-hand anchor of the header scoreboard, independent of scroll: the current best
     /// (highest single-set volume in the last four weeks) and the day it was reached. When the
-    /// current-best window is empty (untrained for over a month) it falls back to the "last best" —
-    /// the best on the most recent session — which flips the label to "Last Best" and drops the pill.
-    private var bestAnchor: (value: Int, date: Date?, isLapsed: Bool)? {
+    /// current-best window is empty (untrained for over a month) it falls back to the "last best" — the
+    /// best on the most recent session — which flips the label to "Last Best" and drops the pill.
+    private static func bestAnchor(for exercise: Exercise, in workoutSets: [WorkoutSet]) -> (value: Int, date: Date?, isLapsed: Bool)? {
         if let best = exercise.currentBestSetVolumeSet(in: workoutSets) {
             return (best.volume(for: exercise), best.workout?.date, false)
         }
@@ -305,36 +120,6 @@ struct ExerciseSetVolumeScreen: View {
         }
         return nil
     }
-
-    /// The header pill: the current best measured against the best in the shown window. Nil when
-    /// either side is empty, so the pill drops out only when there is genuinely nothing to compare.
-    private func headerTrendPercentage(visibleBest: Int?) -> Double? {
-        guard let current = bestAnchor?.value, current > 0,
-              let visible = visibleBest, visible > 0 else { return nil }
-        return (Double(current) - Double(visible)) / Double(visible) * 100
-    }
-
-    // MARK: - Selection helpers
-
-    private var visibleEndDate: Date {
-        Calendar.current.date(byAdding: .second, value: visibleChartDomainInSeconds, to: chartScrollPosition)!
-    }
-
-    private func nearestSet(to date: Date?, in sets: [WorkoutSet]) -> WorkoutSet? {
-        let visibleSets = sets.filter {
-            guard let d = $0.workout?.date else { return false }
-            return d >= chartScrollPosition && d <= visibleEndDate
-        }
-        let candidates = visibleSets.isEmpty ? sets : visibleSets
-        guard !candidates.isEmpty else { return nil }
-        guard let target = date else { return nil }
-        return candidates.min { a, b in
-            let ad = a.workout?.date ?? .distantPast
-            let bd = b.workout?.date ?? .distantPast
-            return abs(ad.timeIntervalSince(target)) < abs(bd.timeIntervalSince(target))
-        }
-    }
-
 }
 
 private struct PreviewWrapperView: View {

--- a/LOGIT/Features/Exercise/ExerciseDetail/ExerciseWeightScreen.swift
+++ b/LOGIT/Features/Exercise/ExerciseDetail/ExerciseWeightScreen.swift
@@ -8,204 +8,61 @@
 import Charts
 import SwiftUI
 
+/// Max weight per day for a single exercise — the detail screen behind the Weight tile. All the
+/// scrolling, inspecting and header math lives in the shared `CapabilityChartView`; this screen just
+/// reduces the sets to plotted `Point`s and the fixed scoreboard anchor once, up front.
 struct ExerciseWeightScreen: View {
-    private let yAxisMaxValuesKG = [10, 25, 50, 100, 150, 200, 300, 400, 500, 600, 700, 800, 900, 1000]
-    private let yAxisMaxValuesLBS = [25, 55, 110, 225, 335, 445, 665, 885, 1105, 1325, 1545, 1765, 1985, 2205]
+    private static let yAxisMaxValuesKG = [10, 25, 50, 100, 150, 200, 300, 400, 500, 600, 700, 800, 900, 1000]
+    private static let yAxisMaxValuesLBS = [25, 55, 110, 225, 335, 445, 665, 885, 1105, 1325, 1545, 1765, 1985, 2205]
 
     let exercise: Exercise
     let workoutSets: [WorkoutSet]
-    /// Daily-max sets, grouped once at init. The chart, the header baseline, the y-scale, the domain
-    /// and the selection all read from this — so scrolling or inspecting never regroups every set
-    /// again. (The selection lag came from `firstDataDate` re-grouping all sets once per axis mark,
-    /// every frame.)
-    private let dailyMaxSets: [WorkoutSet]
-    /// Earliest day with a recorded weight — anchors the scrollable domain and the All range. Derived
-    /// once from `dailyMaxSets`, not recomputed on every scroll/selection frame.
-    private let firstDataDate: Date?
 
-    @State private var chartRange: ChartRange = .threeMonths
-    @State private var chartScrollPosition: Date = .now
-    @State private var selectedDate: Date?
+    /// The plotted history — one daily-max point, reduced to plain values, built once at init so
+    /// scrolling and inspecting never regroup sets or convert units per frame.
+    private let points: [CapabilityChartView.Point]
+    /// Earliest day with a recorded weight — the left end of the scrollable domain.
+    private let firstDataDate: Date?
+    /// The fixed right-hand scoreboard anchor (current or last best), computed once rather than
+    /// re-scanning every set on each render.
+    private let bestAnchor: (value: Int, date: Date?, isLapsed: Bool)?
+    /// The y-axis cap in display units — the next weight ladder step above the all-time PR.
+    private let yScaleMax: Int
 
     init(exercise: Exercise, workoutSets: [WorkoutSet]) {
         self.exercise = exercise
         self.workoutSets = workoutSets
         let daily = Self.dailyMaxWeightSets(in: workoutSets, for: exercise)
-        self.dailyMaxSets = daily
         self.firstDataDate = daily.first?.workout?.date
+        self.points = daily.enumerated().map { index, set in
+            let raw = set.maximum(.weight, for: exercise)
+            return CapabilityChartView.Point(
+                id: index,
+                date: set.workout?.date ?? .now,
+                value: convertWeightForDisplayingDecimal(raw),
+                raw: raw,
+                formatted: formatWeightForDisplay(raw)
+            )
+        }
+        let pr = convertWeightForDisplaying(daily.map { $0.maximum(.weight, for: exercise) }.max() ?? 0)
+        self.yScaleMax = Self.chartYScaleMax(maxYValue: pr)
+        self.bestAnchor = Self.bestAnchor(for: exercise, in: workoutSets)
     }
 
     var body: some View {
-        let allDailyMaxSets = dailyMaxSets
-        // Determine the snapped selected set only when a selection exists; snap to the nearest datapoint (prefer visible)
-        let snappedSelectedSet: WorkoutSet? = selectedDate != nil ? nearestSet(to: selectedDate, in: allDailyMaxSets) : nil
-        let bestVisibleWeight = bestWeightInVisibleWindow()
         ScrollView {
             VStack(spacing: SECTION_SPACING) {
-                VStack {
-                    RangePicker(selection: $chartRange)
-            .padding(.vertical)
-            .padding(.horizontal)
-            MetricComparisonView(
-                leading: .init(
-                    label: NSLocalizedString("previousBest", comment: ""),
-                    value: bestVisibleWeight.map(formatWeightForDisplay) ?? "––",
+                CapabilityChartView(
+                    points: points,
+                    firstDataDate: firstDataDate,
+                    bestAnchor: bestAnchor,
+                    yScaleMax: yScaleMax,
+                    color: exerciseMuscleGroupColor,
                     unit: WeightUnit.used.rawValue,
-                    caption: chartRange.visibleWindowDescription(from: chartScrollPosition, firstDataDate: firstDataDate)
-                ),
-                trailing: .init(
-                    label: NSLocalizedString(bestAnchor?.isLapsed == true ? "lastBest" : "currentBest", comment: ""),
-                    value: bestAnchor.map { formatWeightForDisplay($0.value) } ?? "––",
-                    unit: WeightUnit.used.rawValue,
-                    caption: bestAnchor?.date.map { $0.formatted(.dateTime.day().month()) }
-                ),
-                trailingValueStyle: AnyShapeStyle(exerciseMuscleGroupColor.gradient),
-                percentChange: bestAnchor?.isLapsed == true ? nil : headerTrendPercentage(visibleBest: bestVisibleWeight),
-                positiveColor: exerciseMuscleGroupColor,
-                explanation: NSLocalizedString("currentBestComparisonInfo", comment: "")
-            )
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.horizontal)
-            Chart {
-                // Show selection only when a selection exists, snapped to the nearest datapoint
-                if selectedDate != nil, let selectedSet = snappedSelectedSet, let sDate = selectedSet.workout?.date {
-                    let snapped = Calendar.current.startOfDay(for: sDate)
-                    let valueDisplayed = formatWeightForDisplay(selectedSet.maximum(.weight, for: exercise))
-                    RuleMark(x: .value("Selected", snapped, unit: .day))
-                        .foregroundStyle(exerciseMuscleGroupColor.opacity(0.35))
-                        .lineStyle(StrokeStyle(lineWidth: 2))
-                        .annotation(position: .top, overflowResolution: .init(x: .fit(to: .chart), y: .fit(to: .chart))) {
-                            VStack(alignment: .leading) {
-                                UnitView(
-                                    value: "\(valueDisplayed)",
-                                    unit: WeightUnit.used.rawValue
-                                )
-                                .foregroundStyle(exerciseMuscleGroupColor.gradient)
-                                Text(snapped.formatted(.dateTime.day().month()))
-                                    .fontWeight(.bold)
-                                    .fontDesign(.rounded)
-                                    .foregroundStyle(.secondary)
-                            }
-                            .padding(.horizontal, 10)
-                            .padding(.vertical, 8)
-                            .background(RoundedRectangle(cornerRadius: 10).fill(Color.secondaryBackground))
-                        }
-                }
-                if let firstEntry = allDailyMaxSets.first {
-                    LineMark(
-                        x: .value("Date", Date.distantPast, unit: .day),
-                        y: .value("Max repetitions on day", convertWeightForDisplayingDecimal(firstEntry.maximum(.weight, for: exercise)))
-                    )
-                    .interpolationMethod(.monotone)
-                    .foregroundStyle(exerciseMuscleGroupColor.gradient)
-                    .lineStyle(StrokeStyle(lineWidth: 5))
-                    .opacity(snappedSelectedSet == nil ? 1.0 : 0.3)
-                    AreaMark(
-                        x: .value("Date", Date.distantPast, unit: .day),
-                        y: .value("Max repetitions on day", convertWeightForDisplayingDecimal(firstEntry.maximum(.weight, for: exercise)))
-                    )
-                    .interpolationMethod(.monotone)
-                    .foregroundStyle(Gradient(colors: [
-                        exerciseMuscleGroupColor.opacity(0.5),
-                        exerciseMuscleGroupColor.opacity(0.2),
-                        exerciseMuscleGroupColor.opacity(0.05),
-                    ]))
-                    .opacity(snappedSelectedSet == nil ? 1.0 : 0.3)
-                }
-                ForEach(allDailyMaxSets) { workoutSet in
-                    LineMark(
-                        x: .value("Date", workoutSet.workout?.date ?? .now, unit: .day),
-                        y: .value("Max weight on day", convertWeightForDisplayingDecimal(workoutSet.maximum(.weight, for: exercise)))
-                    )
-                    .interpolationMethod(.monotone)
-                    .foregroundStyle(exerciseMuscleGroupColor.gradient)
-                    .lineStyle(StrokeStyle(lineWidth: 5))
-                    .symbol {
-                        Circle()
-                            .frame(width: 10, height: 10)
-                            .foregroundStyle(
-                                exerciseMuscleGroupColor.gradient
-                                    .opacity({
-                                        guard let s = snappedSelectedSet?.workout?.date else { return 1.0 }
-                                        return Calendar.current.isDate(workoutSet.workout?.date ?? .distantPast, inSameDayAs: s) ? 1.0 : 0.3
-                                    }())
-                            )
-                            .overlay {
-                                Circle()
-                                    .frame(width: 4, height: 4)
-                                    .foregroundStyle(Color.black)
-                            }
-                            .background(Circle().fill(Color.black))
-                    }
-                    .opacity({
-                        guard let s = snappedSelectedSet?.workout?.date else { return 1.0 }
-                        return Calendar.current.isDate(workoutSet.workout?.date ?? .distantPast, inSameDayAs: s) ? 1.0 : 0.3
-                    }())
-                    AreaMark(
-                        x: .value("Date", workoutSet.workout?.date ?? .now, unit: .day),
-                        y: .value("Max weight on day", convertWeightForDisplayingDecimal(workoutSet.maximum(.weight, for: exercise)))
-                    )
-                    .interpolationMethod(.monotone)
-                    .foregroundStyle(Gradient(colors: [
-                        exerciseMuscleGroupColor.opacity(0.5),
-                        exerciseMuscleGroupColor.opacity(0.2),
-                        exerciseMuscleGroupColor.opacity(0.05),
-                    ]))
-                    .opacity(selectedDate == nil ? 1.0 : 0.0)
-                }
-                if selectedDate == nil, let lastSet = allDailyMaxSets.last, let lastDate = lastSet.workout?.date, !Calendar.current.isDateInToday(lastDate) {
-                    let weightDisplayed = convertWeightForDisplayingDecimal(lastSet.maximum(.weight, for: exercise))
-                    RuleMark(
-                        xStart: .value("Start", lastDate),
-                        xEnd: .value("End", Date()),
-                        y: .value("Max weight on day", weightDisplayed)
-                    )
-                    .foregroundStyle(exerciseMuscleGroupColor.opacity(0.45))
-                    .lineStyle(
-                        StrokeStyle(
-                            lineWidth: 5,
-                            lineCap: .round,
-                            dash: [5, 10]
-                        )
-                    )
-                }
-            }
-            .chartXScale(domain: chartRange.xDomain(firstDataDate: firstDataDate))
-            .chartYScale(domain: 0 ... chartYScaleMax(maxYValue: allTimeWeightPR))
-            .chartScrollableAxes(.horizontal)
-            .chartScrollPosition(x: $chartScrollPosition)
-            .chartScrollTargetBehavior(
-                .valueAligned(matching: chartRange.scrollSnapComponents)
-            )
-            .chartXSelection(value: $selectedDate)
-            .chartXVisibleDomain(length: visibleChartDomainInSeconds)
-            .chartXAxis {
-                let axisStride = chartRange.axisStride(firstDataDate: firstDataDate)
-                AxisMarks(
-                    position: .bottom,
-                    values: .stride(by: axisStride.component, count: axisStride.count)
-                ) { value in
-                    if let date = value.as(Date.self) {
-                        AxisGridLine()
-                            .foregroundStyle(Color.gray.opacity(0.5))
-                        AxisValueLabel(chartRange.axisLabel(for: date, firstDataDate: firstDataDate))
-                            .foregroundStyle(chartRange.isCurrentAxisMark(date, firstDataDate: firstDataDate) ? Color.primary : .secondary)
-                            .font(.caption.weight(.bold))
-                    }
-                }
-            }
-            .chartYAxis {
-                let chartYScaleMax = chartYScaleMax(maxYValue: allTimeWeightPR)
-                AxisMarks(values: [0, chartYScaleMax / 2, chartYScaleMax])
-            }
-            .emptyPlaceholder(allDailyMaxSets) {
-                Text(NSLocalizedString("noData", comment: ""))
-            }
-                .frame(height: 300)
-                .padding(.leading)
-                .padding(.trailing, 5)
-                }
-                
+                    valueLabel: NSLocalizedString("weight", comment: ""),
+                    formatValue: { formatWeightForDisplay($0) }
+                )
+
                 // MARK: - About Section
                 AboutSection(
                     metricTitle: NSLocalizedString("weight", comment: ""),
@@ -229,15 +86,15 @@ struct ExerciseWeightScreen: View {
                 }
             }
         }
-        .onAppear {
-            chartScrollPosition = chartRange.initialScrollPosition(firstDataDate: firstDataDate)
-        }
-        .onChange(of: chartRange) {
-            // Re-initialize scroll position when switching ranges to avoid desync with visible window
-            chartScrollPosition = chartRange.initialScrollPosition(firstDataDate: firstDataDate)
-        }
     }
 
+    // MARK: - Data
+
+    private var exerciseMuscleGroupColor: Color {
+        exercise.muscleGroup?.color ?? Color.accentColor
+    }
+
+    /// One max-weight set per day, oldest first, days with no recorded weight dropped.
     private static func dailyMaxWeightSets(in workoutSets: [WorkoutSet], for exercise: Exercise) -> [WorkoutSet] {
         let groupedSets = Dictionary(grouping: workoutSets) {
             Calendar.current.startOfDay(for: $0.workout?.date ?? .now)
@@ -250,39 +107,7 @@ struct ExerciseWeightScreen: View {
             .filter { $0.maximum(.weight, for: exercise) > 0 }
     }
 
-    private var visibleChartDomainInSeconds: Int {
-        chartRange.visibleDomainSeconds(firstDataDate: firstDataDate)
-    }
-
-    private var exerciseMuscleGroupColor: Color {
-        exercise.muscleGroup?.color ?? Color.accentColor
-    }
-
-    /// The all-time best max-weight in display units — the y-axis cap. Read from `dailyMaxSets` (each
-    /// day's max already includes that day's best), so it scans days, not every set.
-    private var allTimeWeightPR: Int {
-        convertWeightForDisplaying(
-            dailyMaxSets.map { $0.maximum(.weight, for: exercise) }.max() ?? 0
-        )
-    }
-
-    /// The header's left value and the comparison baseline: the best max-weight in the visible window
-    /// *other than* the current best, so the pill measures the current best against the rest of the
-    /// shown period rather than itself when the peak is in view. Falls back to the most recent day's
-    /// best before the window when it holds no other value (see `exerciseOtherBestBaseline`).
-    /// The header's left value and the pill baseline, read from `dailyMaxSets` (a per-day max is the
-    /// day's best, so the best over the window is the same as over every set) — a day scan, not a
-    /// full-set scan on every scroll/selection frame.
-    private func bestWeightInVisibleWindow() -> Int? {
-        exerciseOtherBestBaseline(
-            sets: dailyMaxSets,
-            windowStart: chartScrollPosition,
-            windowEnd: visibleEndDate,
-            currentBestDay: bestAnchor?.date
-        ) { $0.maximum(.weight, for: exercise) }
-    }
-
-    private func chartYScaleMax(maxYValue: Int) -> Int {
+    private static func chartYScaleMax(maxYValue: Int) -> Int {
         let values = WeightUnit.used == .kg ? yAxisMaxValuesKG : yAxisMaxValuesLBS
         let nextBiggerYAxisMaxValue = values.filter { $0 > maxYValue }.min()
         return nextBiggerYAxisMaxValue ?? maxYValue
@@ -290,9 +115,9 @@ struct ExerciseWeightScreen: View {
 
     /// The fixed right-hand anchor of the header scoreboard, independent of scroll: the current best
     /// (highest max-weight in the last four weeks) and the day it was reached. When the current-best
-    /// window is empty (untrained for over a month) it falls back to the "last best" — the best on
-    /// the most recent session — which flips the label to "Last Best" and drops the comparison pill.
-    private var bestAnchor: (value: Int, date: Date?, isLapsed: Bool)? {
+    /// window is empty (untrained for over a month) it falls back to the "last best" — the best on the
+    /// most recent session — which flips the label to "Last Best" and drops the comparison pill.
+    private static func bestAnchor(for exercise: Exercise, in workoutSets: [WorkoutSet]) -> (value: Int, date: Date?, isLapsed: Bool)? {
         if let best = exercise.currentBestSet(for: .weight, in: workoutSets) {
             return (best.maximum(.weight, for: exercise), best.workout?.date, false)
         }
@@ -301,36 +126,6 @@ struct ExerciseWeightScreen: View {
         }
         return nil
     }
-
-    /// The header pill: the current best measured against the best in the shown window. Nil when
-    /// either side is empty, so the pill drops out only when there is genuinely nothing to compare.
-    private func headerTrendPercentage(visibleBest: Int?) -> Double? {
-        guard let current = bestAnchor?.value, current > 0,
-              let visible = visibleBest, visible > 0 else { return nil }
-        return (Double(current) - Double(visible)) / Double(visible) * 100
-    }
-
-    // MARK: - Selection helpers
-
-    private var visibleEndDate: Date {
-        Calendar.current.date(byAdding: .second, value: visibleChartDomainInSeconds, to: chartScrollPosition)!
-    }
-
-    private func nearestSet(to date: Date?, in sets: [WorkoutSet]) -> WorkoutSet? {
-        let visibleSets = sets.filter {
-            guard let d = $0.workout?.date else { return false }
-            return d >= chartScrollPosition && d <= visibleEndDate
-        }
-        let candidates = visibleSets.isEmpty ? sets : visibleSets
-        guard !candidates.isEmpty else { return nil }
-        guard let target = date else { return nil }
-        return candidates.min { a, b in
-            let ad = a.workout?.date ?? .distantPast
-            let bd = b.workout?.date ?? .distantPast
-            return abs(ad.timeIntervalSince(target)) < abs(bd.timeIntervalSince(target))
-        }
-    }
-
 }
 
 private struct PreviewWrapperView: View {

--- a/LOGIT/Features/Exercise/ExerciseDetail/Tiles/ExerciseMetricTile.swift
+++ b/LOGIT/Features/Exercise/ExerciseDetail/Tiles/ExerciseMetricTile.swift
@@ -145,38 +145,6 @@ func exerciseWindowTrendPercentage(
     return (current - baseline) / baseline * 100
 }
 
-/// The exercise chart headers' comparison baseline: the best value in the visible window *other than*
-/// the current best, so the header pill measures the current best against the rest of the shown
-/// period instead of against itself when the peak is on screen. `currentBestDay` — the day the
-/// current best was reached — is excluded from the window. When the window holds no other value, the
-/// baseline falls back to the most recent day's best before it; nil only when there's nothing earlier
-/// to compare against either. `value` extracts the per-set metric (a max for these screens).
-func exerciseOtherBestBaseline(
-    sets: [WorkoutSet],
-    windowStart: Date,
-    windowEnd: Date,
-    currentBestDay: Date?,
-    value: (WorkoutSet) -> Int
-) -> Int? {
-    let calendar = Calendar.current
-    let otherInWindow = sets.filter { set in
-        guard let date = set.workout?.date, date >= windowStart, date <= windowEnd else { return false }
-        if let currentBestDay, calendar.isDate(date, inSameDayAs: currentBestDay) { return false }
-        return value(set) > 0
-    }
-    if let best = otherInWindow.map(value).max(), best > 0 { return best }
-    // No other value in the shown window: the most recent day's best before it.
-    let prior = sets.filter { set in
-        guard let date = set.workout?.date, date < windowStart else { return false }
-        return value(set) > 0
-    }
-    guard let lastDate = prior.compactMap({ $0.workout?.date }).max() else { return nil }
-    return prior
-        .filter { calendar.isDate($0.workout?.date ?? .distantPast, inSameDayAs: lastDate) }
-        .map(value)
-        .max()
-}
-
 // MARK: - Ghost Sparkline
 
 /// The empty states' placeholder artwork: a dashed, muted curve rising toward a single

--- a/LOGIT/SharedUI/Charts/CapabilityChartView.swift
+++ b/LOGIT/SharedUI/Charts/CapabilityChartView.swift
@@ -1,0 +1,289 @@
+//
+//  CapabilityChartView.swift
+//  LOGIT
+//
+//  Created by Lukas Kaibel on 15.07.26.
+//
+
+import Charts
+import SwiftUI
+
+/// The shared scrollable line chart behind every exercise *capability* detail screen — Weight, e1RM,
+/// Set Volume and Repetitions. Capability metrics track what the body can do *right now*, so the chart
+/// scrolls a rolling `ChartRange` window ("3M" / "1Y" / "All") through the whole history, with a
+/// scoreboard header comparing the current best against the best in the visible window.
+///
+/// It owns the scroll position, the selection and the range picker — deliberately, exactly like
+/// `PeriodStatChartView` does for the effort stats. Scrolling and inspecting drive `chartScrollPosition`
+/// / `selectedDate` on *this* view, so only this small view re-renders per frame; the screen that
+/// builds the data never does. And the data it re-renders is already reduced to plain value types —
+/// `Point`s carry a precomputed display value, a raw metric and a formatted string, so a scroll frame
+/// touches no Core Data, does no unit conversion and runs no per-set metric math. That is the whole
+/// fix for the "basically unusable" selection/scroll lag: the earlier inline charts rebuilt every
+/// mark from `WorkoutSet`s and re-scanned the full set list for the header on every frame.
+struct CapabilityChartView: View {
+    /// One plotted day — the day's best set, reduced to plain values up front so a render frame reads
+    /// numbers instead of faulting `WorkoutSet`s. There is exactly one `Point` per calendar day (the
+    /// daily max), which is why the selection dimming can compare by `id` instead of by calendar day.
+    struct Point: Identifiable {
+        let id: Int
+        /// The real timestamp of the day's best set — positioned to its day by the marks' `unit: .day`,
+        /// and compared against the visible window (which is expressed in real dates) for selection.
+        let date: Date
+        /// The value plotted on the y-axis, already in display units (kg / lbs / reps).
+        let value: Double
+        /// The metric in raw storage units (grams, or a bare rep count) — what the visible-window
+        /// baseline maxes over and the header trend is a percentage of, matching `bestAnchor.value`.
+        let raw: Int
+        /// The value spelled out for the selection tooltip, in the screen's own units ("142.5", "12").
+        let formatted: String
+    }
+
+    /// The whole history, one `Point` per day, oldest first — built once by the screen.
+    let points: [Point]
+    /// Earliest data date — the left end of the scrollable domain and the `All` range. Passed in so it
+    /// isn't re-derived from the data on every scroll/selection frame.
+    let firstDataDate: Date?
+    /// The fixed right-hand anchor of the header scoreboard, independent of scroll: the current best
+    /// (highest in the last four weeks) or, when that window is empty, the "last best". Computed once
+    /// by the screen — reading it here is a struct field, not the full-set rescan it used to be.
+    let bestAnchor: (value: Int, date: Date?, isLapsed: Bool)?
+    /// The y-axis cap in display units — each screen picks it by its own rule (a fixed ladder for
+    /// weight / e1RM / reps, a rounded magnitude for set volume).
+    let yScaleMax: Int
+    let color: Color
+    /// Unit shown after the header and tooltip values ("kg", "reps").
+    let unit: String
+    /// Accessibility series name for the y-values (not rendered).
+    let valueLabel: String
+    /// Formats a raw metric (the header baseline and the anchor) into the screen's units — the same
+    /// formatter the `Point.formatted` strings were built with.
+    let formatValue: (Int) -> String
+
+    @State private var chartRange: ChartRange = .threeMonths
+    @State private var chartScrollPosition: Date = .now
+    @State private var selectedDate: Date?
+
+    var body: some View {
+        // Per-frame work, now all O(points) integer/date math over the precomputed values — no Core
+        // Data, no unit conversion, no full-set rescan.
+        let snappedSelectedPoint = selectedDate.flatMap { nearestPoint(to: $0) }
+        let baselineRaw = otherBestBaseline(currentBestDay: bestAnchor?.date)
+        VStack {
+            RangePicker(selection: $chartRange)
+                .padding(.vertical)
+                .padding(.horizontal)
+            MetricComparisonView(
+                leading: .init(
+                    label: NSLocalizedString("previousBest", comment: ""),
+                    value: baselineRaw.map(formatValue) ?? "––",
+                    unit: unit,
+                    caption: chartRange.visibleWindowDescription(from: chartScrollPosition, firstDataDate: firstDataDate)
+                ),
+                trailing: .init(
+                    label: NSLocalizedString(bestAnchor?.isLapsed == true ? "lastBest" : "currentBest", comment: ""),
+                    value: bestAnchor.map { formatValue($0.value) } ?? "––",
+                    unit: unit,
+                    caption: bestAnchor?.date.map { $0.formatted(.dateTime.day().month()) }
+                ),
+                trailingValueStyle: AnyShapeStyle(color.gradient),
+                percentChange: bestAnchor?.isLapsed == true ? nil : headerTrendPercentage(visibleBest: baselineRaw),
+                positiveColor: color,
+                explanation: NSLocalizedString("currentBestComparisonInfo", comment: "")
+            )
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal)
+            Chart {
+                // The selection: a rule mark and a value card, snapped to the nearest datapoint, shown
+                // only while a selection exists.
+                if selectedDate != nil, let selectedPoint = snappedSelectedPoint {
+                    let snapped = Calendar.current.startOfDay(for: selectedPoint.date)
+                    RuleMark(x: .value("Selected", snapped, unit: .day))
+                        .foregroundStyle(color.opacity(0.35))
+                        .lineStyle(StrokeStyle(lineWidth: 2))
+                        .annotation(position: .top, overflowResolution: .init(x: .fit(to: .chart), y: .fit(to: .chart))) {
+                            VStack(alignment: .leading) {
+                                UnitView(value: selectedPoint.formatted, unit: unit)
+                                    .foregroundStyle(color.gradient)
+                                Text(snapped.formatted(.dateTime.day().month()))
+                                    .fontWeight(.bold)
+                                    .fontDesign(.rounded)
+                                    .foregroundStyle(.secondary)
+                            }
+                            .padding(.horizontal, 10)
+                            .padding(.vertical, 8)
+                            .background(RoundedRectangle(cornerRadius: 10).fill(Color.secondaryBackground))
+                        }
+                }
+                // A flat lead-in from the far past to the first datapoint, so a young history still
+                // reads as a line rather than a lone dot at the right edge.
+                if let firstPoint = points.first {
+                    LineMark(
+                        x: .value("Date", Date.distantPast, unit: .day),
+                        y: .value(valueLabel, firstPoint.value)
+                    )
+                    .interpolationMethod(.monotone)
+                    .foregroundStyle(color.gradient)
+                    .lineStyle(StrokeStyle(lineWidth: 5))
+                    .opacity(snappedSelectedPoint == nil ? 1.0 : 0.3)
+                    AreaMark(
+                        x: .value("Date", Date.distantPast, unit: .day),
+                        y: .value(valueLabel, firstPoint.value)
+                    )
+                    .interpolationMethod(.monotone)
+                    .foregroundStyle(Gradient(colors: [
+                        color.opacity(0.5),
+                        color.opacity(0.2),
+                        color.opacity(0.05),
+                    ]))
+                    .opacity(snappedSelectedPoint == nil ? 1.0 : 0.3)
+                }
+                ForEach(points) { point in
+                    let isSelected = snappedSelectedPoint?.id == point.id
+                    let lineOpacity = snappedSelectedPoint == nil || isSelected ? 1.0 : 0.3
+                    LineMark(
+                        x: .value("Date", point.date, unit: .day),
+                        y: .value(valueLabel, point.value)
+                    )
+                    .interpolationMethod(.monotone)
+                    .foregroundStyle(color.gradient)
+                    .lineStyle(StrokeStyle(lineWidth: 5))
+                    .opacity(lineOpacity)
+                    .symbol {
+                        Circle()
+                            .frame(width: 10, height: 10)
+                            .foregroundStyle(color.gradient.opacity(lineOpacity))
+                            .overlay {
+                                Circle()
+                                    .frame(width: 4, height: 4)
+                                    .foregroundStyle(Color.black)
+                            }
+                            .background(Circle().fill(Color.black))
+                    }
+                    AreaMark(
+                        x: .value("Date", point.date, unit: .day),
+                        y: .value(valueLabel, point.value)
+                    )
+                    .interpolationMethod(.monotone)
+                    .foregroundStyle(Gradient(colors: [
+                        color.opacity(0.5),
+                        color.opacity(0.2),
+                        color.opacity(0.05),
+                    ]))
+                    .opacity(selectedDate == nil ? 1.0 : 0.0)
+                }
+                // A dashed carry-forward from the last datapoint to today, so a lapsed metric doesn't
+                // just stop mid-chart. Hidden while inspecting.
+                if selectedDate == nil, let lastPoint = points.last, !Calendar.current.isDateInToday(lastPoint.date) {
+                    RuleMark(
+                        xStart: .value("Start", lastPoint.date),
+                        xEnd: .value("End", Date()),
+                        y: .value(valueLabel, lastPoint.value)
+                    )
+                    .foregroundStyle(color.opacity(0.45))
+                    .lineStyle(
+                        StrokeStyle(
+                            lineWidth: 5,
+                            lineCap: .round,
+                            dash: [5, 10]
+                        )
+                    )
+                }
+            }
+            .chartXScale(domain: chartRange.xDomain(firstDataDate: firstDataDate))
+            .chartYScale(domain: 0 ... yScaleMax)
+            .chartScrollableAxes(.horizontal)
+            .chartScrollPosition(x: $chartScrollPosition)
+            .chartScrollTargetBehavior(
+                .valueAligned(matching: chartRange.scrollSnapComponents)
+            )
+            .chartXSelection(value: $selectedDate)
+            .chartXVisibleDomain(length: chartRange.visibleDomainSeconds(firstDataDate: firstDataDate))
+            .chartXAxis {
+                let axisStride = chartRange.axisStride(firstDataDate: firstDataDate)
+                AxisMarks(
+                    position: .bottom,
+                    values: .stride(by: axisStride.component, count: axisStride.count)
+                ) { value in
+                    if let date = value.as(Date.self) {
+                        AxisGridLine()
+                            .foregroundStyle(Color.gray.opacity(0.5))
+                        AxisValueLabel(chartRange.axisLabel(for: date, firstDataDate: firstDataDate))
+                            .foregroundStyle(chartRange.isCurrentAxisMark(date, firstDataDate: firstDataDate) ? Color.primary : .secondary)
+                            .font(.caption.weight(.bold))
+                    }
+                }
+            }
+            .chartYAxis {
+                AxisMarks(values: [0, yScaleMax / 2, yScaleMax])
+            }
+            .emptyPlaceholder(points) {
+                Text(NSLocalizedString("noData", comment: ""))
+            }
+            .frame(height: 300)
+            .padding(.leading)
+            .padding(.trailing, 5)
+        }
+        .onAppear {
+            chartScrollPosition = chartRange.initialScrollPosition(firstDataDate: firstDataDate)
+        }
+        .onChange(of: chartRange) {
+            // Re-initialize scroll position when switching ranges to avoid desync with visible window.
+            chartScrollPosition = chartRange.initialScrollPosition(firstDataDate: firstDataDate)
+        }
+    }
+
+    // MARK: - Selection
+
+    private var visibleEndDate: Date {
+        Calendar.current.date(
+            byAdding: .second,
+            value: chartRange.visibleDomainSeconds(firstDataDate: firstDataDate),
+            to: chartScrollPosition
+        ) ?? chartScrollPosition
+    }
+
+    /// The datapoint nearest the raw selection point, preferring the visible window so a tap always
+    /// lands on a bar on screen. Mirrors the old `nearestSet`, over precomputed points.
+    private func nearestPoint(to date: Date) -> Point? {
+        let visible = points.filter { $0.date >= chartScrollPosition && $0.date <= visibleEndDate }
+        let candidates = visible.isEmpty ? points : visible
+        guard !candidates.isEmpty else { return nil }
+        return candidates.min {
+            abs($0.date.timeIntervalSince(date)) < abs($1.date.timeIntervalSince(date))
+        }
+    }
+
+    // MARK: - Header
+
+    /// The header's left value and comparison baseline: the best value in the visible window *other
+    /// than* the current best (its day excluded), falling back to the most recent day's best before
+    /// the window when the window holds no other value. Runs over the precomputed points, so it costs
+    /// integer compares per frame, not the full-set rescan the inline charts did.
+    private func otherBestBaseline(currentBestDay: Date?) -> Int? {
+        let calendar = Calendar.current
+        let windowStart = chartScrollPosition
+        let windowEnd = visibleEndDate
+        let otherInWindow = points.filter { point in
+            guard point.date >= windowStart, point.date <= windowEnd else { return false }
+            if let currentBestDay, calendar.isDate(point.date, inSameDayAs: currentBestDay) { return false }
+            return point.raw > 0
+        }
+        if let best = otherInWindow.map(\.raw).max(), best > 0 { return best }
+        // No other value in the shown window: the most recent day's best before it.
+        let prior = points.filter { $0.date < windowStart && $0.raw > 0 }
+        guard let lastDate = prior.map(\.date).max() else { return nil }
+        return prior
+            .filter { calendar.isDate($0.date, inSameDayAs: lastDate) }
+            .map(\.raw)
+            .max()
+    }
+
+    /// The header pill: the current best measured against the best in the shown window. Nil when
+    /// either side is empty, so the pill drops out only when there's genuinely nothing to compare.
+    private func headerTrendPercentage(visibleBest: Int?) -> Double? {
+        guard let current = bestAnchor?.value, current > 0,
+              let visible = visibleBest, visible > 0 else { return nil }
+        return (Double(current) - Double(visible)) / Double(visible) * 100
+    }
+}


### PR DESCRIPTION
## Problem
The Weight / e1RM / Set Volume / Repetitions detail charts were near-frozen while scrolling or inspecting on a long history. Each screen held its `Chart` inline in the screen `body` with `chartScrollPosition`/`selectedDate` as `@State` on the screen, so Swift Charts re-ran the **entire screen body every frame** — work that scaled with the whole history: a full-set header scan (`currentBestSet`, ~5×/frame), per-mark Core Data metric lookups + `UserDefaults` unit conversions, and custom symbols for every point across the full domain. #77 memoized the daily-max grouping but left the inline chart in the body, so those per-frame rescans remained.

## Fix
A shared **`CapabilityChartView`** (the capability twin of `PeriodStatChartView`):
- **Owns** `chartRange`/`chartScrollPosition`/`selectedDate`, so scrolling/inspecting re-render only that subview — never the parent screen.
- Renders from a precomputed `[Point]` (display value + raw + formatted string) plus a `bestAnchor` and `yScaleMax`, all built **once in the screen's `init`**. A scroll frame touches no `WorkoutSet`, does no unit conversion, runs no full-set scan.
- The four ~350-line screens collapse to ~120-line wrappers; the orphaned `exerciseOtherBestBaseline` helper is removed. **Net −879 lines.**

## Verification
- Builds green (LOGIT scheme).
- **Visuals** — all four charts + the hold-to-inspect tooltip captured on device (iPhone 17 Pro / iOS 26.4); pixel-identical to before.
- **Perf** — before/after `sample` of the main thread during a live scroll on `-SCENARIO stress` (2 years, ~104 daily points): the per-frame `currentBestSet` / `WorkoutSet.maximum` / `convertWeightForDisplaying` and the whole-screen re-render are **gone**; only `CapabilityChartView.body` re-renders. Busiest app frame ≈106 → ≈16 samples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)