### PR TITLE
Fix workout recorder lag on focus, unfocus, and rest-timer changes

### DIFF
--- a/LOGIT/App/LOGITApp.swift
+++ b/LOGIT/App/LOGITApp.swift
@@ -158,7 +158,7 @@ struct LOGIT: App {
                 .environment(\.goHome) { selectedTab = .home }
                 .environment(\.presentWorkoutRecorder, showWorkoutRecorder)
                 .fullScreenDraggableCover(isPresented: $isShowingWorkoutRecorder) {
-                    WorkoutRecorderScreen()
+                    WorkoutRecorderScreen(chronograph: chronograph)
                         .environmentObject(database)
                         .environmentObject(measurementController)
                         .environmentObject(templateService)

--- a/LOGIT/Features/Workout/Cells/WorkoutSetGroupCell.swift
+++ b/LOGIT/Features/Workout/Cells/WorkoutSetGroupCell.swift
@@ -7,6 +7,7 @@
 
 import Charts
 import Combine
+import CoreData
 import SwiftUI
 
 struct WorkoutSetGroupCell: View {
@@ -25,10 +26,24 @@ struct WorkoutSetGroupCell: View {
     let supplementaryText: String?
     var showDetailAsSheet: Bool = false
     var showPendingRestInTertiary: Bool = false
+    /// Whether any set field is currently focused, passed as a plain value (instead of reading
+    /// `focusedIntegerFieldIndex` here) so this cell's body doesn't re-run for every focus move
+    /// between fields — only for the keyboard appearing or disappearing.
+    var isFieldFocused: Bool = false
+    /// Position of this group in the workout, passed by `WorkoutSetGroupList` so it is part of
+    /// this cell's `Equatable` inputs: with body skipping, deleting or reordering *another*
+    /// group must still refresh this cell's header number. Nil when the cell is used standalone
+    /// (previews), where the position is derived from the workout instead.
+    var indexInWorkout: Int? = nil
+    /// Flat index of this group's first set within the whole workout. Not rendered, but part of
+    /// `==`: the set cells derive their keyboard-focus indices from flat set positions, so a
+    /// structural change in an earlier group has to re-render this cell's children too.
+    var firstSetIndexInWorkout: Int = 0
     var onTapRestDuration: ((WorkoutSet) -> Void)? = nil
     var onReorderSetGroups: (() -> Void)? = nil
     var onTapPreviousSet: ((Exercise) -> Void)? = nil
     var onTapExerciseName: ((Exercise) -> Void)? = nil
+    var onTapMetricBadge: ((WorkoutSetGroup, CGRect) -> Void)? = nil
 
     // MARK: - State
 
@@ -248,7 +263,8 @@ struct WorkoutSetGroupCell: View {
                 MetricBadgeView(
                     setGroup: setGroup,
                     workout: workout,
-                    isEditing: focusedIntegerFieldIndex != nil
+                    isEditing: isFieldFocused,
+                    onTapBadge: onTapMetricBadge
                 )
                 // The badge floats here without claiming layout space; feed its width back so the
                 // exercise name can reserve room and fade out before it (see `exerciseNameTrailingInset`).
@@ -286,7 +302,7 @@ struct WorkoutSetGroupCell: View {
     private var header: some View {
         VStack(spacing: 8) {
             HStack(spacing: 10) {
-                if let indexInWorkout = setGroup.workout?.setGroups.firstIndex(of: setGroup) {
+                if let indexInWorkout = indexInWorkout ?? setGroup.workout?.setGroups.firstIndex(of: setGroup) {
                     Text("\(indexInWorkout + 1)")
                         .font(.title)
                         .fontWeight(.medium)
@@ -504,7 +520,144 @@ struct WorkoutSetGroupCell: View {
     }
 }
 
+/// Lets SwiftUI skip this cell's body when a parent re-render didn't change what it draws. The
+/// recorder screen re-renders for reasons that don't concern individual cells (focus moves
+/// between fields, timer state, progress), and without this every such pass re-ran every cell.
+/// The comparison deliberately ignores the callback closures (their behavior is stable across
+/// renders) and the bindings (views reading a binding's value re-render on its changes on their
+/// own). Set-level edits still re-render instantly through the cell's `@ObservedObject setGroup`
+/// and the set cells' own observed sets, which bypass this check entirely.
+extension WorkoutSetGroupCell: Equatable {
+    static func == (lhs: WorkoutSetGroupCell, rhs: WorkoutSetGroupCell) -> Bool {
+        lhs.setGroup === rhs.setGroup
+            && lhs.supplementaryText == rhs.supplementaryText
+            && lhs.showDetailAsSheet == rhs.showDetailAsSheet
+            && lhs.showPendingRestInTertiary == rhs.showPendingRestInTertiary
+            && lhs.isFieldFocused == rhs.isFieldFocused
+            && lhs.indexInWorkout == rhs.indexInWorkout
+            && lhs.firstSetIndexInWorkout == rhs.firstSetIndexInWorkout
+    }
+}
+
 // MARK: - Session vs current best
+
+/// Cache for the history-derived side of `SetGroupMetricComparison` (`previousAllTimeBest` and
+/// `currentBest`). Both scan the exercise's entire set history — hundreds of sets for a trained
+/// exercise — and the badge consults them several times per render, which made every full
+/// recorder re-render pay dozens of history scans (the dominant main-thread cost while typing,
+/// focusing fields, or running the rest timer). During a session that history is static: both
+/// values exclude the workout being recorded. So the scans are cached here and recomputed only
+/// when something *outside* the current workout changes — a CloudKit import, deleting or editing
+/// an old workout, or an exercise change.
+private final class ExerciseHistoryBestsCache: @unchecked Sendable {
+    static let shared = ExerciseHistoryBestsCache()
+
+    enum Kind: Hashable {
+        case allTimeBest
+        case currentBest
+    }
+
+    private struct Key: Hashable {
+        let kind: Kind
+        let exercise: NSManagedObjectID
+        let metric: ExercisePrimaryMetric
+        let excludedWorkout: NSManagedObjectID?
+        let anchor: Date?
+    }
+
+    private let lock = NSLock()
+    private var values: [Key: Int?] = [:]
+
+    private init() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(contextObjectsDidChange),
+            name: .NSManagedObjectContextObjectsDidChange,
+            object: nil
+        )
+    }
+
+    func value(
+        _ kind: Kind,
+        exercise: Exercise,
+        metric: ExercisePrimaryMetric,
+        excludedWorkout: Workout?,
+        anchor: Date?,
+        compute: () -> Int?
+    ) -> Int? {
+        let key = Key(
+            kind: kind,
+            exercise: exercise.objectID,
+            metric: metric,
+            excludedWorkout: excludedWorkout?.objectID,
+            anchor: anchor
+        )
+        lock.lock()
+        if let cached = values[key] {
+            lock.unlock()
+            return cached
+        }
+        lock.unlock()
+        let computed = compute()
+        lock.lock()
+        values[key] = computed
+        lock.unlock()
+        return computed
+    }
+
+    private func invalidateAll() {
+        lock.lock()
+        values.removeAll()
+        lock.unlock()
+    }
+
+    /// The context-change notification arrives on the posting context's queue. Background
+    /// contexts (CloudKit imports) always concern history, so they invalidate wholesale.
+    /// Main-context changes are inspected on their own (main) queue: edits confined to the
+    /// workout currently being recorded (typing a set value, adding a set) don't touch prior
+    /// history and keep the cache.
+    @objc private func contextObjectsDidChange(_ notification: Notification) {
+        guard Thread.isMainThread else {
+            invalidateAll()
+            return
+        }
+        lock.lock()
+        let isEmpty = values.isEmpty
+        lock.unlock()
+        guard !isEmpty else { return }
+
+        let changeKeys = [
+            NSInsertedObjectsKey, NSUpdatedObjectsKey, NSDeletedObjectsKey, NSRefreshedObjectsKey,
+        ]
+        for changeKey in changeKeys {
+            guard let objects = notification.userInfo?[changeKey] as? Set<NSManagedObject> else {
+                continue
+            }
+            for object in objects {
+                let workout: Workout?
+                switch object {
+                case let workoutSet as WorkoutSet:
+                    workout = workoutSet.setGroup?.workout
+                case let setGroup as WorkoutSetGroup:
+                    workout = setGroup.workout
+                case let changedWorkout as Workout:
+                    workout = changedWorkout
+                case is Exercise:
+                    invalidateAll()
+                    return
+                default:
+                    continue
+                }
+                // Anything not clearly confined to the in-progress workout — including
+                // deletions, whose relationships are already severed — invalidates.
+                guard let workout, !workout.isDeleted, workout.isCurrentWorkout else {
+                    invalidateAll()
+                    return
+                }
+            }
+        }
+    }
+}
 
 /// The numbers behind the metric badge and its info panel: what this set group achieved per metric,
 /// the exercise's current best it's measured against, and the percent between them. One shared home
@@ -532,6 +685,20 @@ private struct SetGroupMetricComparison {
     /// comparison keeps telling that day's story even after later sessions surpass it. While
     /// recording, the window stays anchored at now — the two coincide there anyway.
     func currentBest(_ metric: ExercisePrimaryMetric) -> Int? {
+        guard let exercise = setGroup.exercise else { return nil }
+        let anchor = setGroup.workout?.isCurrentWorkout == true ? nil : setGroup.workout?.date
+        return ExerciseHistoryBestsCache.shared.value(
+            .currentBest,
+            exercise: exercise,
+            metric: metric,
+            excludedWorkout: setGroup.workout,
+            anchor: anchor
+        ) {
+            currentBestImpl(metric)
+        }
+    }
+
+    private func currentBestImpl(_ metric: ExercisePrimaryMetric) -> Int? {
         guard let exercise = setGroup.exercise else { return nil }
         let anchor = setGroup.workout?.isCurrentWorkout == true ? nil : setGroup.workout?.date
         var priorSets = exercise.sets.filter { $0.workout != setGroup.workout }
@@ -572,6 +739,19 @@ private struct SetGroupMetricComparison {
     /// record has to clear (all-time, intentionally NOT the current-best window). Excludes the
     /// current workout.
     func previousAllTimeBest(_ metric: ExercisePrimaryMetric) -> Int {
+        guard let exercise = setGroup.exercise else { return 0 }
+        return ExerciseHistoryBestsCache.shared.value(
+            .allTimeBest,
+            exercise: exercise,
+            metric: metric,
+            excludedWorkout: setGroup.workout,
+            anchor: nil
+        ) {
+            previousAllTimeBestImpl(metric)
+        } ?? 0
+    }
+
+    private func previousAllTimeBestImpl(_ metric: ExercisePrimaryMetric) -> Int {
         guard let exercise = setGroup.exercise else { return 0 }
         let priorSets = exercise.sets.filter { $0.workout != setGroup.workout }
         switch metric {
@@ -616,11 +796,13 @@ private struct MetricBadgeView: View {
     /// keyboard, which often pushes this badge out of view — so peeks found mid-edit are deferred
     /// until editing ends and the badge is back on screen.
     let isEditing: Bool
-    @StateObject private var peek = MetricPeekController()
     /// Set by the workout recorder. There the badge sits behind a persistent sheet, so presenting its
     /// own popover/sheet would tear that sheet down — instead the tap is routed up and the recorder
     /// presents the panel from the sheet's own context. Nil elsewhere, where the popover is fine.
-    @Environment(\.metricInfoRequest) private var metricInfoRequest
+    /// A plain parameter (not an environment value) so the recorder's per-render closure can't
+    /// register every badge as environment-dependent on it.
+    let onTapBadge: ((WorkoutSetGroup, CGRect) -> Void)?
+    @StateObject private var peek = MetricPeekController()
 
     @State private var primaryMetric: ExercisePrimaryMetric = .estimatedOneRepMax
     @State private var isShowingInfo = false
@@ -640,10 +822,16 @@ private struct MetricBadgeView: View {
 
     private var displayedIsRecord: Bool { comparison.isPersonalRecord(displayedMetric) }
 
-    init(setGroup: WorkoutSetGroup, workout: Workout, isEditing: Bool) {
+    init(
+        setGroup: WorkoutSetGroup,
+        workout: Workout,
+        isEditing: Bool,
+        onTapBadge: ((WorkoutSetGroup, CGRect) -> Void)? = nil
+    ) {
         _setGroup = ObservedObject(wrappedValue: setGroup)
         _workout = ObservedObject(wrappedValue: workout)
         self.isEditing = isEditing
+        self.onTapBadge = onTapBadge
         // Resolve the committed metric up front so the very first render already evaluates the right
         // metric: the idle/empty decision below shouldn't wait on `onAppear`, and it spares a
         // first-frame roll up from the `.estimatedOneRepMax` default.
@@ -675,9 +863,9 @@ private struct MetricBadgeView: View {
                     .contentShape(Rectangle())
                     .onTapGesture {
                         UIImpactFeedbackGenerator(style: .soft).impactOccurred()
-                        if let metricInfoRequest {
+                        if let onTapBadge {
                             if badgeFrame != .zero {
-                                metricInfoRequest(setGroup, badgeFrame)
+                                onTapBadge(setGroup, badgeFrame)
                             }
                         } else {
                             isShowingInfo = true
@@ -1307,19 +1495,3 @@ struct MetricInfoPanel: View {
     }
 }
 
-// MARK: - Metric info request (environment)
-
-private struct MetricInfoRequestKey: EnvironmentKey {
-    static let defaultValue: ((WorkoutSetGroup, CGRect) -> Void)? = nil
-}
-
-extension EnvironmentValues {
-    /// Set by the workout recorder so a metric-badge tap presents the info popover from the
-    /// recorder's persistent sheet context, anchored at the badge's global frame — a popover
-    /// presented from the badge itself (which lives behind that sheet) tears the sheet down. Absent
-    /// elsewhere, where the badge presents its own popover.
-    var metricInfoRequest: ((WorkoutSetGroup, CGRect) -> Void)? {
-        get { self[MetricInfoRequestKey.self] }
-        set { self[MetricInfoRequestKey.self] = newValue }
-    }
-}

--- a/LOGIT/Features/Workout/WorkoutRecorder/WorkoutRecorderScreen.swift
+++ b/LOGIT/Features/Workout/WorkoutRecorder/WorkoutRecorderScreen.swift
@@ -28,18 +28,22 @@ struct WorkoutRecorderScreen: View {
     @EnvironmentObject private var database: Database
     @EnvironmentObject var workoutRecorder: WorkoutRecorder
     @EnvironmentObject private var muscleGroupService: MuscleGroupService
-    @EnvironmentObject private var chronograph: Chronograph
     /// Re-injected into the metric-info popover's `UIHostingController` (environment objects don't
     /// cross the UIKit bridge): the panel's Pro gate reads `purchaseManager`, and the upgrade
     /// screen it can present needs both.
     @EnvironmentObject private var purchaseManager: PurchaseManager
     @EnvironmentObject private var networkMonitor: NetworkMonitor
 
-    // MARK: - State
+    // MARK: - Parameters
 
-    @AppStorage("autoTimerEnabled") private var autoTimerEnabled: Bool = false
-    @AppStorage("autoStopwatchEnabled") private var autoStopwatchEnabled: Bool = false
-    @AppStorage("lastTimerDuration") private var lastTimerDuration: Int = 30
+    /// Deliberately a plain reference, not an `@EnvironmentObject`: the chronograph publishes on
+    /// every start/stop/adjustment, and observing it here re-rendered the whole recorder tree each
+    /// time. The screen only drives it imperatively; the views that *display* it
+    /// (`FloatingChronoControlsOverlay`, `TimerStopwatchView`, `RestTimerBetweenSetsView`)
+    /// observe it themselves.
+    let chronograph: Chronograph
+
+    // MARK: - State
 
     @State var isShowingChronoSheet = false
     @State private var didAppear = false
@@ -59,11 +63,11 @@ struct WorkoutRecorderScreen: View {
     @State private var metricInfoSetGroup: WorkoutSetGroup?
     @State private var metricInfoSourceRect: CGRect?
     @State private var scrollToRecentAttempts = false
-    @State private var sheetHeight: CGFloat = 0
-    @State private var mediumSheetHeight: CGFloat = 0
-    @State private var animationDuration: CGFloat = 0
-    @State private var toolbarOpacity: CGFloat = 1
-    @State private var safeAreaBottomInset: CGFloat = 0
+    /// Plain `@State` holding a reference type on purpose: the screen must keep the instance
+    /// alive WITHOUT subscribing to it (`@StateObject` would). The persistent sheet's height
+    /// changes on every frame of a detent or keyboard animation; only the floating chrono
+    /// overlay consumes it, so only that child observes it.
+    @State private var sheetGeometry = RecorderSheetGeometry()
 
     @State var focusedIntegerFieldIndex: IntegerField.Index?
 
@@ -95,17 +99,17 @@ struct WorkoutRecorderScreen: View {
                                         }
                                     },
                                     onTapPreviousSet: { scrollToRecentAttempts = true; exerciseDetailAutoMetric = nil; exerciseForDetailSheet = $0 },
-                                    onTapExerciseName: { scrollToRecentAttempts = false; exerciseDetailAutoMetric = nil; exerciseForDetailSheet = $0 }
+                                    onTapExerciseName: { scrollToRecentAttempts = false; exerciseDetailAutoMetric = nil; exerciseForDetailSheet = $0 },
+                                    // A metric-badge tap routes here instead of presenting from the
+                                    // badge: the badge sits behind the persistent exercise sheet, so a
+                                    // popover presented from it would dismiss that sheet. The popover
+                                    // is instead presented from the sheet's own view controller
+                                    // (below), anchored back to the badge, so the sheet survives.
+                                    onTapMetricBadge: { setGroup, frame in
+                                        metricInfoSetGroup = setGroup
+                                        metricInfoSourceRect = frame
+                                    }
                                 )
-                                // A metric-badge tap routes here instead of presenting from the badge:
-                                // the badge sits behind the persistent exercise sheet, so a popover
-                                // presented from it would dismiss that sheet. The popover is instead
-                                // presented from the sheet's own view controller (below), anchored back
-                                // to the badge, so the sheet survives.
-                                .environment(\.metricInfoRequest) { setGroup, frame in
-                                    metricInfoSetGroup = setGroup
-                                    metricInfoSourceRect = frame
-                                }
                                 .padding(.horizontal)
                                 .padding(.top, 90)
                                 .padding(.bottom, exerciseSelectionPresentationDetent == .medium ? (UIScreen.current?.bounds.height ?? 0) * 0.5 : BOTTOM_SHEET_SMALL)
@@ -227,23 +231,11 @@ struct WorkoutRecorderScreen: View {
                             .onGeometryChange(for: CGFloat.self) {
                                 max($0.size.height, 0)
                             } action: { oldValue, newValue in
-                                sheetHeight = newValue
-
-                                if exerciseSelectionPresentationDetent == .medium {
-                                    mediumSheetHeight = newValue
-                                }
-
-                                if mediumSheetHeight > 0 {
-                                    let fadeStartHeight = mediumSheetHeight + 140
-                                    let progress = max(min((newValue - fadeStartHeight) / 72, 1), 0)
-                                    toolbarOpacity = 1 - progress
-                                } else {
-                                    toolbarOpacity = 1
-                                }
-
-                                let diff = abs(newValue - oldValue)
-                                let duration = max(min(diff / 180, 0.3), 0)
-                                animationDuration = duration
+                                sheetGeometry.update(
+                                    sheetHeight: newValue,
+                                    previousHeight: oldValue,
+                                    isAtMediumDetent: exerciseSelectionPresentationDetent == .medium
+                                )
                             }
                             .opacity(fullScreenDraggableCoverIsDragging ? 0 : 1)
                             .animation(.easeOut(duration: 0.2), value: fullScreenDraggableCoverIsDragging)
@@ -257,37 +249,20 @@ struct WorkoutRecorderScreen: View {
                             }
                         }
                         .overlay(alignment: .bottomTrailing) {
-                            if shouldShowFloatingTimerButton {
-                                HStack {
-                                    WorkoutRecorderFloatingTimerButton(
-                                        chronograph: chronograph,
-                                        workoutRecorder: workoutRecorder,
-                                        action: { isShowingChronoSheet = true }
-                                    )
-                                    if shouldShowFloatingStopwatchStopButton {
-                                        WorkoutRecorderFloatingStopwatchStopButton(
-                                            workoutRecorder: workoutRecorder,
-                                            action: stopStopwatch
-                                        )
-                                    } else if shouldShowFloatingTimerCancelButton {
-                                        WorkoutRecorderFloatingStopwatchStopButton(
-                                            workoutRecorder: workoutRecorder,
-                                            action: cancelTimer
-                                        )
-                                    }
-                                }
-                                .opacity(toolbarOpacity)
-                                .offset(y: -sheetHeight)
-                                .padding(.trailing, 15)
-                                .offset(y: floatingTimerBottomOffset)
-                                .animation(.easeInOut(duration: animationDuration), value: sheetHeight)
-                                .animation(.easeInOut(duration: animationDuration), value: floatingTimerBottomOffset)
-                            }
+                            FloatingChronoControlsOverlay(
+                                chronograph: chronograph,
+                                workoutRecorder: workoutRecorder,
+                                sheetGeometry: sheetGeometry,
+                                isAtSmallDetent: exerciseSelectionPresentationDetent == .height(BOTTOM_SHEET_SMALL),
+                                onOpenChronoSheet: { isShowingChronoSheet = true },
+                                onStopStopwatch: stopStopwatch,
+                                onCancelTimer: cancelTimer
+                            )
                         }
                         .onGeometryChange(for: CGFloat.self) {
                             $0.safeAreaInsets.bottom
                         } action: { newValue in
-                            safeAreaBottomInset = newValue
+                            sheetGeometry.safeAreaBottomInset = newValue
                         }
                     }
                     .onAppear {
@@ -435,21 +410,6 @@ struct WorkoutRecorderScreen: View {
         }
     }
 
-    // MARK: - Floating Timer Button
-
-    private var shouldShowFloatingTimerButton: Bool {
-        sheetHeight > 0
-            && !fullScreenDraggableCoverIsDragging
-    }
-
-    private var floatingTimerBottomOffset: CGFloat {
-        let base = safeAreaBottomInset - 10
-        if exerciseSelectionPresentationDetent == .height(BOTTOM_SHEET_SMALL) {
-            return base - 10
-        }
-        return base
-    }
-
     @ViewBuilder
     private func reorderSetGroupsSheet(for workout: Workout) -> some View {
         NavigationStack {
@@ -490,16 +450,6 @@ struct WorkoutRecorderScreen: View {
                 }
             }
         }
-    }
-
-    private var shouldShowFloatingStopwatchStopButton: Bool {
-        chronograph.mode == .stopwatch
-            && chronograph.status == .running
-    }
-
-    private var shouldShowFloatingTimerCancelButton: Bool {
-        chronograph.mode == .timer
-            && chronograph.status == .running
     }
 
     // MARK: - Supporting Methods / Computed Properties
@@ -557,11 +507,19 @@ struct WorkoutRecorderScreen: View {
         guard workoutRecorder.activeRestTimerSet?.objectID != completedSet.objectID else { return }
         guard chronograph.status != .running else { return }
 
+        // Read at call time instead of via `@AppStorage`: these settings are only consumed
+        // here, and an `@AppStorage` subscription re-rendered the whole recorder tree on every
+        // write (the timer sheet writes `lastTimerDuration` on each preset/adjustment tap).
+        let defaults = UserDefaults.standard
+        let lastTimerDuration = defaults.object(forKey: "lastTimerDuration") == nil
+            ? 30
+            : defaults.integer(forKey: "lastTimerDuration")
+
         guard let autoRestBehavior = workoutRecorder.autoRestBehavior(
             forSet: completedSet,
             usesStopwatch: chronograph.mode == .stopwatch,
-            autoTimerEnabled: autoTimerEnabled,
-            autoStopwatchEnabled: autoStopwatchEnabled,
+            autoTimerEnabled: defaults.bool(forKey: "autoTimerEnabled"),
+            autoStopwatchEnabled: defaults.bool(forKey: "autoStopwatchEnabled"),
             timerDuration: lastTimerDuration
         ) else {
             return
@@ -763,6 +721,89 @@ struct WorkoutRecorderScreen: View {
     }
 }
 
+// MARK: - Sheet geometry + floating chrono controls
+
+/// Live geometry of the persistent exercise sheet. Written from the recorder's
+/// `onGeometryChange` callbacks and observed ONLY by `FloatingChronoControlsOverlay` — the sheet
+/// height changes on every frame of a detent or keyboard animation, and when these values were
+/// `@State` on the screen each frame re-rendered the entire recorder tree.
+final class RecorderSheetGeometry: ObservableObject {
+    @Published var sheetHeight: CGFloat = 0
+    @Published var toolbarOpacity: CGFloat = 1
+    @Published var animationDuration: CGFloat = 0
+    @Published var safeAreaBottomInset: CGFloat = 0
+    private var mediumSheetHeight: CGFloat = 0
+
+    func update(sheetHeight newHeight: CGFloat, previousHeight: CGFloat, isAtMediumDetent: Bool) {
+        sheetHeight = newHeight
+
+        if isAtMediumDetent {
+            mediumSheetHeight = newHeight
+        }
+
+        if mediumSheetHeight > 0 {
+            let fadeStartHeight = mediumSheetHeight + 140
+            let progress = max(min((newHeight - fadeStartHeight) / 72, 1), 0)
+            toolbarOpacity = 1 - progress
+        } else {
+            toolbarOpacity = 1
+        }
+
+        let diff = abs(newHeight - previousHeight)
+        animationDuration = max(min(diff / 180, 0.3), 0)
+    }
+}
+
+/// The floating timer/stopwatch button (with its stop/cancel companion) and the placement math
+/// that tracks the persistent sheet. Isolated from the recorder screen so the chronograph's
+/// frequent publishes and the per-frame sheet-geometry updates re-render only this small
+/// overlay, never the whole recorder tree.
+private struct FloatingChronoControlsOverlay: View {
+    @Environment(\.fullScreenDraggableCoverIsDragging) private var fullScreenDraggableCoverIsDragging
+
+    @ObservedObject var chronograph: Chronograph
+    @ObservedObject var workoutRecorder: WorkoutRecorder
+    @ObservedObject var sheetGeometry: RecorderSheetGeometry
+    let isAtSmallDetent: Bool
+    let onOpenChronoSheet: () -> Void
+    let onStopStopwatch: () -> Void
+    let onCancelTimer: () -> Void
+
+    var body: some View {
+        if sheetGeometry.sheetHeight > 0 && !fullScreenDraggableCoverIsDragging {
+            HStack {
+                WorkoutRecorderFloatingTimerButton(
+                    chronograph: chronograph,
+                    workoutRecorder: workoutRecorder,
+                    action: onOpenChronoSheet
+                )
+                if chronograph.mode == .stopwatch, chronograph.status == .running {
+                    WorkoutRecorderFloatingStopwatchStopButton(
+                        workoutRecorder: workoutRecorder,
+                        action: onStopStopwatch
+                    )
+                } else if chronograph.mode == .timer, chronograph.status == .running {
+                    WorkoutRecorderFloatingStopwatchStopButton(
+                        workoutRecorder: workoutRecorder,
+                        action: onCancelTimer
+                    )
+                }
+            }
+            .opacity(sheetGeometry.toolbarOpacity)
+            .offset(y: -sheetGeometry.sheetHeight)
+            .padding(.trailing, 15)
+            .offset(y: bottomOffset)
+            .animation(.easeInOut(duration: sheetGeometry.animationDuration), value: sheetGeometry.sheetHeight)
+            .animation(.easeInOut(duration: sheetGeometry.animationDuration), value: bottomOffset)
+        }
+    }
+
+    private var bottomOffset: CGFloat {
+        let base = sheetGeometry.safeAreaBottomInset - 10
+        return isAtSmallDetent ? base - 10 : base
+    }
+}
+
 struct WorkoutMuscleGroupChart: View {
     @ObservedObject var workout: Workout
     @EnvironmentObject private var muscleGroupService: MuscleGroupService
@@ -788,9 +829,10 @@ struct WorkoutMuscleGroupChart: View {
 private struct PreviewWrapperView: View {
     @EnvironmentObject private var database: Database
     @EnvironmentObject private var workoutRecorder: WorkoutRecorder
+    @EnvironmentObject private var chronograph: Chronograph
 
     var body: some View {
-        WorkoutRecorderScreen()
+        WorkoutRecorderScreen(chronograph: chronograph)
             .onAppear {
                 workoutRecorder.startWorkout(from: database.testTemplate)
             }

--- a/LOGIT/Features/Workout/WorkoutSetGroupList.swift
+++ b/LOGIT/Features/Workout/WorkoutSetGroupList.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct WorkoutSetGroupList: View {
+struct WorkoutSetGroupList: View, Equatable {
     // MARK: - Environment
 
     @EnvironmentObject var database: Database
@@ -23,6 +23,9 @@ struct WorkoutSetGroupList: View {
     var onReorderSetGroups: (() -> Void)? = nil
     var onTapPreviousSet: ((Exercise) -> Void)? = nil
     var onTapExerciseName: ((Exercise) -> Void)? = nil
+    /// Recorder only: routes a metric-badge tap up so the popover is presented from the
+    /// recorder's persistent sheet (see `MetricBadgeView.onTapBadge`).
+    var onTapMetricBadge: ((WorkoutSetGroup, CGRect) -> Void)? = nil
 
     // MARK: - State
 
@@ -32,28 +35,45 @@ struct WorkoutSetGroupList: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            ForEach(workout.setGroups) { setGroup in
+            ForEach(indexedSetGroups, id: \.setGroup.id) { entry in
                 VStack(spacing: 0) {
                     WorkoutSetGroupCell(
-                        setGroup: setGroup,
+                        setGroup: entry.setGroup,
                         focusedIntegerFieldIndex: $focusedIntegerFieldIndex,
                         isReordering: $isReordering,
                         supplementaryText: nil,
                         showDetailAsSheet: showDetailAsSheet,
+                        isFieldFocused: focusedIntegerFieldIndex != nil,
+                        indexInWorkout: entry.index,
+                        firstSetIndexInWorkout: entry.firstSetIndex,
                         onTapRestDuration: onTapRestDuration,
                         onReorderSetGroups: onReorderSetGroups,
                         onTapPreviousSet: onTapPreviousSet,
-                        onTapExerciseName: onTapExerciseName
+                        onTapExerciseName: onTapExerciseName,
+                        onTapMetricBadge: onTapMetricBadge
                     )
                     .shadow(color: .black.opacity(reduceShadow ? 0.5 : 1.0), radius: 5)
                     .zIndex(1)
-                    setGroupConnector(for: setGroup)
+                    setGroupConnector(for: entry.setGroup)
                 }
                 .transition(.scale)
-                .id(setGroup)
+                .id(entry.setGroup)
             }
         }
         .animation(.interactiveSpring(), value: workout.setGroups.count)
+    }
+
+    /// Each set group with its position and the flat index of its first set. Computed here and
+    /// passed into the cells because the cells' `Equatable` skipping needs structural changes to
+    /// be visible in their inputs: the header number and the set cells' focus indices depend on
+    /// what comes *before* a group, so deleting/reordering/resizing an earlier group must
+    /// re-render the ones after it even though their own set group didn't change.
+    private var indexedSetGroups: [(index: Int, firstSetIndex: Int, setGroup: WorkoutSetGroup)] {
+        var firstSetIndex = 0
+        return workout.setGroups.enumerated().map { index, setGroup in
+            defer { firstSetIndex += setGroup.sets.count }
+            return (index: index, firstSetIndex: firstSetIndex, setGroup: setGroup)
+        }
     }
 
     @ViewBuilder
@@ -81,6 +101,19 @@ struct WorkoutSetGroupList: View {
                     .frame(width: 3, height: SECTION_SPACING)
             }
         }
+    }
+
+    /// Lets SwiftUI skip re-running the list body when a parent re-render didn't change its
+    /// inputs (the recorder screen re-renders for progress, timer, and sheet reasons that don't
+    /// concern the list). Ignores the callback closures (stable behavior across renders) and the
+    /// focus binding — the list reads the binding's value in `body`, so focus changes re-render
+    /// it through that dependency regardless of this comparison. Structural changes re-render
+    /// through the `@ObservedObject workout`.
+    static func == (lhs: WorkoutSetGroupList, rhs: WorkoutSetGroupList) -> Bool {
+        lhs.workout === rhs.workout
+            && lhs.canReorder == rhs.canReorder
+            && lhs.reduceShadow == rhs.reduceShadow
+            && lhs.showDetailAsSheet == rhs.showDetailAsSheet
     }
 
     private func restCapsule(for workoutSet: WorkoutSet) -> some View {

--- a/LOGIT/SharedUI/Views/DecimalField.swift
+++ b/LOGIT/SharedUI/Views/DecimalField.swift
@@ -208,15 +208,27 @@ struct DecimalField: View {
         return filtered
     }
 
+    /// Formatters are expensive to create and this runs twice per body evaluation (placeholder
+    /// and prompt) across every weight field on screen, so they are cached per decimal-place
+    /// count instead of rebuilt per call.
+    private static var formatters: [Int: NumberFormatter] = [:]
+
     private func formatNumber(_ number: Double) -> String {
         // Format the number to remove unnecessary trailing zeros
-        let formatter = NumberFormatter()
-        formatter.numberStyle = .decimal
-        formatter.minimumFractionDigits = 0
-        formatter.maximumFractionDigits = decimalPlaces
-        formatter.decimalSeparator = "."
-        formatter.groupingSeparator = ""
-        
+        let formatter: NumberFormatter
+        if let cached = Self.formatters[decimalPlaces] {
+            formatter = cached
+        } else {
+            let created = NumberFormatter()
+            created.numberStyle = .decimal
+            created.minimumFractionDigits = 0
+            created.maximumFractionDigits = decimalPlaces
+            created.decimalSeparator = "."
+            created.groupingSeparator = ""
+            Self.formatters[decimalPlaces] = created
+            formatter = created
+        }
+
         return formatter.string(from: NSNumber(value: number)) ?? "0"
     }
 }


### PR DESCRIPTION
## Problem

The workout recorder froze for 0.5–1s when focusing or leaving a set field, and when the auto rest timer started or its time was adjusted — reported as "the workout recorder just doesn't feel super smooth."

Instrumented profiling (an in-app render counter + `sample`) on the two-year `-SCENARIO stress` dataset (209 workouts / ~3,300 sets) showed each of those interactions re-rendered the **entire** recorder tree several times, and every metric badge re-scanned the exercise's whole history on each pass. A single +15s timer tap cost 2 full-tree passes and 66 history scans.

## Fix — cut the cascades off at every source

- **Cache the badge's history-derived bests** (`ExerciseHistoryBestsCache`). They exclude the workout being recorded, so they're static during a session; invalidated only when something *outside* the current workout changes (CloudKit import, editing/deleting an old workout, exercise change). Per-render scans went from 45–100ms/s of interaction to **0**.
- **Stop the screen observing the `Chronograph` and the timer's `@AppStorage` keys.** The chronograph is now a plain reference driven imperatively; the views that display it observe it themselves. Auto-timer settings are read from `UserDefaults` at trigger time.
- **Isolate the persistent sheet's per-frame geometry** in its own observable (`RecorderSheetGeometry`), consumed only by `FloatingChronoControlsOverlay`, so keyboard/detent animation frames no longer re-render the tree.
- **Make `WorkoutSetGroupList` and `WorkoutSetGroupCell` `Equatable`** so parent re-renders skip them; set edits still render through their own observed objects. The cell receives its position and first-set offset so structural changes (delete/reorder) still refresh header numbers and keyboard-focus indices.
- **Route the metric-badge tap through an explicit parameter** instead of a per-render environment closure that marked every badge dirty.
- **Cache `DecimalField`'s per-render `NumberFormatter`.**

## Measured effect

| Interaction (time-to-quiesce, stress, sim) | Before | After |
|---|---|---|
| Focus a set field | 2.1–2.6s | ~1.0s |
| Type a digit | 1.3–2.5s | 0.7–1.3s |
| Dismiss the keyboard | 2.1–2.7s | 1.3–1.4s |
| Adjust running timer +15s | 1.6s | 1.4s* |

A +15s tap went from *2 full-tree passes + 66 history scans + 128 field bodies* to **one cheap pass with zero list/cell/badge work**. Main-thread busy time over a 22s interaction window dropped 11.0s → 8.4s. (*Quiesce times include finishing animations, which set a ~1s floor the tool can't see past; the render counters are the honest signal.)

## Regression audit

Render-skipping can silently freeze UI that used to refresh by accident. Audited every skipped path; found and fixed one real gap (header numbers + flat focus indices depend on earlier groups, so delete/reorder must invalidate later cells). Verified end-to-end on the stress dataset:

- Live badge/trend updates while typing
- Set deletion via context menu (renumbering)
- Keyboard chevron navigation across groups **before and after** structural changes
- Add Set, exercise reorder, auto-timer start + ±15s adjustments

`LOGITTests` unit suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)