### PR TITLE
Swipeable, haptic month calendars (History + Weekly Goal)

### DIFF
--- a/LOGIT.xcodeproj/project.pbxproj
+++ b/LOGIT.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		28E43ABE4881F802FBBACCE9 /* RangePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F685CCE0EE8FE86E8E0135C /* RangePicker.swift */; };
 		2A384BE3816900000002 /* ExerciseSuggestionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54EE2592821500000001 /* ExerciseSuggestionService.swift */; };
 		2BD2E4720FB2C657F8CA372B /* CompletionRing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C72085C4C10146858277690 /* CompletionRing.swift */; };
+		9870C5C11EC204B609726272 /* SwipeableMonthView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79EEE8722792E15D71C22DA3 /* SwipeableMonthView.swift */; };
 		34ED649B10150341352AE3D1 /* StatPeriodTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F8CD271000D75928FAE0887 /* StatPeriodTests.swift */; };
 		396ADE67CD8C1D14F7A8D82A /* LOGITWidgetExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3BDDD14FE5BF0C275AF30C5 /* LOGITWidgetExtension.swift */; };
 		435F070826CC8D1F8D7239B8 /* WorkoutDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4845CEF582EB23AB447C90B2 /* WorkoutDTO.swift */; };
@@ -356,6 +357,7 @@
 		3184F4CAAB24791B6F5AC79A /* SharedWithYouBanner.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SharedWithYouBanner.swift; sourceTree = "<group>"; };
 		336772BB4E860E3894BA7355 /* SummaryStatTiles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryStatTiles.swift; sourceTree = "<group>"; };
 		3C72085C4C10146858277690 /* CompletionRing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionRing.swift; sourceTree = "<group>"; };
+		79EEE8722792E15D71C22DA3 /* SwipeableMonthView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwipeableMonthView.swift; sourceTree = "<group>"; };
 		3CDACB5BDD447438F8D60BAE /* LOGITScreenshots.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LOGITScreenshots.swift; sourceTree = "<group>"; };
 		4845CEF582EB23AB447C90B2 /* WorkoutDTO.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkoutDTO.swift; sourceTree = "<group>"; };
 		4B6F634C95B552C305EA0055 /* WorkoutLiveActivitySnapshotBuilder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkoutLiveActivitySnapshotBuilder.swift; sourceTree = "<group>"; };
@@ -1248,6 +1250,7 @@
 				D1D1D1000000000000000F01 /* MetricTile.swift */,
 				BBBF6087BB65A5971FB5F866 /* BodyMapFigure.swift */,
 				3C72085C4C10146858277690 /* CompletionRing.swift */,
+				79EEE8722792E15D71C22DA3 /* SwipeableMonthView.swift */,
 				BEA597E1519E8F6D2CBC8F9E /* PeriodPicker.swift */,
 				E1E1E1000000000000000F12 /* ProgressIndicatorPill.swift */,
 				E1E1E1000000000000000F16 /* PersonalBestRow.swift */,
@@ -1647,6 +1650,7 @@
 				D1D1D1000000000000000B01 /* MetricTile.swift in Sources */,
 				73A9CED8C934FDF36F9C4061 /* BodyMapFigure.swift in Sources */,
 				2BD2E4720FB2C657F8CA372B /* CompletionRing.swift in Sources */,
+				9870C5C11EC204B609726272 /* SwipeableMonthView.swift in Sources */,
 				77B7E6990E4C00B75D9BC6ED /* PeriodPicker.swift in Sources */,
 				E1E1E1000000000000000B12 /* ProgressIndicatorPill.swift in Sources */,
 				E1E1E1000000000000000B16 /* PersonalBestRow.swift in Sources */,

--- a/LOGIT/Features/Home/WorkoutGoalScreen.swift
+++ b/LOGIT/Features/Home/WorkoutGoalScreen.swift
@@ -61,18 +61,9 @@ struct WorkoutGoalScreen: View {
     // MARK: - Calendar
 
     private var calendarTile: some View {
-        VStack(spacing: 12) {
-            HStack {
-                Button { changeMonth(-1) } label: { Image(systemName: "chevron.left") }
-                Spacer()
-                Text(displayedMonth.formatted(.dateTime.month(.wide).year()))
-                    .font(.headline)
-                Spacer()
-                Button { changeMonth(1) } label: { Image(systemName: "chevron.right") }
-                    .disabled(displayedMonth.startOfMonth >= Date.now.startOfMonth)
-            }
-            .foregroundStyle(.secondary)
-            .padding(.horizontal, CELL_PADDING)
+        // Month paging (swipe the grid horizontally or tap the chevrons, both animated + haptic) lives in
+        // `SwipeableMonthView`; here we hand it the target-column weekday row and this month's week rows.
+        SwipeableMonthView(month: $displayedMonth) {
             HStack(spacing: 0) {
                 ForEach(weekdaySymbols, id: \.self) { symbol in
                     Text(symbol)
@@ -87,17 +78,17 @@ struct WorkoutGoalScreen: View {
                     .frame(maxWidth: .infinity)
             }
             .padding(.horizontal, CELL_PADDING)
-            ForEach(weeksOfMonth, id: \.self) { week in
-                weekRowView(week)
+        } weeks: { month in
+            VStack(spacing: 12) {
+                ForEach(weeks(of: month), id: \.self) { week in
+                    weekRowView(week, in: month)
+                }
             }
         }
-        .padding(.top, CELL_PADDING)
-        .padding(.bottom, CELL_PADDING / 2)
-        .tileStyle()
     }
 
     @ViewBuilder
-    private func weekRowView(_ week: [Date]) -> some View {
+    private func weekRowView(_ week: [Date], in month: Date) -> some View {
         if isCurrentWeek(week) {
             currentWeekRow(week)
         } else {
@@ -105,7 +96,7 @@ struct WorkoutGoalScreen: View {
             // ring isn't flush-right and the layout matches the shared `WeeklyGoalStrip` below.
             HStack(spacing: 0) {
                 ForEach(week, id: \.self) { day in
-                    dayCell(day)
+                    dayCell(day, in: month)
                 }
                 weekRing(for: week)
                     .frame(maxWidth: .infinity)
@@ -138,8 +129,8 @@ struct WorkoutGoalScreen: View {
         .padding(.horizontal, CELL_PADDING / 2)
     }
 
-    private func dayCell(_ day: Date) -> some View {
-        let inMonth = calendar.isDate(day, equalTo: displayedMonth, toGranularity: .month)
+    private func dayCell(_ day: Date, in month: Date) -> some View {
+        let inMonth = calendar.isDate(day, equalTo: month, toGranularity: .month)
         let isToday = calendar.isDateInToday(day)
         let isFuture = day > Date.now && !isToday
         let occurrences = muscleOccurrences(on: day)
@@ -445,10 +436,10 @@ struct WorkoutGoalScreen: View {
         week.contains { calendar.isDateInToday($0) }
     }
 
-    private var weeksOfMonth: [[Date]] {
-        let monthEnd = displayedMonth.endOfMonth
+    private func weeks(of month: Date) -> [[Date]] {
+        let monthEnd = month.endOfMonth
         var weeks: [[Date]] = []
-        var cursor = displayedMonth.startOfMonth.startOfWeek
+        var cursor = month.startOfMonth.startOfWeek
         while cursor <= monthEnd, weeks.count < 6 {
             let week = (0 ..< 7).map { calendar.date(byAdding: .day, value: $0, to: cursor) ?? cursor }
             weeks.append(week)
@@ -487,11 +478,5 @@ struct WorkoutGoalScreen: View {
         let symbols = calendar.veryShortWeekdaySymbols
         let first = calendar.firstWeekday - 1
         return Array(symbols[first...] + symbols[..<first])
-    }
-
-    private func changeMonth(_ delta: Int) {
-        withAnimation {
-            displayedMonth = (calendar.date(byAdding: .month, value: delta, to: displayedMonth) ?? displayedMonth).startOfMonth
-        }
     }
 }

--- a/LOGIT/Features/Workout/WorkoutListScreen.swift
+++ b/LOGIT/Features/Workout/WorkoutListScreen.swift
@@ -23,8 +23,6 @@ struct WorkoutListScreen: View {
     @State private var workoutToAdd: Workout?
     @State private var isShowingFilters = false
     @State private var selectedWorkout: Workout?
-    /// The day tapped in the calendar header — rings it and is scrolled to. Purely a scrubbing aid.
-    @State private var selectedDay: Date?
     /// Object IDs of the fetched workouts that set at least one personal record, filled lazily while
     /// the "personal records only" filter is on (nil = not computed yet, so the list waits).
     @State private var personalRecordWorkoutIDs: Set<NSManagedObjectID>?
@@ -54,7 +52,7 @@ struct WorkoutListScreen: View {
                                 .padding(.top, 80)
                         } else {
                             if !displayed.isEmpty {
-                                HistoryCalendarView(workouts: displayed, selectedDay: $selectedDay) { day in
+                                HistoryCalendarView(workouts: displayed) { day in
                                     jump(to: day, in: displayed, proxy: proxy)
                                 }
                                 .padding(.horizontal)
@@ -157,14 +155,13 @@ struct WorkoutListScreen: View {
         return workouts.filter { ids.contains($0.objectID) }
     }
 
-    /// Scrolls the list to the workout on the tapped calendar day and rings that day. A scrubber —
-    /// the list itself is never filtered by the tap.
+    /// Scrolls the list down to the workout on the tapped calendar day. A scrubber — the list itself is
+    /// never filtered by the tap.
     private func jump(to day: Date, in workouts: [Workout], proxy: ScrollViewProxy) {
         guard let target = workouts.first(where: {
             guard let date = $0.date else { return false }
             return Calendar.current.isDate(date, inSameDayAs: day)
         }) else { return }
-        selectedDay = day
         withAnimation {
             proxy.scrollTo(target.objectID, anchor: .top)
         }
@@ -341,30 +338,20 @@ private struct WorkoutHistorySectionView: View {
 /// A month calendar shown at the top of History — each trained day carries a `MuscleOccurrenceRing`,
 /// the same muscle-group arcs the Weekly Goal calendar draws (sized by that day's set counts), so the
 /// two calendars read alike, but here without the goal's target column and per-week rings. Tapping a
-/// trained day calls `onSelectDate` so the list can jump to it, and rings the day as a scrubbing cue.
+/// trained day calls `onSelectDate` so the list can scroll down to that workout. The month is paged
+/// through `SwipeableMonthView` — swipe the grid horizontally or use the chevrons, both animating and
+/// ticking a selection haptic.
 private struct HistoryCalendarView: View {
     @EnvironmentObject private var muscleGroupService: MuscleGroupService
 
     let workouts: [Workout]
-    @Binding var selectedDay: Date?
     let onSelectDate: (Date) -> Void
 
     @State private var displayedMonth: Date = .now.startOfMonth
     private let calendar = Calendar.current
 
     var body: some View {
-        VStack(spacing: 12) {
-            HStack {
-                Button { changeMonth(-1) } label: { Image(systemName: "chevron.left") }
-                Spacer()
-                Text(displayedMonth.formatted(.dateTime.month(.wide).year()))
-                    .font(.headline)
-                Spacer()
-                Button { changeMonth(1) } label: { Image(systemName: "chevron.right") }
-                    .disabled(displayedMonth.startOfMonth >= Date.now.startOfMonth)
-            }
-            .foregroundStyle(.secondary)
-            .padding(.horizontal, CELL_PADDING)
+        SwipeableMonthView(month: $displayedMonth) {
             HStack(spacing: 0) {
                 ForEach(weekdaySymbols, id: \.self) { symbol in
                     Text(symbol)
@@ -374,28 +361,27 @@ private struct HistoryCalendarView: View {
                 }
             }
             .padding(.horizontal, CELL_PADDING)
-            ForEach(weeksOfMonth, id: \.self) { week in
-                HStack(spacing: 0) {
-                    ForEach(week, id: \.self) { day in
-                        dayCell(day)
+        } weeks: { month in
+            VStack(spacing: 12) {
+                ForEach(weeks(of: month), id: \.self) { week in
+                    HStack(spacing: 0) {
+                        ForEach(week, id: \.self) { day in
+                            dayCell(day, in: month)
+                        }
                     }
+                    .padding(.horizontal, CELL_PADDING)
                 }
-                .padding(.horizontal, CELL_PADDING)
             }
         }
-        .padding(.top, CELL_PADDING)
-        .padding(.bottom, CELL_PADDING / 2)
-        .tileStyle()
     }
 
     @ViewBuilder
-    private func dayCell(_ day: Date) -> some View {
-        let inMonth = calendar.isDate(day, equalTo: displayedMonth, toGranularity: .month)
+    private func dayCell(_ day: Date, in month: Date) -> some View {
+        let inMonth = calendar.isDate(day, equalTo: month, toGranularity: .month)
         let isToday = calendar.isDateInToday(day)
         let isFuture = day > Date.now && !isToday
         let occurrences = muscleOccurrences(on: day)
         let hasWorkout = !occurrences.isEmpty
-        let isSelected = selectedDay.map { calendar.isDate($0, inSameDayAs: day) } ?? false
         let cell = ZStack {
             if isToday {
                 Circle()
@@ -411,11 +397,6 @@ private struct HistoryCalendarView: View {
                 .foregroundStyle(dayForeground(inMonth: inMonth, isToday: isToday, isFuture: isFuture, hasWorkout: hasWorkout))
         }
         .frame(width: 34, height: 34)
-        .overlay {
-            if isSelected {
-                Circle().strokeBorder(Color.accentColor, lineWidth: 2)
-            }
-        }
         .frame(maxWidth: .infinity)
         if hasWorkout {
             Button { onSelectDate(day) } label: { cell }
@@ -442,10 +423,10 @@ private struct HistoryCalendarView: View {
         return muscleGroupService.getMuscleGroupOccurances(in: dayWorkouts)
     }
 
-    private var weeksOfMonth: [[Date]] {
-        let monthEnd = displayedMonth.endOfMonth
+    private func weeks(of month: Date) -> [[Date]] {
+        let monthEnd = month.endOfMonth
         var weeks: [[Date]] = []
-        var cursor = displayedMonth.startOfMonth.startOfWeek
+        var cursor = month.startOfMonth.startOfWeek
         while cursor <= monthEnd, weeks.count < 6 {
             let week = (0 ..< 7).map { calendar.date(byAdding: .day, value: $0, to: cursor) ?? cursor }
             weeks.append(week)
@@ -458,12 +439,6 @@ private struct HistoryCalendarView: View {
         let symbols = calendar.veryShortWeekdaySymbols
         let first = calendar.firstWeekday - 1
         return Array(symbols[first...] + symbols[..<first])
-    }
-
-    private func changeMonth(_ delta: Int) {
-        withAnimation {
-            displayedMonth = (calendar.date(byAdding: .month, value: delta, to: displayedMonth) ?? displayedMonth).startOfMonth
-        }
     }
 }
 

--- a/LOGIT/SharedUI/Views/SwipeableMonthView.swift
+++ b/LOGIT/SharedUI/Views/SwipeableMonthView.swift
@@ -1,0 +1,151 @@
+//
+//  SwipeableMonthView.swift
+//  LOGIT
+//
+//  Created by Lukas Kaibel on 15.07.26.
+//
+
+import SwiftUI
+
+/// The month-paged calendar shell shared by the History and Weekly-Goal calendars. It owns the
+/// prev/next header — a month title flanked by chevrons — and a horizontally swipeable body: dragging
+/// left/right reveals the adjacent month and snaps to it, and the chevrons drive the very same slide.
+/// Every committed change, whether an arrow tap or a swipe, ticks a selection haptic. The forward edge
+/// is capped at the current month (no future); paging backward is unbounded, matching the calendars'
+/// prior behaviour.
+///
+/// Callers supply the two month-specific pieces: a fixed `weekdayHeader` (the weekday-symbol row, which
+/// never changes from month to month) and `weeks(month)`, the grid of week rows for a given month.
+/// Only `weeks` slides — the header and the weekday row stay put, as they do in a system calendar.
+struct SwipeableMonthView<WeekdayHeader: View, Weeks: View>: View {
+    /// The centred month, as a `startOfMonth`. Committed changes flow back out through this binding.
+    @Binding var month: Date
+    @ViewBuilder var weekdayHeader: () -> WeekdayHeader
+    @ViewBuilder var weeks: (Date) -> Weeks
+
+    /// Live horizontal translation of the grid: 0 at rest, positive while dragging toward the previous
+    /// month, negative toward the next. The neighbouring page is only built while this is non-zero.
+    @State private var dragOffset: CGFloat = 0
+    /// Measured width of one page, used both to park a neighbour a full page away and to size a swipe.
+    @State private var pageWidth: CGFloat = 1
+    /// Latches a gesture to horizontal once its dominant axis is known, so vertical scrolls fall through
+    /// to the enclosing ScrollView untouched.
+    @State private var isPagingDrag: Bool?
+
+    private let calendar = Calendar.current
+
+    /// The next month is reachable only while it isn't in the future.
+    private var canGoForward: Bool { month.startOfMonth < Date.now.startOfMonth }
+
+    private func neighbouringMonth(_ delta: Int) -> Date {
+        (calendar.date(byAdding: .month, value: delta, to: month) ?? month).startOfMonth
+    }
+
+    var body: some View {
+        VStack(spacing: 12) {
+            header
+            weekdayHeader()
+            pager
+        }
+        .padding(.top, CELL_PADDING)
+        .padding(.bottom, CELL_PADDING / 2)
+        .tileStyle()
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack {
+            Button { move(by: -1) } label: { Image(systemName: "chevron.left") }
+            Spacer()
+            Text(month.formatted(.dateTime.month(.wide).year()))
+                .font(.headline)
+            Spacer()
+            Button { move(by: 1) } label: { Image(systemName: "chevron.right") }
+                .disabled(!canGoForward)
+        }
+        .foregroundStyle(.secondary)
+        .padding(.horizontal, CELL_PADDING)
+    }
+
+    // MARK: - Swipeable grid
+
+    private var pager: some View {
+        ZStack(alignment: .top) {
+            weeks(month)
+                .frame(maxWidth: .infinity)
+                .offset(x: dragOffset)
+            // The one neighbour the current drag is reaching toward — never both, so an off-screen page
+            // isn't laid out or its occurrence rings recomputed until a swipe actually asks for it.
+            if dragOffset > 0 {
+                weeks(neighbouringMonth(-1))
+                    .frame(maxWidth: .infinity)
+                    .offset(x: dragOffset - pageWidth)
+            } else if dragOffset < 0 {
+                weeks(neighbouringMonth(1))
+                    .frame(maxWidth: .infinity)
+                    .offset(x: dragOffset + pageWidth)
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .background {
+            GeometryReader { geo in
+                Color.clear
+                    .onAppear { pageWidth = geo.size.width }
+                    .onChange(of: geo.size.width) { pageWidth = $1 }
+            }
+        }
+        .clipped()
+        .contentShape(Rectangle())
+        .simultaneousGesture(pagingGesture)
+    }
+
+    private var pagingGesture: some Gesture {
+        DragGesture(minimumDistance: 8)
+            .onChanged { value in
+                // Decide the axis once; ignore the gesture entirely if it's a vertical scroll so the
+                // ScrollView keeps it (this gesture runs simultaneously with the scroll).
+                if isPagingDrag == nil {
+                    isPagingDrag = abs(value.translation.width) > abs(value.translation.height)
+                }
+                guard isPagingDrag == true else { return }
+                var translation = value.translation.width
+                // Rubber-band when there's no next month to reveal at the future edge.
+                if translation < 0, !canGoForward { translation /= 4 }
+                dragOffset = translation
+            }
+            .onEnded { value in
+                defer { isPagingDrag = nil }
+                guard isPagingDrag == true else { return }
+                // Fold a little of the fling velocity in so a fast flick pages even if it fell short.
+                let travelled = value.translation.width + value.predictedEndTranslation.width / 3
+                let threshold = pageWidth * 0.28
+                if travelled > threshold {
+                    move(by: -1)
+                } else if travelled < -threshold, canGoForward {
+                    move(by: 1)
+                } else {
+                    withAnimation(.snappy(duration: 0.25)) { dragOffset = 0 }
+                }
+            }
+    }
+
+    /// Slides the grid one page in `delta`'s direction, then commits the month and resets the offset —
+    /// so the neighbour that just slid to centre is seamlessly re-hosted as the now-current month. This
+    /// is also the chevrons' path. Blocked (with a spring-back) at the future edge; ticks a selection
+    /// haptic on every real move.
+    private func move(by delta: Int) {
+        guard delta != 0 else { return }
+        if delta > 0, !canGoForward {
+            withAnimation(.snappy(duration: 0.25)) { dragOffset = 0 }
+            return
+        }
+        UISelectionFeedbackGenerator().selectionChanged()
+        withAnimation(.snappy(duration: 0.3)) {
+            dragOffset = -CGFloat(delta) * pageWidth
+        } completion: {
+            month = neighbouringMonth(delta)
+            dragOffset = 0
+        }
+    }
+}


### PR DESCRIPTION
Both the History and Weekly-Goal month calendars now share a new `SwipeableMonthView`:

- **Swipeable** — drag the grid horizontally to reveal and snap to the previous/next month.
- **Horizontal animation** — arrows and swipes both slide the grid sideways (`.snappy`) instead of cross-fading in place.
- **Arrow/swipe haptic** — every committed month change fires `UISelectionFeedbackGenerator().selectionChanged()`. Forward paging stays capped at the current month; back-paging is unbounded, as before.
- **History day tap** — no longer draws a selection ring; it just scrolls the list down to that workout (the `selectedDay` state + overlay were removed).

The weekday header stays fixed; only the week grid slides, and the drag is axis-latched so vertical scrolling passes through untouched. The goal calendar's tall "This Week" tile (current month only) is handled cleanly — paging to a past month collapses the calendar to the compact grid.

## Verification
Built and run on iPhone 17 Pro · iOS 26.4. Drove real swipes via XCUITest and captured before/after on both screens: History July ⇄ June (forward chevron correctly re-enables/locks at the current-month edge), and the Weekly-Goal calendar collapsing from the tall current-month layout to the compact past-month grid. Temporary verification tests were removed; the diff is the three code files + the new shared view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)