### PR TITLE
Rework Summary stats around per-workout averages

### DIFF
--- a/LOGIT/Core/Enums/StatPeriod.swift
+++ b/LOGIT/Core/Enums/StatPeriod.swift
@@ -37,6 +37,16 @@ enum StatPeriod: String, CaseIterable, Identifiable {
         range(periodsAgo: 1, from: date)
     }
 
+    /// How far through the current period `now` sits — 0 at the period's first instant, 1 at its last
+    /// (clamped). Drives the "building your trend" ring on a fresh tile, so it fills as the week (or
+    /// month / year) goes on rather than sitting at a fixed mark.
+    func elapsedFraction(now: Date = .now) -> Double {
+        let range = currentRange(containing: now)
+        let total = range.upperBound.timeIntervalSince(range.lowerBound)
+        guard total > 0 else { return 0 }
+        return min(max(now.timeIntervalSince(range.lowerBound) / total, 0), 1)
+    }
+
     /// How many periods of history a period-scoped chart shows — the current period plus its recent
     /// past. One rule for every such chart in the app: 12 recent weeks, 12 recent months or 6 recent
     /// years, so switching screens never silently changes how far back "history" reaches.
@@ -123,6 +133,37 @@ enum StatPeriod: String, CaseIterable, Identifiable {
             let start = lower.formatted(.dateTime.year())
             let end = upper.formatted(.dateTime.year())
             return start == end ? start : "\(start) - \(end)"
+        }
+    }
+}
+
+// MARK: - Stat Basis
+
+/// How a period's workouts collapse into the single number a stat surface shows: the running
+/// **total** over the period, or the **per-workout average** that divides frequency out so a light
+/// week and a heavy week compare on session quality alone — the reason a one-workout week can still
+/// be read against a four-workout one. The Summary tiles are always per-workout; their detail screens
+/// let the reader flip back to totals.
+enum StatBasis: String, CaseIterable, Identifiable {
+    case perWorkout, total
+
+    var id: String { rawValue }
+
+    /// Segmented-control title — "Per Workout" / "Total".
+    var title: String {
+        switch self {
+        case .perWorkout: return NSLocalizedString("perWorkoutBasis", comment: "")
+        case .total: return NSLocalizedString("total", comment: "")
+        }
+    }
+
+    /// Collapses a period's summed raw value and its non-empty workout count into the one number this
+    /// basis shows. Per-workout is the mean per session — zero when the period had no workout, so an
+    /// empty period reads as no data rather than a misleading zero average; total is the sum untouched.
+    func aggregate(sum: Int, count: Int) -> Double {
+        switch self {
+        case .total: return Double(sum)
+        case .perWorkout: return count > 0 ? Double(sum) / Double(count) : 0
         }
     }
 }

--- a/LOGIT/Core/Environment/de.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/de.lproj/Localizable.strings
@@ -1037,3 +1037,10 @@
 "monthWorkoutCount" = "%d Workout";
 "filters" = "Filter";
 "fromTemplate" = "Aus Vorlage";
+
+// Per-workout vs total basis (Summary stat tiles + detail toggle)
+"perWorkout" = "pro Workout";
+"perWorkoutBasis" = "Pro Workout";
+"basis" = "Werte";
+
+"buildingYourTrend" = "Dein Trend entsteht";

--- a/LOGIT/Core/Environment/en.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/en.lproj/Localizable.strings
@@ -1041,3 +1041,10 @@
 "monthWorkoutCount" = "%d workout";
 "filters" = "Filters";
 "fromTemplate" = "From a Template";
+
+// Per-workout vs total basis (Summary stat tiles + detail toggle)
+"perWorkout" = "per workout";
+"perWorkoutBasis" = "Per Workout";
+"basis" = "Values";
+
+"buildingYourTrend" = "Building your trend";

--- a/LOGIT/Core/Environment/es.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/es.lproj/Localizable.strings
@@ -1041,3 +1041,10 @@
 "monthWorkoutCount" = "%d entrenamiento";
 "filters" = "Filtros";
 "fromTemplate" = "Desde una plantilla";
+
+// Per-workout vs total basis (Summary stat tiles + detail toggle)
+"perWorkout" = "por entrenamiento";
+"perWorkoutBasis" = "Por entrenamiento";
+"basis" = "Valores";
+
+"buildingYourTrend" = "Creando tu tendencia";

--- a/LOGIT/Core/Environment/fr.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/fr.lproj/Localizable.strings
@@ -1041,3 +1041,10 @@
 "monthWorkoutCount" = "%d séance";
 "filters" = "Filtres";
 "fromTemplate" = "Depuis un modèle";
+
+// Per-workout vs total basis (Summary stat tiles + detail toggle)
+"perWorkout" = "par séance";
+"perWorkoutBasis" = "Par séance";
+"basis" = "Valeurs";
+
+"buildingYourTrend" = "Tendance en cours";

--- a/LOGIT/Core/Environment/it.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/it.lproj/Localizable.strings
@@ -1041,3 +1041,10 @@
 "monthWorkoutCount" = "%d allenamento";
 "filters" = "Filtri";
 "fromTemplate" = "Da un modello";
+
+// Per-workout vs total basis (Summary stat tiles + detail toggle)
+"perWorkout" = "per allenamento";
+"perWorkoutBasis" = "Per allenamento";
+"basis" = "Valori";
+
+"buildingYourTrend" = "Creazione del trend";

--- a/LOGIT/Core/Environment/ja.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/ja.lproj/Localizable.strings
@@ -1041,3 +1041,10 @@
 "monthWorkoutCount" = "%d回";
 "filters" = "フィルタ";
 "fromTemplate" = "テンプレートから";
+
+// Per-workout vs total basis (Summary stat tiles + detail toggle)
+"perWorkout" = "ワークアウトあたり";
+"perWorkoutBasis" = "ワークアウトあたり";
+"basis" = "値";
+
+"buildingYourTrend" = "トレンドを作成中";

--- a/LOGIT/Core/Environment/ko.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/ko.lproj/Localizable.strings
@@ -1041,3 +1041,10 @@
 "monthWorkoutCount" = "%d회";
 "filters" = "필터";
 "fromTemplate" = "템플릿에서";
+
+// Per-workout vs total basis (Summary stat tiles + detail toggle)
+"perWorkout" = "운동당";
+"perWorkoutBasis" = "운동당";
+"basis" = "값";
+
+"buildingYourTrend" = "추세 만드는 중";

--- a/LOGIT/Core/Environment/pt-BR.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/pt-BR.lproj/Localizable.strings
@@ -1041,3 +1041,10 @@
 "monthWorkoutCount" = "%d treino";
 "filters" = "Filtros";
 "fromTemplate" = "De um modelo";
+
+// Per-workout vs total basis (Summary stat tiles + detail toggle)
+"perWorkout" = "por treino";
+"perWorkoutBasis" = "Por treino";
+"basis" = "Valores";
+
+"buildingYourTrend" = "Criando sua tendência";

--- a/LOGIT/Features/Exercise/ExerciseDetail/ExerciseSetsScreen.swift
+++ b/LOGIT/Features/Exercise/ExerciseDetail/ExerciseSetsScreen.swift
@@ -32,11 +32,11 @@ struct ExerciseSetsScreen: View {
                         currentBarStyle: AnyShapeStyle(muscleGroupColor.gradient),
                         currentLabel: period.currentPeriodLabel,
                         currentValue: "\(currentCount)",
-                        currentRaw: currentCount,
+                        currentRaw: Double(currentCount),
                         trailingValueStyle: AnyShapeStyle(muscleGroupColor.gradient),
                         positiveColor: muscleGroupColor,
-                        formatAverage: { "\($0)" },
-                        displayAverage: { Double($0) },
+                        formatAverage: { "\(Int($0.rounded()))" },
+                        displayAverage: { $0.rounded() },
                         explanation: NSLocalizedString("averageComparisonInfo", comment: "")
                     )
                 }
@@ -90,10 +90,10 @@ struct ExerciseSetsScreen: View {
     private var buckets: [PeriodHistoryChart.Bucket] {
         PeriodHistoryChart.scrollableBuckets(
             for: period,
-            rawByPeriodStart: countByPeriodStart,
+            rawByPeriodStart: countByPeriodStart.mapValues(Double.init),
             firstDataDate: firstDataDate,
-            display: { Double($0) },
-            formatted: { "\($0)" }
+            display: { $0 },
+            formatted: { "\(Int($0.rounded()))" }
         )
     }
 

--- a/LOGIT/Features/Exercise/ExerciseDetail/ExerciseVolumeScreen.swift
+++ b/LOGIT/Features/Exercise/ExerciseDetail/ExerciseVolumeScreen.swift
@@ -32,13 +32,13 @@ struct ExerciseVolumeScreen: View {
                         currentBarStyle: AnyShapeStyle(muscleGroupColor.gradient),
                         currentLabel: period.currentPeriodLabel,
                         currentValue: formatWeightForDisplay(currentRawVolume),
-                        currentRaw: currentRawVolume,
+                        currentRaw: Double(currentRawVolume),
                         trailingValueStyle: AnyShapeStyle(muscleGroupColor.gradient),
                         positiveColor: muscleGroupColor,
                         // Volumes run to thousands, so round the mean to a whole unit — the raw
                         // decimals only wrap the large header number onto a second line.
-                        formatAverage: { "\(Int(convertWeightForDisplayingDecimal($0).rounded()))" },
-                        displayAverage: { Double(Int(convertWeightForDisplayingDecimal($0).rounded())) },
+                        formatAverage: { "\(Int(convertWeightForDisplayingDecimal(Int($0.rounded())).rounded()))" },
+                        displayAverage: { Double(Int(convertWeightForDisplayingDecimal(Int($0.rounded())).rounded())) },
                         explanation: NSLocalizedString("averageComparisonInfo", comment: "")
                     )
                 }
@@ -92,10 +92,10 @@ struct ExerciseVolumeScreen: View {
     private var buckets: [PeriodHistoryChart.Bucket] {
         PeriodHistoryChart.scrollableBuckets(
             for: period,
-            rawByPeriodStart: rawByPeriodStart,
+            rawByPeriodStart: rawByPeriodStart.mapValues(Double.init),
             firstDataDate: firstDataDate,
-            display: { convertWeightForDisplayingDecimal($0) },
-            formatted: { formatWeightForDisplay($0) }
+            display: { convertWeightForDisplayingDecimal(Int($0.rounded())) },
+            formatted: { formatWeightForDisplay(Int($0.rounded())) }
         )
     }
 

--- a/LOGIT/Features/Home/SummaryStatScreen.swift
+++ b/LOGIT/Features/Home/SummaryStatScreen.swift
@@ -7,16 +7,21 @@
 
 import SwiftUI
 
-/// Detail screen behind a Summary core-stat tile: the stat summed per period across recent history,
-/// scoped by the shared `PeriodPicker`. The tile shows the current period; the screen zooms out to the
-/// last several periods, the current one highlighted. One screen serves all four stats —
-/// `WorkoutStatMetric` supplies values, formatting, and the about text. Pro, like the other stat
-/// detail screens (the tile is the free hook).
+/// Detail screen behind a Summary core-stat tile: the stat across recent history, scoped by the
+/// shared `PeriodPicker` and read either **per workout** (the default, matching the tile — a typical
+/// session with frequency divided out) or as the period's running **total**, flipped with the
+/// `StatBasisPicker`. The tile shows the current period; the screen zooms out to the last several
+/// periods, the current one highlighted. One screen serves all four stats — `WorkoutStatMetric`
+/// supplies values, formatting, and the about text. Pro, like the other stat detail screens (the tile
+/// is the free hook).
 struct SummaryStatScreen: View {
     let metric: WorkoutStatMetric
     let workouts: [Workout]
 
     @State private var period: StatPeriod
+    /// The tiles are always per-workout (a typical session); the screen opens the same way but lets
+    /// the reader flip to the period's running total.
+    @State private var basis: StatBasis = .perWorkout
 
     init(metric: WorkoutStatMetric, workouts: [Workout], initialPeriod: StatPeriod = .week) {
         self.metric = metric
@@ -39,12 +44,12 @@ struct SummaryStatScreen: View {
                         unit: metric.unit,
                         currentBarStyle: AnyShapeStyle(isDuration ? Color.secondary : Color.accentColor),
                         currentLabel: period.currentPeriodLabel,
-                        currentValue: metric.formattedValue(fromRaw: currentRaw),
+                        currentValue: currentValue,
                         currentRaw: currentRaw,
                         trailingValueStyle: isDuration ? AnyShapeStyle(Color.label) : AnyShapeStyle(Color.accentColor.gradient),
                         positiveColor: isDuration ? .secondary : .accentColor,
-                        formatAverage: { metric.formattedAverage(rawAverage: Double($0)) },
-                        displayAverage: { metric.displayValue(fromRaw: $0) },
+                        formatAverage: { metric.formattedAverage(rawAverage: $0) },
+                        displayAverage: { metric.displayValue(fromRaw: Int($0.rounded())) },
                         explanation: NSLocalizedString("averageComparisonInfo", comment: "")
                     )
                 }
@@ -62,35 +67,75 @@ struct SummaryStatScreen: View {
                 Text(metric.title)
                     .font(.headline)
             }
+            // The Per Workout / Total switch lives in the nav bar — a menu keeps the chart area to the
+            // single Week / Month / Year scope, and the checkmarked options say which basis is showing.
+            ToolbarItem(placement: .topBarTrailing) {
+                Menu {
+                    Picker(NSLocalizedString("basis", comment: ""), selection: $basis) {
+                        ForEach(StatBasis.allCases) { basis in
+                            Text(basis.title).tag(basis)
+                        }
+                    }
+                } label: {
+                    Image(systemName: "ellipsis.circle")
+                        .accessibilityLabel(NSLocalizedString("basis", comment: ""))
+                }
+            }
         }
     }
 
     // MARK: - Data
 
-    private var currentRaw: Int { sum(in: period.currentRange()) }
+    /// Sum of the metric and the non-empty workout count per period start, built in one pass so the
+    /// scrollable chart looks each period up instead of re-scanning per bar. The count is the
+    /// per-workout divisor — matching the "N workouts" the weekly-goal hero counts — and empty
+    /// workouts are left out: they add nothing to the sum yet would inflate the count and drag an
+    /// average down. Keyed the way `scrollableBuckets` looks periods up: `currentRange(containing:).lowerBound`.
+    private var aggregatesByPeriodStart: [Date: (sum: Int, count: Int)] {
+        var dict: [Date: (sum: Int, count: Int)] = [:]
+        for workout in workouts where !workout.isEmpty {
+            guard let date = workout.date else { continue }
+            let start = period.currentRange(containing: date).lowerBound
+            var entry = dict[start] ?? (sum: 0, count: 0)
+            entry.sum += metric.rawValue(of: workout)
+            entry.count += 1
+            dict[start] = entry
+        }
+        return dict
+    }
+
+    /// The current period's sum and workout count.
+    private var currentAggregate: (sum: Int, count: Int) {
+        aggregatesByPeriodStart[period.currentRange().lowerBound] ?? (sum: 0, count: 0)
+    }
+
+    /// The current period's value in raw units for the chosen basis — the per-workout average or the
+    /// running total. Drives the header's trend against the visible-window average.
+    private var currentRaw: Double {
+        basis.aggregate(sum: currentAggregate.sum, count: currentAggregate.count)
+    }
+
+    /// The current period's headline string: the total formatted whole, or the per-workout average
+    /// with its fractional precision kept (for the small set / rep counts). "––" when nothing was
+    /// logged — there is no session to average, and a "0" total would read as a decline.
+    private var currentValue: String {
+        switch basis {
+        case .total:
+            return metric.formattedValue(fromRaw: currentAggregate.sum)
+        case .perWorkout:
+            return currentAggregate.count > 0 ? metric.formattedAverage(rawAverage: currentRaw) : "––"
+        }
+    }
 
     /// Earliest recorded workout — the left end of the scrollable domain.
     private var firstDataDate: Date? {
         workouts.compactMap { $0.date }.min()
     }
 
-    /// The metric summed per period start, in one pass over the workouts so the scrollable chart looks
-    /// each period up instead of re-summing per bar. Keyed the same way `scrollableBuckets` keys its
-    /// lookups — `currentRange(containing:).lowerBound`.
-    private var rawByPeriodStart: [Date: Int] {
-        var dict: [Date: Int] = [:]
-        for workout in workouts {
-            guard let date = workout.date else { continue }
-            let start = period.currentRange(containing: date).lowerBound
-            dict[start, default: 0] += metric.rawValue(of: workout)
-        }
-        return dict
-    }
-
-    private func sum(in range: ClosedRange<Date>) -> Int {
-        workouts
-            .filter { ($0.date).map { range.contains($0) } ?? false }
-            .reduce(0) { $0 + metric.rawValue(of: $1) }
+    /// Each period start mapped to its basis value — the per-workout average or the total — for the
+    /// scrollable history bars.
+    private var rawByPeriodStart: [Date: Double] {
+        aggregatesByPeriodStart.mapValues { basis.aggregate(sum: $0.sum, count: $0.count) }
     }
 
     private var buckets: [PeriodHistoryChart.Bucket] {
@@ -98,8 +143,12 @@ struct SummaryStatScreen: View {
             for: period,
             rawByPeriodStart: rawByPeriodStart,
             firstDataDate: firstDataDate,
-            display: { metric.displayValue(fromRaw: $0) },
-            formatted: { metric.formattedValue(fromRaw: $0) }
+            display: { metric.displayValue(fromRaw: Int($0.rounded())) },
+            formatted: {
+                basis == .total
+                    ? metric.formattedValue(fromRaw: Int($0.rounded()))
+                    : metric.formattedAverage(rawAverage: $0)
+            }
         )
     }
 }

--- a/LOGIT/Features/Home/SummaryViewModel.swift
+++ b/LOGIT/Features/Home/SummaryViewModel.swift
@@ -33,10 +33,18 @@ final class SummaryViewModel: ObservableObject {
 
     // MARK: - Stat Data
 
-    /// Everything a core-stat tile renders: the current period's value, the change versus the prior
-    /// period, and the last five periods as display-unit buckets (oldest → newest, last = current).
+    /// Everything a core-stat tile renders. The tile reads a *per-workout average* — a typical
+    /// session, frequency divided out — so a light week and a heavy week compare on session quality
+    /// rather than on how many times the user showed up (that lives in the weekly-goal hero above).
+    /// The current period's average, the change versus the prior period's average, and the last five
+    /// periods as display-unit buckets (oldest → newest, last = current).
     struct StatData {
-        let rawValue: Int
+        /// The current period's per-workout average in raw units (grams / minutes / counts); 0 when
+        /// the period had no workout.
+        let rawAverage: Double
+        /// Whether the current period had any workout to average — false renders the "––" no-data
+        /// tile instead of a misleading "0", since there is no session to average.
+        let hasData: Bool
         let percentChange: Double?
         let buckets: [Double]
     }
@@ -93,23 +101,35 @@ final class SummaryViewModel: ObservableObject {
     // MARK: - Core stats
 
     func statData(for metric: WorkoutStatMetric, period: StatPeriod, workouts: [Workout]) -> StatData {
-        var rawBuckets: [Int] = []
+        // Per bucket: the per-workout average (sum ÷ non-empty workout count), the divisor matching
+        // the "3 workouts" the weekly-goal hero counts so the tile reads as "per one of those". Empty
+        // workouts are excluded — they'd only drag an average down while inflating the count; a blank
+        // workout contributed nothing to the old sum either.
+        var averages: [Double] = []
+        var counts: [Int] = []
         for n in stride(from: Self.statBucketCount - 1, through: 0, by: -1) {
             let range = period.range(periodsAgo: n)
-            let sum = workouts
-                .filter { ($0.date).map { range.contains($0) } ?? false }
-                .reduce(0) { $0 + metric.rawValue(of: $1) }
-            rawBuckets.append(sum)
+            let periodWorkouts = workouts.filter { workout in
+                guard !workout.isEmpty, let date = workout.date else { return false }
+                return range.contains(date)
+            }
+            let sum = periodWorkouts.reduce(0) { $0 + metric.rawValue(of: $1) }
+            averages.append(StatBasis.perWorkout.aggregate(sum: sum, count: periodWorkouts.count))
+            counts.append(periodWorkouts.count)
         }
-        let current = rawBuckets.last ?? 0
-        let previous = rawBuckets.count >= 2 ? rawBuckets[rawBuckets.count - 2] : 0
-        let percentChange: Double? = previous > 0
-            ? (Double(current) - Double(previous)) / Double(previous) * 100
+        let currentAverage = averages.last ?? 0
+        let currentCount = counts.last ?? 0
+        let previousAverage = averages.count >= 2 ? averages[averages.count - 2] : 0
+        let previousCount = counts.count >= 2 ? counts[counts.count - 2] : 0
+        // Both periods need a session to compare — a fresh, still-empty week never reads as a collapse.
+        let percentChange: Double? = (currentCount > 0 && previousCount > 0 && previousAverage > 0)
+            ? (currentAverage - previousAverage) / previousAverage * 100
             : nil
         return StatData(
-            rawValue: current,
+            rawAverage: currentAverage,
+            hasData: currentCount > 0,
             percentChange: percentChange,
-            buckets: rawBuckets.map { metric.displayValue(fromRaw: $0) }
+            buckets: averages.map { metric.displayValue(fromRaw: Int($0.rounded())) }
         )
     }
 

--- a/LOGIT/Features/Home/Tiles/SummaryStatTiles.swift
+++ b/LOGIT/Features/Home/Tiles/SummaryStatTiles.swift
@@ -10,9 +10,11 @@ import SwiftUI
 // MARK: - Summary Stat Tile
 
 /// One period-scoped core stat on the Summary screen — the shared `MetricTile` carrying a Summary
-/// value: the sum over the selected period, the change versus the prior period, and a five-bucket
-/// history bar chart with the current period highlighted. Parallel to `WorkoutStatTile` (which is
-/// hardwired to "this workout vs prior runs"), but reading the period block's window instead.
+/// value: the *per-workout average* over the selected period (a typical session, frequency divided
+/// out), the change versus the prior period's average, and a five-bucket history bar chart with the
+/// current period highlighted. The "per workout" subtitle names the basis right under the number.
+/// Parallel to `WorkoutStatTile` (which is hardwired to "this workout vs prior runs"), but reading
+/// the period block's window instead.
 ///
 /// The highlighted bar always uses the app accent — it marks "this week" (the current period). The
 /// trend pill tints with the accent for a genuine gain and mutes to gray for a decline or no change
@@ -20,6 +22,8 @@ import SwiftUI
 struct SummaryStatTile: View {
     let metric: WorkoutStatMetric
     let data: SummaryViewModel.StatData
+    /// The scoped period — the placeholder ring reads how far through it we are.
+    let period: StatPeriod
     let onOpen: () -> Void
 
     /// Positive trends carry the app accent; `TrendIndicatorView` mutes declines and flat weeks to
@@ -30,24 +34,52 @@ struct SummaryStatTile: View {
         Button(action: onOpen) {
             MetricTile(
                 title: metric.title,
-                label: .none,
-                // A period sum is a real value even at zero ("0 sets this week"), clearer than the
-                // "––" no-data dash; the trend pill is suppressed when empty so a blank week never
-                // reads as a misleading "100 % decline".
-                value: metric.formattedValue(fromRaw: data.rawValue),
+                // "per workout" as a quiet qualifier under the title — a soft annotation on the value,
+                // deliberately lighter than the title so the number stays the tile's focus.
+                label: .caption(NSLocalizedString("perWorkout", comment: "")),
+                // A per-workout average needs a session to exist: with no workout in the period there
+                // is nothing to average, so show the "––" no-data dash rather than a misleading "0",
+                // and suppress the trend pill (also nil'd upstream when either period is empty).
+                value: data.hasData ? metric.formattedAverage(rawAverage: data.rawAverage, compact: true) : nil,
                 unit: metric.unit,
                 accent: AnyShapeStyle(pillColor),
                 accentColor: pillColor,
-                percentChange: data.rawValue > 0 ? data.percentChange : nil,
+                percentChange: data.hasData ? data.percentChange : nil,
                 requiresPro: metric.requiresPro,
                 chartBleeds: false
             ) {
-                // The highlighted "this week" bar always uses the accent, even for duration — it marks
-                // the current period, not a judgement, so it reads the same as the other tiles.
-                WorkoutRunsBarChart(bars: bars, currentStyle: AnyShapeStyle(Color.accentColor))
+                if showsTrendPlaceholder {
+                    // One lone bar (or none) isn't a trend — it just reads as a half-loaded tile. Until
+                    // a second period has data, show a quiet "building your trend" hint instead; the real
+                    // bars return on their own once there's something to compare.
+                    SummaryTrendPlaceholder(progress: trendProgress)
+                } else {
+                    // The highlighted "this week" bar always uses the accent, even for duration — it
+                    // marks the current period, not a judgement, so it reads the same as the other tiles.
+                    WorkoutRunsBarChart(bars: bars, currentStyle: AnyShapeStyle(Color.accentColor))
+                }
             }
         }
         .buttonStyle(TileButtonStyle())
+    }
+
+    /// Fewer than two periods with data means there's no trend to plot yet — a single bar, or none.
+    /// Swap the bar chart for the placeholder, but only once this period itself has a value: an
+    /// all-empty tile already shows "––" and keeps the shared chart's own no-data treatment.
+    private var showsTrendPlaceholder: Bool {
+        data.hasData && periodsWithData < 2
+    }
+
+    /// Periods in the five-bucket window that have data — gates the placeholder (a lone period isn't
+    /// a trend).
+    private var periodsWithData: Int {
+        data.buckets.filter { $0 > 0 }.count
+    }
+
+    /// The placeholder ring's fill — how far through the current period we are, so it creeps forward
+    /// as the week (or month / year) goes on rather than sitting at a fixed mark.
+    private var trendProgress: Double {
+        period.elapsedFraction()
     }
 
     /// The five history buckets right-aligned into the fixed five-slot chart, newest (current period)
@@ -57,6 +89,44 @@ struct SummaryStatTile: View {
         return data.buckets.enumerated().map { index, value in
             WorkoutRunsBarChart.Bar(slot: index, value: value, isCurrent: index == count - 1)
         }
+    }
+}
+
+// MARK: - Trend Placeholder
+
+/// The chart-slot placeholder a core-stat tile shows before it has a trend to draw — a quiet gray
+/// progress ring (around a small bar-chart glyph) beside "Building your trend", sitting where the
+/// bars would, so a brand-new week reads as *in progress* rather than an empty tile. All gray, no
+/// accent: it's a nudge, not data — the honest answer to "there's nothing to chart yet" without
+/// faking bars. The ring tracks how far through the current period the tile is, so it creeps forward
+/// as the week goes on.
+private struct SummaryTrendPlaceholder: View {
+    /// How far through the current period we are (0…1) — the ring's fill.
+    let progress: Double
+
+    var body: some View {
+        HStack(spacing: 9) {
+            ZStack {
+                Circle()
+                    .stroke(Color.fill, lineWidth: 3)
+                Circle()
+                    .trim(from: 0, to: progress)
+                    .stroke(Color.secondaryLabel, style: StrokeStyle(lineWidth: 3, lineCap: .round))
+                    // Start at 12 o'clock and fill clockwise, like every other progress ring.
+                    .rotationEffect(.degrees(-90))
+                Image(systemName: "chart.bar.fill")
+                    .font(.system(size: 10))
+                    .foregroundStyle(.tertiary)
+            }
+            .frame(width: 30, height: 30)
+            Text(NSLocalizedString("buildingYourTrend", comment: ""))
+                .font(.caption.weight(.medium))
+                .foregroundStyle(.tertiary)
+                .lineLimit(1)
+                .minimumScaleFactor(0.8)
+            Spacer(minLength: 0)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomLeading)
     }
 }
 
@@ -100,6 +170,7 @@ struct SummaryStatTileGrid: View {
         SummaryStatTile(
             metric: metric,
             data: viewModel.statData(for: metric, period: period, workouts: workouts),
+            period: period,
             onOpen: { onOpenDetail(metric) }
         )
     }

--- a/LOGIT/Features/Workout/WorkoutStatTiles.swift
+++ b/LOGIT/Features/Workout/WorkoutStatTiles.swift
@@ -76,20 +76,23 @@ enum WorkoutStatMetric: Int, CaseIterable, Identifiable {
     /// two read as the same quantity. Volume rounds to whole display units like the estimated
     /// 1RM does — it's a calculated value, and fractional kilograms on a four-digit average are
     /// noise. Counts keep a decimal instead: a rounded "19" would claim a precision the average
-    /// doesn't have.
-    func formattedAverage(rawAverage: Double) -> String {
+    /// doesn't have. `compact` (the tiles, where width is tight) additionally drops a count's decimal
+    /// once it reaches 1000 — a fractional part is noise at that scale and would overflow the tile.
+    func formattedAverage(rawAverage: Double, compact: Bool = false) -> String {
         switch self {
         case .volume: return String(Int(convertWeightForDisplayingDecimal(Int(rawAverage.rounded())).rounded()))
         case .duration: return formattedWorkoutDuration(minutes: Int(rawAverage.rounded()))
-        case .sets, .repetitions: return Self.formatAverageNumber(rawAverage)
+        case .sets, .repetitions: return Self.formatAverageNumber(rawAverage, compact: compact)
         }
     }
 
-    /// "18.5"-style average formatting — at most one decimal, none when whole.
-    private static func formatAverageNumber(_ value: Double) -> String {
+    /// "18.5"-style average formatting — at most one decimal, none when whole. `compact` drops the
+    /// decimal entirely at 1000+, where it's noise and the extra glyphs overflow a tile ("1,234" not
+    /// "1,234.5").
+    private static func formatAverageNumber(_ value: Double, compact: Bool = false) -> String {
         let formatter = NumberFormatter()
         formatter.numberStyle = .decimal
-        formatter.maximumFractionDigits = 1
+        formatter.maximumFractionDigits = (compact && value >= 1000) ? 0 : 1
         formatter.minimumFractionDigits = 0
         return formatter.string(from: NSNumber(value: value)) ?? String(format: "%.1f", value)
     }

--- a/LOGIT/SharedUI/Charts/PeriodHistoryChart.swift
+++ b/LOGIT/SharedUI/Charts/PeriodHistoryChart.swift
@@ -52,6 +52,11 @@ struct PeriodHistoryChart: View {
     /// the visible periods, excluding the current, still-growing one. Nil draws nothing. In the
     /// buckets' own value units, so it moves with the header as the chart scrolls.
     var averageLine: Double? = nil
+    /// The top of the y-axis, in display units — the tallest bar *currently in view* (with headroom
+    /// added here), passed in by the scrolling owner so the scale adapts to the visible window as you
+    /// scroll, the way Health rescales its charts. Nil (the static muscle tile) falls back to the
+    /// tallest bar across every bucket.
+    var yDomainMax: Double? = nil
     /// When bound, the chart scrolls horizontally: `buckets` span the full history, a window of
     /// `historyBucketCount` periods shows at a time, and this is its left edge (owned by the screen so
     /// its header can read the visible window). Nil keeps the chart static — the compact muscle tile.
@@ -62,7 +67,9 @@ struct PeriodHistoryChart: View {
     @State private var selectedDate: Date?
 
     var body: some View {
-        let maxValue = buckets.map(\.value).max() ?? 0
+        // The y-axis fits the tallest bar in view (passed in while scrolling) or, static, the tallest
+        // across every bucket.
+        let maxValue = yDomainMax ?? (buckets.map(\.value).max() ?? 0)
         let selectedBucket = selectedDate.flatMap { nearestBucket(to: $0) }
         scrollableIfNeeded(
             Chart {
@@ -122,6 +129,12 @@ struct PeriodHistoryChart: View {
             .chartYAxis {
                 AxisMarks(values: .automatic(desiredCount: 3))
             }
+            // Ease the y-scale and the dashed average to their new values as bars scroll in and out, so
+            // the axis rescales and the line glides instead of snapping. Applied to the chart's marks
+            // and scale here, *inside* the scroll wrapper `scrollableIfNeeded` adds — the horizontal
+            // scroll is a modifier outside this animation's scope, so it keeps tracking the finger.
+            .animation(.easeInOut(duration: 0.3), value: maxValue)
+            .animation(.easeInOut(duration: 0.3), value: averageLine)
         )
         .frame(height: height)
     }
@@ -245,15 +258,17 @@ extension PeriodHistoryChart {
     /// the current period. `rawByPeriodStart` is the data pre-grouped by period start (built in one
     /// pass by the screen), looked up per period so building N bars stays O(periods) rather than
     /// re-filtering the data per bar; keys must be `period.currentRange(containing:).lowerBound`, the
-    /// same canonical period start this uses. `display` maps a raw sum to the bar's height, `formatted`
-    /// to its tooltip, and the raw sum rides along for the moving visible-window average.
+    /// same canonical period start this uses. Values are `Double` so a per-workout average (a
+    /// fractional 17.5 sets) rides through with its precision intact, not just an integer sum.
+    /// `display` maps a raw value to the bar's height, `formatted` to its tooltip, and the raw value
+    /// rides along for the moving visible-window average.
     static func scrollableBuckets(
         for period: StatPeriod,
-        rawByPeriodStart: [Date: Int],
+        rawByPeriodStart: [Date: Double],
         firstDataDate: Date?,
         now: Date = .now,
-        display: (Int) -> Double,
-        formatted: (Int) -> String
+        display: (Double) -> Double,
+        formatted: (Double) -> String
     ) -> [Bucket] {
         let domain = period.scrollableXDomain(firstDataDate: firstDataDate, now: now)
         let currentStart = period.currentRange(containing: now).lowerBound
@@ -268,7 +283,7 @@ extension PeriodHistoryChart {
                 value: display(raw),
                 isCurrent: start == currentStart,
                 formattedValue: formatted(raw),
-                rawValue: Double(raw)
+                rawValue: raw
             ))
             guard let next = Calendar.current.date(byAdding: period.calendarComponent, value: 1, to: start) else { break }
             start = period.currentRange(containing: next).lowerBound
@@ -280,9 +295,9 @@ extension PeriodHistoryChart {
     /// The period-over-period trend for a stat header, or nil unless both periods have data — a
     /// freshly started week must not read as a "−100%" collapse (the same suppression rule as the
     /// stat tiles).
-    static func trendPercentChange(current: Int, previous: Int) -> Double? {
+    static func trendPercentChange(current: Double, previous: Double) -> Double? {
         guard current > 0, previous > 0 else { return nil }
-        return (Double(current) - Double(previous)) / Double(previous) * 100
+        return (current - previous) / previous * 100
     }
 }
 
@@ -315,14 +330,14 @@ struct PeriodStatChartView: View {
     /// Trailing (subject) side: "This Week" and the current period's value, fixed as the chart scrolls.
     let currentLabel: String
     let currentValue: String
-    let currentRaw: Int
+    let currentRaw: Double
     let trailingValueStyle: AnyShapeStyle
     let positiveColor: Color
     var positiveStyle: AnyShapeStyle? = nil
     /// Raw visible-window average → the header string (each screen rounds / formats in its own units).
-    let formatAverage: (Int) -> String
+    let formatAverage: (Double) -> String
     /// Raw visible-window average → the dashed line's height in display units.
-    let displayAverage: (Int) -> Double
+    let displayAverage: (Double) -> Double
     var explanation: String? = nil
 
     @State private var scrollPosition: Date
@@ -336,12 +351,12 @@ struct PeriodStatChartView: View {
         currentBarStyle: AnyShapeStyle,
         currentLabel: String,
         currentValue: String,
-        currentRaw: Int,
+        currentRaw: Double,
         trailingValueStyle: AnyShapeStyle,
         positiveColor: Color,
         positiveStyle: AnyShapeStyle? = nil,
-        formatAverage: @escaping (Int) -> String,
-        displayAverage: @escaping (Int) -> Double,
+        formatAverage: @escaping (Double) -> String,
+        displayAverage: @escaping (Double) -> Double,
         explanation: String? = nil
     ) {
         self.period = period
@@ -363,20 +378,20 @@ struct PeriodStatChartView: View {
     }
 
     var body: some View {
-        // The completed periods on screen — the current, still-growing one and untrained periods left
-        // out, matching the pill's "both sides need data" rule. O(buckets) per scroll frame; the
-        // buckets themselves are the parent's, unchanged by scrolling.
+        // One pass over the buckets covers everything the visible window drives: the completed-period
+        // average (the header + dashed line) and the tallest bar on screen (the y-axis top). The
+        // average excludes the current, still-growing period and untrained ones, matching the pill's
+        // "both sides need data" rule; the max includes every visible bar so the axis fits the current
+        // one too. A single pass replaces the old filter-then-reduce here plus the chart's own max scan
+        // — cheaper per scroll frame, which is the frame that has to stay smooth.
         let window = period.visibleWindowRange(from: scrollPosition)
-        let visible = buckets.filter { !$0.isCurrent && $0.rawValue > 0 && window.contains($0.date) }
-        let averageRaw: Int? = visible.isEmpty
-            ? nil
-            : Int((visible.map(\.rawValue).reduce(0, +) / Double(visible.count)).rounded())
-        let percentChange = PeriodHistoryChart.trendPercentChange(current: currentRaw, previous: averageRaw ?? 0)
+        let visible = Self.visibleStats(buckets: buckets, window: window)
+        let percentChange = PeriodHistoryChart.trendPercentChange(current: currentRaw, previous: visible.averageRaw ?? 0)
         return VStack(spacing: 16) {
             MetricComparisonView(
                 leading: .init(
                     label: NSLocalizedString("average", comment: ""),
-                    value: averageRaw.map(formatAverage) ?? "––",
+                    value: visible.averageRaw.map(formatAverage) ?? "––",
                     unit: unit,
                     caption: period.rangeCaption(window)
                 ),
@@ -399,7 +414,8 @@ struct PeriodStatChartView: View {
                 valueLabel: valueLabel,
                 currentBarStyle: currentBarStyle,
                 unit: unit,
-                averageLine: averageRaw.map(displayAverage),
+                averageLine: visible.averageRaw.map(displayAverage),
+                yDomainMax: visible.displayMax,
                 scrollPosition: $scrollPosition,
                 firstDataDate: firstDataDate
             )
@@ -410,6 +426,29 @@ struct PeriodStatChartView: View {
         .onChange(of: period) {
             scrollPosition = period.initialScrollPosition()
         }
+    }
+
+    /// The visible window's completed-period average and its tallest bar, gathered in one pass.
+    /// `averageRaw` excludes the current, still-growing period and untrained periods (nil when none
+    /// remain); `displayMax` is the tallest bar in view — the current period included — in display
+    /// units, the y-axis top before headroom.
+    private struct VisibleStats {
+        var averageRaw: Double?
+        var displayMax: Double
+    }
+
+    private static func visibleStats(buckets: [PeriodHistoryChart.Bucket], window: ClosedRange<Date>) -> VisibleStats {
+        var sum = 0.0
+        var count = 0
+        var maxDisplay = 0.0
+        for bucket in buckets where window.contains(bucket.date) {
+            if bucket.value > maxDisplay { maxDisplay = bucket.value }
+            if !bucket.isCurrent && bucket.rawValue > 0 {
+                sum += bucket.rawValue
+                count += 1
+            }
+        }
+        return VisibleStats(averageRaw: count > 0 ? sum / Double(count) : nil, displayMax: maxDisplay)
     }
 }
 

--- a/LOGIT/SharedUI/Views/MetricTile.swift
+++ b/LOGIT/SharedUI/Views/MetricTile.swift
@@ -27,6 +27,9 @@ struct MetricTile<ChartContent: View>: View {
         /// A plain label with an info button explaining the value — the workout stat tiles explain
         /// their comparison basis this way.
         case info(String, explanation: String)
+        /// A quiet, understated qualifier under the title — smaller and lighter than `.plain`, so it
+        /// reads as a soft annotation on the value ("per workout") rather than a second heading.
+        case caption(String)
         /// No subtitle line at all — the title and value carry the whole tile.
         case none
     }
@@ -197,6 +200,11 @@ struct MetricTile<ChartContent: View>: View {
                 .foregroundStyle(.secondary)
         case let .info(text, explanation):
             MetricTileInfoLabel(text: text, explanation: explanation)
+        case let .caption(text):
+            Text(text)
+                .font(.caption.weight(.medium))
+                .tracking(0.3)
+                .foregroundStyle(.tertiary)
         case .none:
             // Reserve one subtitle line's height so the value keeps the same fixed vertical position
             // as tiles that do have a subtitle. Without it the value floats up into the empty slot and

--- a/LOGITTests/StatPeriodTests.swift
+++ b/LOGITTests/StatPeriodTests.swift
@@ -285,4 +285,41 @@ final class WeeklyStreakTests: XCTestCase {
             1
         )
     }
+
+    // MARK: - Compact tile averages
+
+    /// Digit characters only, so assertions ignore the locale's grouping / decimal separators
+    /// ("1,234.5", "1.234,5" and "1 234,5" all count five digits).
+    private func digitCount(_ string: String) -> Int {
+        string.filter(\.isNumber).count
+    }
+
+    func testTileAverageKeepsDecimalBelowThousand() {
+        // Under 1000 the compact tile still carries its one decimal — a rounded count would overstate
+        // a fractional average's precision.
+        let sets = WorkoutStatMetric.sets.formattedAverage(rawAverage: 18.5, compact: true)
+        XCTAssertEqual(digitCount(sets), 3, "18.5 should keep its fractional digit")
+        XCTAssertEqual(
+            sets,
+            WorkoutStatMetric.sets.formattedAverage(rawAverage: 18.5, compact: false),
+            "compact and full agree below 1000"
+        )
+    }
+
+    func testTileAverageDropsDecimalAtThousand() {
+        // 1000+: the compact tile drops the fractional part so it doesn't overflow…
+        let compact = WorkoutStatMetric.repetitions.formattedAverage(rawAverage: 1234.5, compact: true)
+        XCTAssertEqual(digitCount(compact), 4, "1234.5 should render as four whole digits when compact")
+
+        // …while the roomier detail header (non-compact) keeps the decimal.
+        let full = WorkoutStatMetric.repetitions.formattedAverage(rawAverage: 1234.5, compact: false)
+        XCTAssertEqual(digitCount(full), 5, "the detail header keeps the fractional digit")
+        XCTAssertNotEqual(compact, full)
+    }
+
+    func testTileAverageDropsDecimalExactlyAtThousand() {
+        // The threshold is inclusive: exactly 1000 already drops the decimal.
+        let atThreshold = WorkoutStatMetric.repetitions.formattedAverage(rawAverage: 1000.4, compact: true)
+        XCTAssertEqual(digitCount(atThreshold), 4, "1000 should render as four whole digits")
+    }
 }


### PR DESCRIPTION
The four Summary tiles and their detail screens now read a **per-workout average** — a typical session, frequency divided out — instead of a weekly total, so any week (even a single-workout one) compares to its neighbours. The detail screens keep a Per Workout / Total switch.

## What changed
- **Tiles + `SummaryStatScreen` default to per-workout** — new `StatBasis` enum, divisor = the non-empty workout count (matching the weekly-goal streak). The detail screen gains a nav-bar **Per Workout / Total** menu.
- **Shared period-chart pipeline widened `Int` → `Double`** (`PeriodStatChartView` / `scrollableBuckets` / `trendPercentChange`) so fractional averages carry through.
- **Chart polish:** the y-axis now fits the *visible window's* max (animated), the dashed average line eases as you scroll, and both derive from a single pass over the visible buckets (was a filter+reduce plus a separate max scan).
- **Empty state:** a tile with no trend yet shows a *"Building your trend"* placeholder — a gray ring that fills clockwise with the week — instead of a lone bar.
- **Compact tile values:** counts drop the decimal at ≥ 1000 so a four-digit average doesn't overflow the tile (new `MetricTile.Label.caption` for the quiet "per workout" line).
- **Exercise Volume/Sets screens** adapted to the `Double` pipeline (behaviour unchanged — still totals). Localised in all **8 languages**.

## Verification
- Screenshot-verified across the empty / one-workout / rich / free-tier scenarios, the nav-bar toggle, Week/Month/Year, and the adaptive y-axis (on `stress`).
- New unit tests in `StatPeriodTests` cover the ≥1000 compact formatting (locale-robust).

🤖 Generated with [Claude Code](https://claude.com/claude-code)