### PR TITLE
Summary welcome: Apple-style empty-state subtitle

### DIFF
--- a/LOGIT/Core/Environment/en.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/en.lproj/Localizable.strings
@@ -961,7 +961,7 @@
 "suggestAFeatureSubtitle" = "Tell us what's still missing.";
 "rateLogit" = "Rate LOGIT";
 "summaryWelcomeTitle" = "Log your first workout";
-"summaryWelcomeSubtitle" = "Your Summary fills with your weekly goal, records and muscle balance as soon as you start training.";
+"summaryWelcomeSubtitle" = "Your Summary appears here after your first workout.";
 "browseTemplates" = "Browse templates";
 "whatYoullTrack" = "What you'll track";
 "volumeAndSets" = "Volume & Sets";


### PR DESCRIPTION
## What

Rewrites the brand-new-user Summary welcome subtitle.

**Before:** "Your Summary fills with your weekly goal, records and muscle balance as soon as you start training."

**After:** "Your Summary appears here after your first workout."

## Why

The old copy read awkwardly ("fills with…") and re-listed the exact four items already shown in the **"What you'll track"** grid directly beneath it, so the sentence duplicated the UI right below. The new line uses Apple's stock empty-state pattern ("… appears here") — one calm, factual sentence that says what shows up and when, letting the grid handle the *what*.

Copy-only change in `en.lproj/Localizable.strings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)