### PR TITLE
Rework the template detail + list cell to match the workout screens

### DIFF
--- a/LOGIT/Features/Search/GlobalSearchScreen.swift
+++ b/LOGIT/Features/Search/GlobalSearchScreen.swift
@@ -331,13 +331,9 @@ struct GlobalSearchScreen: View {
                     Button {
                         selectedTemplate = template
                     } label: {
-                        HStack {
-                            TemplateCell(template: template)
-                            NavigationChevron()
-                                .foregroundStyle(.secondary)
-                        }
-                        .padding(CELL_PADDING)
-                        .tileStyle()
+                        TemplateCell(template: template)
+                            .padding(CELL_PADDING)
+                            .tileStyle()
                     }
                     .buttonStyle(TileButtonStyle())
                 }

--- a/LOGIT/Features/Template/Cells/TemplateCell.swift
+++ b/LOGIT/Features/Template/Cells/TemplateCell.swift
@@ -8,6 +8,12 @@
 import Charts
 import SwiftUI
 
+/// A template row in the lists you pick from. Structured like `WorkoutCell` — recency caption, name
+/// with a navigation chevron, muscle-group donut, then a contents summary — so a plan and a performed
+/// workout read as the same family. Kept deliberately distinct from `WorkoutCell` in two ways: it has
+/// no colorful muscle-gradient background (a plan is quieter than a session), and its caption is the
+/// *recency* of use ("Last used 3 days ago" / "Never used") rather than a concrete date and duration.
+/// Content only — the caller supplies the flat `.tileStyle()` background and padding.
 struct TemplateCell: View {
     // MARK: - Environment
 
@@ -20,37 +26,87 @@ struct TemplateCell: View {
     // MARK: - Body
 
     var body: some View {
-        VStack(alignment: .leading) {
-            HStack(spacing: 12) {
-                Chart {
-                    ForEach(muscleGroupService.getMuscleGroupOccurances(in: template), id: \.0) { muscleGroupOccurance in
-                        SectorMark(
-                            angle: .value("Value", muscleGroupOccurance.1),
-                            innerRadius: .ratio(0.65),
-                            angularInset: 1
-                        )
-                        .foregroundStyle(muscleGroupOccurance.0.color.gradient)
-                    }
-                }
-                .frame(width: 40, height: 40)
-                VStack(alignment: .leading) {
-                    Text(NSLocalizedString("template", comment: "").uppercased())
-                        .font(.footnote.weight(.medium))
-                        .foregroundStyle(.secondary)
-                    Text(template.displayName)
-                        .fontWeight(.bold)
-                        .foregroundColor(.primary)
-                        .lineLimit(1)
-                }
-            }
-            if let description = template.displayDescription {
-                Text(description)
-                    .font(.footnote)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(2)
-            }
+        VStack(alignment: .leading, spacing: 10) {
+            headerRow
+            summaryRow
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    // MARK: - View Components
+
+    private var headerRow: some View {
+        HStack(spacing: 10) {
+            VStack(alignment: .leading, spacing: 3) {
+                Text(recencyCaption)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                HStack(spacing: 5) {
+                    Text(template.displayName)
+                        .font(.body.weight(.semibold))
+                        .foregroundColor(.primary)
+                        .lineLimit(1)
+                    NavigationChevron()
+                        .foregroundStyle(.secondary)
+                }
+            }
+            Spacer()
+            muscleGroupChart
+        }
+    }
+
+    private var muscleGroupChart: some View {
+        Chart {
+            ForEach(muscleGroupService.getMuscleGroupOccurances(in: template), id: \.0) { muscleGroupOccurance in
+                SectorMark(
+                    angle: .value("Value", muscleGroupOccurance.1),
+                    innerRadius: .ratio(0.6),
+                    angularInset: 1.5
+                )
+                .foregroundStyle(muscleGroupOccurance.0.color.gradient)
+            }
+        }
+        .frame(width: 40, height: 40)
+    }
+
+    private var summaryRow: some View {
+        HStack(alignment: .bottom, spacing: 4) {
+            Text(contentsSummary)
+                .font(.footnote)
+                .lineLimit(2)
+            Spacer()
+        }
+    }
+
+    // MARK: - Computed Properties
+
+    /// "Last used 3 days ago" for a used template, "Never" for one that has never been run — the
+    /// plan-side counterpart to the workout cell's date, built from `template.lastUsed`. The relative
+    /// date is system-localized and the "Last used" prefix reuses the existing string, so the caption
+    /// stays localized in every language without adding new keys.
+    private var recencyCaption: String {
+        guard let lastUsed = template.lastUsed else {
+            return NSLocalizedString("never", comment: "")
+        }
+        let relative = lastUsed.formatted(.relative(presentation: .named))
+        return "\(NSLocalizedString("lastUsed", comment: "")) \(relative)"
+    }
+
+    /// The user's description when they wrote one — their words win — otherwise the planned exercises,
+    /// mirroring the workout cell's exercise summary so an unused template still says what it trains.
+    private var contentsSummary: String {
+        if let description = template.displayDescription {
+            return description
+        }
+        let names = template.exercises.compactMap { $0.displayName.isEmpty ? nil : $0.displayName }
+        if names.isEmpty {
+            return NSLocalizedString("noExercises", comment: "")
+        }
+        let maxToShow = 20
+        let shown = names.prefix(maxToShow)
+        return names.count > maxToShow
+            ? shown.joined(separator: ", ") + " & more"
+            : shown.joined(separator: ", ")
     }
 }
 

--- a/LOGIT/Features/Template/TemplateDetailScreen.swift
+++ b/LOGIT/Features/Template/TemplateDetailScreen.swift
@@ -12,8 +12,11 @@ struct TemplateDetailScreen: View {
     // MARK: - Environment
 
     @Environment(\.dismiss) var dismiss
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    @Environment(\.presentWorkoutRecorder) private var presentWorkoutRecorder
     @EnvironmentObject private var database: Database
     @EnvironmentObject private var muscleGroupService: MuscleGroupService
+    @EnvironmentObject private var workoutRecorder: WorkoutRecorder
 
     // MARK: - State
 
@@ -21,15 +24,17 @@ struct TemplateDetailScreen: View {
     @State private var showingTemplateInfoAlert = false
     @State private var showingDeletionAlert = false
     @State private var showingTemplateEditor = false
-    @State private var isMuscleGroupExpanded = false
     @State private var templateShareFileURL: URL?
+    /// Sizes the header donut to the height of the kicker + title beside it (like the workout
+    /// detail's header), so a wrapping title scales it rather than leaving it floating.
+    @State private var headerTextHeight: CGFloat = 64
 
     // MARK: - Variables
 
     @StateObject var template: Template
-    
+
     // MARK: - Sharing Service
-    
+
     private var sharingService: WorkoutSharingService {
         WorkoutSharingService(database: database)
     }
@@ -40,17 +45,10 @@ struct TemplateDetailScreen: View {
         ScrollView(.vertical, showsIndicators: true) {
             VStack(spacing: SECTION_SPACING) {
                 templateHeader
-                VStack(spacing: SECTION_HEADER_SPACING) {
-                    Text(NSLocalizedString("overview", comment: ""))
-                        .sectionHeaderStyle2()
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                    VStack(spacing: CELL_SPACING) {
-                        templateInfo
-                            .padding(CELL_PADDING)
-                            .tileStyle()
-                        setsPerMuscleGroup
-                            .padding(CELL_PADDING)
-                            .tileStyle()
+                VStack(spacing: 10) {
+                    startButton
+                    if hasSessions {
+                        progressGrid
                     }
                 }
                 VStack(spacing: SECTION_HEADER_SPACING) {
@@ -60,7 +58,7 @@ struct TemplateDetailScreen: View {
                     exercisesList
                 }
                 VStack(spacing: SECTION_HEADER_SPACING) {
-                    Text(NSLocalizedString("lastUsed", comment: ""))
+                    Text(NSLocalizedString("history", comment: ""))
                         .sectionHeaderStyle2()
                         .frame(maxWidth: .infinity, alignment: .leading)
                     workoutList
@@ -147,131 +145,126 @@ struct TemplateDetailScreen: View {
 
     // MARK: - Supporting Views
 
+    /// The kicker + title beside the muscle-group donut, mirroring the workout detail's header so
+    /// the two screens read as one family. The donut carries the muscle split now that the standalone
+    /// muscle-group tile is gone. The optional description flows full-width beneath.
     private var templateHeader: some View {
-        VStack(alignment: .leading) {
-            Text(NSLocalizedString("template", comment: ""))
-                .screenHeaderTertiaryStyle()
-            Text(template.resolvedName ?? "")
-                .screenHeaderStyle()
-                .lineLimit(2)
+        VStack(alignment: .leading, spacing: SECTION_HEADER_SPACING) {
+            HStack(alignment: .center, spacing: 16) {
+                VStack(alignment: .leading) {
+                    Text(NSLocalizedString("template", comment: ""))
+                        .screenHeaderTertiaryStyle()
+                    Text(template.resolvedName ?? "")
+                        .screenHeaderStyle()
+                        .lineLimit(2)
+                        .minimumScaleFactor(0.6)
+                }
+                .onGeometryChange(for: CGFloat.self) { proxy in
+                    proxy.size.height
+                } action: { newValue in
+                    headerTextHeight = newValue
+                }
+                Spacer()
+                MuscleGroupOccurancesChart(
+                    muscleGroupOccurances: muscleGroupService.getMuscleGroupOccurances(in: template)
+                )
+                .frame(width: headerTextHeight, height: headerTextHeight)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
             if let description = template.displayDescription {
                 Text(description)
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
-                    .padding(.top, 2)
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 
-    private var templateInfo: some View {
-        VStack(spacing: 10) {
-            HStack {
-                VStack(alignment: .leading) {
-                    Text(NSLocalizedString("exercises", comment: ""))
-                        .foregroundStyle(.secondary)
-                        .font(.footnote)
-                        .fontWeight(.semibold)
-                    Text("\(template.numberOfSetGroups)")
-                        .font(.system(.title3, design: .rounded, weight: .semibold))
-                        .foregroundColor(.primary)
+    /// The screen's primary action: start recording a workout from this template. Uses the same
+    /// recorder entry point (`startWorkout(from:)` + `presentWorkoutRecorder`) as the Start tab's
+    /// template list, so both paths behave identically.
+    private var startButton: some View {
+        Button {
+            workoutRecorder.startWorkout(from: template)
+            presentWorkoutRecorder()
+        } label: {
+            Label(NSLocalizedString("startWorkout", comment: ""), systemImage: "play.fill")
+        }
+        .buttonStyle(PrimaryButtonStyle())
+    }
+
+    /// This template's recent sessions shown as the workout detail's stat grid — volume, duration,
+    /// sets, and repetitions — each tile's bars the last few runs of the template with the newest
+    /// highlighted, so the screen answers "is this routine getting more productive?" with the same
+    /// components (and Pro gating) as the workout screen. Only shown once the template has been run.
+    @ViewBuilder
+    private var progressGrid: some View {
+        let history = WorkoutRunHistory(basis: .sameWorkout, runs: recentSessions)
+        let spacing: CGFloat = 10
+        if dynamicTypeSize.isAccessibilitySize {
+            VStack(spacing: spacing) {
+                ForEach(WorkoutStatMetric.allCases) { metric in
+                    templateStatTile(metric, history: history)
                 }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                VStack(alignment: .leading) {
-                    Text(NSLocalizedString("sets", comment: ""))
-                        .foregroundStyle(.secondary)
-                        .font(.footnote)
-                        .fontWeight(.semibold)
-                    Text("\(template.sets.count)")
-                        .font(.system(.title3, design: .rounded, weight: .semibold))
-                        .foregroundColor(.primary)
+            }
+        } else {
+            VStack(spacing: spacing) {
+                HStack(alignment: .top, spacing: spacing) {
+                    templateStatTile(.volume, history: history)
+                    templateStatTile(.duration, history: history)
                 }
-                .frame(maxWidth: .infinity, alignment: .leading)
+                HStack(alignment: .top, spacing: spacing) {
+                    templateStatTile(.sets, history: history)
+                    templateStatTile(.repetitions, history: history)
+                }
             }
         }
     }
 
-    @ViewBuilder
-    private var setsPerMuscleGroup: some View {
-        VStack(alignment: .leading, spacing: 20) {
-            let muscleGroupOccurances = muscleGroupService.getMuscleGroupOccurances(in: template)
-            HStack {
-                Text(NSLocalizedString("muscleGroups", comment: ""))
-                    .tileHeaderStyle()
-                Spacer()
-                NavigationChevron()
-                    .foregroundStyle(.tint)
-                    .rotationEffect(isMuscleGroupExpanded ? .degrees(90) : .degrees(0))
-            }
-            VStack(alignment: .leading, spacing: 20) {
-                HStack(alignment: .bottom) {
-                    VStack(alignment: .leading) {
-                        Text(NSLocalizedString("focus", comment: ""))
-                            .foregroundStyle(.secondary)
-                            .font(.footnote)
-                            .fontWeight(.semibold)
-                        HStack {
-                            ForEach(getFocusedMuscleGroups()) { muscleGroup in
-                                Text(muscleGroup.description)
-                                    .font(.title3)
-                                    .fontWeight(.bold)
-                                    .fontDesign(.rounded)
-                                    .foregroundStyle(muscleGroup.color)
-                            }
-                        }
-                    }
-                    .emptyPlaceholder(muscleGroupOccurances) {
-                        Text(NSLocalizedString("noWorkoutsThisWeek", comment: ""))
-                            .font(.body)
-                            .multilineTextAlignment(.center)
-                    }
-                    Spacer()
-                    MuscleGroupOccurancesChart(muscleGroupOccurances: muscleGroupService.getMuscleGroupOccurances(in: template))
-                        .frame(width: 70, height: 70)
-                }
-                if isMuscleGroupExpanded {
-                    VStack(spacing: CELL_SPACING) {
-                        ForEach(muscleGroupOccurances, id: \.self.0) { muscleGroupOccurance in
-                            HStack {
-                                Text(muscleGroupOccurance.0.description)
-                                    .fontWeight(.bold)
-                                    .fontDesign(.rounded)
-                                    .foregroundStyle(muscleGroupOccurance.0.color)
-                                Spacer()
-                                HStack(spacing: 10) {
-                                    VStack(alignment: .leading) {
-                                        Text(NSLocalizedString("exercises", comment: ""))
-                                            .font(.caption)
-                                            .foregroundStyle(.secondary)
-                                        Text("\(template.setGroups.filter { $0.muscleGroups.contains(where: { $0 == muscleGroupOccurance.0 }) }.count)")
-                                            .fontWeight(.bold)
-                                            .fontDesign(.rounded)
-                                    }
-                                    Divider()
-                                    VStack(alignment: .leading) {
-                                        Text(NSLocalizedString("sets", comment: ""))
-                                            .font(.caption)
-                                            .foregroundStyle(.secondary)
-                                        Text("\(template.sets.filter { $0.setGroup?.muscleGroups.contains(where: { $0 == muscleGroupOccurance.0 }) ?? false }.count)")
-                                            .fontWeight(.bold)
-                                            .fontDesign(.rounded)
-                                    }
-                                }
-                            }
-
-                            .padding(CELL_PADDING)
-                            .secondaryTileStyle(backgroundColor: muscleGroupOccurance.0.color.secondaryTranslucentBackground)
-                        }
-                    }
-                }
-            }
-            .isBlockedWithoutPro()
+    /// One session-stat tile: the latest session's value, the trend versus the previous session, and
+    /// the per-session bars — assembled from the shared `MetricTile` + `WorkoutRunsBarChart` the
+    /// workout detail uses, so the two can't drift. Duration stays neutral gray (a longer session is
+    /// neither better nor worse); the rest wear the template's muscle-group tint. No subtitle — the
+    /// screen title and section already say these are this template's sessions.
+    private func templateStatTile(_ metric: WorkoutStatMetric, history: WorkoutRunHistory) -> some View {
+        let latest = history.runs.last
+        let raw = latest.map { metric.rawValue(of: $0) } ?? 0
+        let isDuration = metric == .duration
+        let accent: AnyShapeStyle = isDuration
+            ? AnyShapeStyle(Color.secondary)
+            : (latest?.sets.muscleGroupGradientStyle(startPoint: .bottomLeading, endPoint: .topTrailing)
+                ?? AnyShapeStyle(dominantMuscleColor.gradient))
+        let barStyle: AnyShapeStyle = isDuration
+            ? AnyShapeStyle(Color.secondary)
+            : (latest?.sets.muscleGroupGradientStyle(startPoint: .bottom, endPoint: .top)
+                ?? AnyShapeStyle(dominantMuscleColor.gradient))
+        return MetricTile(
+            title: metric.title,
+            showsChevron: false,
+            label: .none,
+            value: raw > 0 ? metric.formattedValue(fromRaw: raw) : nil,
+            unit: metric.unit,
+            accent: accent,
+            accentColor: isDuration ? .secondary : dominantMuscleColor,
+            percentChange: history.percentChange(for: metric),
+            requiresPro: metric.requiresPro,
+            chartBleeds: false
+        ) {
+            WorkoutRunsBarChart(bars: runBars(for: metric, history: history), currentStyle: barStyle)
         }
-        .contentShape(Rectangle())
-        .onTapGesture {
-            withAnimation {
-                isMuscleGroupExpanded.toggle()
-            }
+    }
+
+    /// Right-aligned into the chart's fixed five slots, newest run last — the template-side twin of
+    /// `WorkoutStatTile.runBars`.
+    private func runBars(for metric: WorkoutStatMetric, history: WorkoutRunHistory) -> [WorkoutRunsBarChart.Bar] {
+        let offset = WorkoutRunsBarChart.slotCount - history.runs.count
+        let latestID = history.runs.last?.objectID
+        return history.runs.enumerated().map { index, run in
+            WorkoutRunsBarChart.Bar(
+                slot: offset + index,
+                value: metric.displayValue(fromRaw: metric.rawValue(of: run)),
+                isCurrent: run.objectID == latestID
+            )
         }
     }
 
@@ -302,7 +295,7 @@ struct TemplateDetailScreen: View {
     }
 
     private var workoutList: some View {
-        ForEach(template.workouts, id: \.objectID) { workout in
+        ForEach(pastWorkouts, id: \.objectID) { workout in
             Button {
                 selectedWorkout = workout
             } label: {
@@ -310,35 +303,36 @@ struct TemplateDetailScreen: View {
             }
             .buttonStyle(TileButtonStyle())
         }
-        .emptyPlaceholder(template.workouts) {
+        .emptyPlaceholder(pastWorkouts) {
             Text(NSLocalizedString("templateNeverUsed", comment: ""))
         }
     }
 
     // MARK: - Computed Properties
 
-    private var lastUsedDateString: String {
-        template.workouts.first?.date?.description(.medium)
-            ?? NSLocalizedString("never", comment: "")
+    /// This template's completed sessions, newest first — the "History" list. The in-progress
+    /// workout (if one was just started from here) is excluded so it doesn't masquerade as history.
+    private var pastWorkouts: [Workout] {
+        Array(template.workouts.filter { !$0.isCurrentWorkout }.reversed())
     }
 
-    private var amountOfOccurances: Int {
-        muscleGroupService.getMuscleGroupOccurances(in: template).reduce(0) { $0 + $1.1 }
+    /// The last few real sessions of this template, oldest → newest, that feed the progress bars.
+    private var recentSessions: [Workout] {
+        Array(
+            template.workouts
+                .filter { !$0.isEmpty && !$0.isCurrentWorkout }
+                .suffix(WorkoutRunsBarChart.slotCount)
+        )
     }
 
-    /// Calculates the smallest number of Muscle Groups that combined account for 51% of the overall sets in the timeframe
-    /// - Returns: The focused Muscle Groups
-    private func getFocusedMuscleGroups() -> [MuscleGroup] {
-        var accumulatedPercetange: Float = 0
-        var focusedMuscleGroups = [MuscleGroup]()
-        for muscleGroupOccurance in muscleGroupService.getMuscleGroupOccurances(in: template) {
-            accumulatedPercetange += Float(muscleGroupOccurance.1) / Float(amountOfOccurances)
-            focusedMuscleGroups.append(muscleGroupOccurance.0)
-            if accumulatedPercetange > 0.51 {
-                return Array(focusedMuscleGroups.prefix(2))
-            }
-        }
-        return []
+    private var hasSessions: Bool {
+        !recentSessions.isEmpty
+    }
+
+    /// The template's most-trained muscle group's color — the flat tint behind the tiles' pills and
+    /// the fallback when a session has no muscle-group gradient.
+    private var dominantMuscleColor: Color {
+        muscleGroupService.getMuscleGroupOccurances(in: template).first?.0.color ?? .accentColor
     }
 }
 

--- a/LOGIT/Features/Template/TemplateListScreen.swift
+++ b/LOGIT/Features/Template/TemplateListScreen.swift
@@ -74,15 +74,9 @@ struct TemplateListScreen: View {
                                         selectedTemplate = template
                                     }
                                 } label: {
-                                    VStack {
-                                        HStack {
-                                            TemplateCell(template: template)
-                                            NavigationChevron()
-                                                .foregroundStyle(.secondary)
-                                        }
-                                    }
-                                    .padding(CELL_PADDING)
-                                    .tileStyle()
+                                    TemplateCell(template: template)
+                                        .padding(CELL_PADDING)
+                                        .tileStyle()
                                 }
                                 .buttonStyle(TileButtonStyle())
                             }
@@ -106,15 +100,9 @@ struct TemplateListScreen: View {
                                             selectedTemplate = template
                                         }
                                     } label: {
-                                        VStack {
-                                            HStack {
-                                                TemplateCell(template: template)
-                                                NavigationChevron()
-                                                    .foregroundStyle(.secondary)
-                                            }
-                                        }
-                                        .padding(CELL_PADDING)
-                                        .tileStyle()
+                                        TemplateCell(template: template)
+                                            .padding(CELL_PADDING)
+                                            .tileStyle()
                                     }
                                     .buttonStyle(TileButtonStyle())
                                 }


### PR DESCRIPTION
The template detail was the last screen still on the old layout. This brings it into the workout detail's family, and reworks the list cell to match `WorkoutCell`.

## Detail screen
- Muscle-group **donut moved into the header** (sized to the title, the `workoutHeader` pattern); the standalone muscle-split tile is gone.
- **Start Workout** primary button that records **straight from this template** (`startWorkout(from:)` + `presentWorkoutRecorder()`) — no start-options sheet.
- **Progress grid** (volume / duration / sets / reps) built from the workout detail's own `MetricTile` + `WorkoutRunsBarChart`, so the two can't drift. Volume stays **Pro-gated**. Shown only once the template has been used.
- **"Last Used" → "History"** (linked sessions, newest first, in-progress run excluded).

## List cell
- Leads with **recency** ("Last used …" / "Never") and a contents summary, donut moved right, kept **flat/gradient-free** so a plan still reads quieter than a session.
- External chevron dropped from the list & search rows.

No new localization keys (reuses `history` / `never` / `lastUsed` / `startWorkout` + the system relative date).

## Verification
Captured on the iOS 26 simulator across empty / one / many / free scenarios. The Start button was driven in a UI test: it opens the recorder **populated from the template** with **no intermediate start-options sheet**. Two deliberate v1 calls: the stat tiles aren't tappable, and History counts sessions linked to the template only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)