### PR TITLE
Apple Health sync: write finished workouts to HealthKit + history backfill

### DIFF
--- a/LOGIT.xcodeproj/project.pbxproj
+++ b/LOGIT.xcodeproj/project.pbxproj
@@ -8,21 +8,16 @@
 
 /* Begin PBXBuildFile section */
 		07A5D2C54CA81141164E3D9D /* MuscleGroupsOverviewScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54FB7DD2DDA0DE70BD366F9C /* MuscleGroupsOverviewScreen.swift */; };
+		09A688DA944843286D5190DB /* HealthKitSyncManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E740E99321E2590B08B80A0 /* HealthKitSyncManager.swift */; };
 		10F53DA7818380C706F42B20 /* WorkoutLiveActivityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06A7CD832F8CF2FDAB33579C /* WorkoutLiveActivityManager.swift */; };
 		18F8886F2E06B3DCB04A2002 /* LOGITWidgetExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 79D10973BCE1A0618D3256CD /* LOGITWidgetExtension.appex */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		1E7CF1C1E77503BD192ECE23 /* WorkoutGoalScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA376FF1C58639B7542A334 /* WorkoutGoalScreen.swift */; };
 		2333D8B12B944AD1A27D0E0A /* SetEntityClasses.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD50531C168D4EDFB527D76A /* SetEntityClasses.swift */; };
-		80SE00112F70CC0100SE0011 /* SetEntryFieldsRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80SE00122F70CC0100SE0012 /* SetEntryFieldsRow.swift */; };
-		80SE00012F70CC0100SE0001 /* SetMeasurementType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80SE00022F70CC0100SE0002 /* SetMeasurementType.swift */; };
-		80SE00032F70CC0100SE0003 /* SetEntry+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80SE00042F70CC0100SE0004 /* SetEntry+.swift */; };
-		80SE00052F70CC0100SE0005 /* TemplateSetEntry+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80SE00062F70CC0100SE0006 /* TemplateSetEntry+.swift */; };
-		80SE00072F70CC0100SE0007 /* Database+SetEntryBackfill.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80SE00082F70CC0100SE0008 /* Database+SetEntryBackfill.swift */; };
 		23A5FD0EA5AC115CC0EC34E6 /* SummaryRecords.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADFEC5772AE8932AA1089603 /* SummaryRecords.swift */; };
 		268525E87C3944BA9208D129 /* TrendIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D5D5995AEAE4AA8849AAF28 /* TrendIndicatorView.swift */; };
 		28E43ABE4881F802FBBACCE9 /* RangePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F685CCE0EE8FE86E8E0135C /* RangePicker.swift */; };
 		2A384BE3816900000002 /* ExerciseSuggestionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54EE2592821500000001 /* ExerciseSuggestionService.swift */; };
 		2BD2E4720FB2C657F8CA372B /* CompletionRing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C72085C4C10146858277690 /* CompletionRing.swift */; };
-		9870C5C11EC204B609726272 /* SwipeableMonthView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79EEE8722792E15D71C22DA3 /* SwipeableMonthView.swift */; };
 		34ED649B10150341352AE3D1 /* StatPeriodTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F8CD271000D75928FAE0887 /* StatPeriodTests.swift */; };
 		396ADE67CD8C1D14F7A8D82A /* LOGITWidgetExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3BDDD14FE5BF0C275AF30C5 /* LOGITWidgetExtension.swift */; };
 		435F070826CC8D1F8D7239B8 /* WorkoutDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4845CEF582EB23AB447C90B2 /* WorkoutDTO.swift */; };
@@ -37,11 +32,7 @@
 		781060648530454E63B22EB3 /* WorkoutSharingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EB3B92BF7A5E9FE9E442716 /* WorkoutSharingService.swift */; };
 		7907FDEA289E99B1006AF271 /* CloudKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7907FDE9289E99B1006AF271 /* CloudKit.framework */; };
 		791347B62AE2BEB100D20BB7 /* MarkdownUI in Frameworks */ = {isa = PBXBuildFile; productRef = 791347B52AE2BEB100D20BB7 /* MarkdownUI */; };
-		80AB10032F15AA0100AB1003 /* Transmission in Frameworks */ = {isa = PBXBuildFile; productRef = 80AB10022F15AA0100AB1002 /* Transmission */; };
-		80AB10052F15AA0100AB1005 /* RecorderPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80AB10042F15AA0100AB1004 /* RecorderPresentation.swift */; };
 		792A3FF32AB478F000C6A097 /* DatabaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792A3FF22AB478F000C6A097 /* DatabaseTests.swift */; };
-		80SE000C2F70CC0100SE000C /* SetEntryMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80SE00092F70CC0100SE0009 /* SetEntryMigrationTests.swift */; };
-		80SE000D2F70CC0100SE000D /* LOGIT-v7-legacy.sqlite in Resources */ = {isa = PBXBuildFile; fileRef = 80SE000A2F70CC0100SE000A /* LOGIT-v7-legacy.sqlite */; };
 		794A8E5D2ACC211D006087EA /* TemplateServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 794A8E5C2ACC211D006087EA /* TemplateServiceTests.swift */; };
 		794A8E602ACC2184006087EA /* athleanx_total_body_A.jpeg in Resources */ = {isa = PBXBuildFile; fileRef = 794A8E5F2ACC2184006087EA /* athleanx_total_body_A.jpeg */; };
 		795767812AE706DB0040E327 /* Camera-SwiftUI in Frameworks */ = {isa = PBXBuildFile; productRef = 795767802AE706DB0040E327 /* Camera-SwiftUI */; };
@@ -86,7 +77,6 @@
 		801BBD802DF7338A00CDB1FB /* TileStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBD4C2DF7338A00CDB1FB /* TileStyle.swift */; };
 		801BBD812DF7338A00CDB1FB /* ExerciseWeightScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBCF22DF7338A00CDB1FB /* ExerciseWeightScreen.swift */; };
 		801BBD822DF7338A00CDB1FB /* ExerciseRepetitionsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBCF02DF7338A00CDB1FB /* ExerciseRepetitionsScreen.swift */; };
-		80DU00042F70CC0100DU0004 /* ExerciseDurationScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80DU00032F70CC0100DU0003 /* ExerciseDurationScreen.swift */; };
 		801BBD832DF7338A00CDB1FB /* Secrets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBC9F2DF7338A00CDB1FB /* Secrets.swift */; };
 		801BBD842DF7338A00CDB1FB /* LogitProLogo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBD532DF7338A00CDB1FB /* LogitProLogo.swift */; };
 		801BBD852DF7338A00CDB1FB /* StopwatchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBD202DF7338A00CDB1FB /* StopwatchView.swift */; };
@@ -171,7 +161,6 @@
 		801BBDE42DF7338A00CDB1FB /* NoDataPlaceholderModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBD3E2DF7338A00CDB1FB /* NoDataPlaceholderModifier.swift */; };
 		801BBDE52DF7338A00CDB1FB /* WeightConverting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBCBF2DF7338A00CDB1FB /* WeightConverting.swift */; };
 		801BBDE62DF7338A00CDB1FB /* ExerciseRepetitionsTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBCEA2DF7338A00CDB1FB /* ExerciseRepetitionsTile.swift */; };
-		80DU00022F70CC0100DU0002 /* ExerciseDurationTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80DU00012F70CC0100DU0001 /* ExerciseDurationTile.swift */; };
 		801BBDE72DF7338A00CDB1FB /* UIConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBCAB2DF7338A00CDB1FB /* UIConstants.swift */; };
 		801BBDE82DF7338A00CDB1FB /* ExerciseHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBD4F2DF7338A00CDB1FB /* ExerciseHeader.swift */; };
 		801BBDE92DF7338A00CDB1FB /* UIScreen+ScreenCorners.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBCB42DF7338A00CDB1FB /* UIScreen+ScreenCorners.swift */; };
@@ -215,12 +204,16 @@
 		80AA10012F5CAA0200AA1001 /* DeterministicUUID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80AA10022F5CAA0200AA1002 /* DeterministicUUID.swift */; };
 		80AA10032F5CAA0200AA1003 /* DefaultTemplateService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80AA10042F5CAA0200AA1004 /* DefaultTemplateService.swift */; };
 		80AA10052F5CAA0200AA1005 /* default_templates.json in Resources */ = {isa = PBXBuildFile; fileRef = 80AA10062F5CAA0200AA1006 /* default_templates.json */; };
+		80AB10032F15AA0100AB1003 /* Transmission in Frameworks */ = {isa = PBXBuildFile; productRef = 80AB10022F15AA0100AB1002 /* Transmission */; };
+		80AB10052F15AA0100AB1005 /* RecorderPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80AB10042F15AA0100AB1004 /* RecorderPresentation.swift */; };
 		80B387BB2EBA187100AD7EFC /* DecimalField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80B387BA2EBA187100AD7EFC /* DecimalField.swift */; };
 		80BEEP012EF0000000000001 /* beep.wav in Resources */ = {isa = PBXBuildFile; fileRef = 80BEEP022EF0000000000001 /* beep.wav */; };
 		80C2B98F2EC9362A00118FE2 /* ColorfulX in Frameworks */ = {isa = PBXBuildFile; productRef = 80C2B98E2EC9362A00118FE2 /* ColorfulX */; };
 		80CBE1D52ED7AFD500DDE1C5 /* MeasurementsEditSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80CBE1D32ED7AFD500DDE1C5 /* MeasurementsEditSheet.swift */; };
 		80CBE1D62ED7AFD500DDE1C5 /* MeasurementDetailScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80CBE1D22ED7AFD500DDE1C5 /* MeasurementDetailScreen.swift */; };
 		80CBE1D72ED7AFD500DDE1C5 /* MeasurementTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80CBE1D42ED7AFD500DDE1C5 /* MeasurementTile.swift */; };
+		80DU00022F70CC0100DU0002 /* ExerciseDurationTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80DU00012F70CC0100DU0001 /* ExerciseDurationTile.swift */; };
+		80DU00042F70CC0100DU0004 /* ExerciseDurationScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80DU00032F70CC0100DU0003 /* ExerciseDurationScreen.swift */; };
 		80NEWSHAR001 /* WorkoutActivityItemSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80NEWSHAR002 /* WorkoutActivityItemSource.swift */; };
 		80NEWTEST001 /* TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80NEWTEST002 /* TestHelpers.swift */; };
 		80NEWTEST003 /* WeightConvertingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80NEWTEST004 /* WeightConvertingTests.swift */; };
@@ -228,6 +221,13 @@
 		80NEWTEST007 /* EntityExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80NEWTEST008 /* EntityExtensionTests.swift */; };
 		80NEWTEST009 /* ServicesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80NEWTEST00A /* ServicesTests.swift */; };
 		80NEWTEST00B /* WorkoutSharingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80NEWTEST00C /* WorkoutSharingTests.swift */; };
+		80SE00012F70CC0100SE0001 /* SetMeasurementType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80SE00022F70CC0100SE0002 /* SetMeasurementType.swift */; };
+		80SE00032F70CC0100SE0003 /* SetEntry+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80SE00042F70CC0100SE0004 /* SetEntry+.swift */; };
+		80SE00052F70CC0100SE0005 /* TemplateSetEntry+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80SE00062F70CC0100SE0006 /* TemplateSetEntry+.swift */; };
+		80SE00072F70CC0100SE0007 /* Database+SetEntryBackfill.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80SE00082F70CC0100SE0008 /* Database+SetEntryBackfill.swift */; };
+		80SE000C2F70CC0100SE000C /* SetEntryMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80SE00092F70CC0100SE0009 /* SetEntryMigrationTests.swift */; };
+		80SE000D2F70CC0100SE000D /* LOGIT-v7-legacy.sqlite in Resources */ = {isa = PBXBuildFile; fileRef = 80SE000A2F70CC0100SE000A /* LOGIT-v7-legacy.sqlite */; };
+		80SE00112F70CC0100SE0011 /* SetEntryFieldsRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80SE00122F70CC0100SE0012 /* SetEntryFieldsRow.swift */; };
 		85709CDA5A20D6B7D9C23487 /* ExerciseMergeServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF956F5D14BBB78133BD528A /* ExerciseMergeServiceTests.swift */; };
 		85D5027D8B1FA8DB36998EBC /* SummaryStatScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE557E27ADC9A2C02BE79DBE /* SummaryStatScreen.swift */; };
 		898FDFC3AC4FF171A0E6C549 /* WorkoutLiveActivityAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 829F12D41C231764936B6B83 /* WorkoutLiveActivityAttributes.swift */; };
@@ -236,6 +236,7 @@
 		8E306606440725A568FE5F1A /* ExerciseMergeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF0CFD6EDA94DA1792A2CA82 /* ExerciseMergeService.swift */; };
 		8F4A3C022E5A9B0100D4E5F2 /* SetVolumeBarChart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F4A3C012E5A9B0100D4E5F1 /* SetVolumeBarChart.swift */; };
 		9392C43C9501E6676A02488A /* WorkoutLiveActivitySnapshotBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B6F634C95B552C305EA0055 /* WorkoutLiveActivitySnapshotBuilder.swift */; };
+		9870C5C11EC204B609726272 /* SwipeableMonthView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79EEE8722792E15D71C22DA3 /* SwipeableMonthView.swift */; };
 		99A5C6A814E6BD98F45BDFF1 /* CapabilityChartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BEA94B4E4E01D1D9185359 /* CapabilityChartView.swift */; };
 		9C03B11C8A034786C5544D2E /* ScreenshotFixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = C05F3FE01CADB8E0526C799F /* ScreenshotFixtures.swift */; };
 		9D2E7A022F30AA0100C1D2E2 /* DemoWorkoutSeeder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D2E7A012F30AA0100C1D2E1 /* DemoWorkoutSeeder.swift */; };
@@ -361,7 +362,6 @@
 		3184F4CAAB24791B6F5AC79A /* SharedWithYouBanner.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SharedWithYouBanner.swift; sourceTree = "<group>"; };
 		336772BB4E860E3894BA7355 /* SummaryStatTiles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryStatTiles.swift; sourceTree = "<group>"; };
 		3C72085C4C10146858277690 /* CompletionRing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionRing.swift; sourceTree = "<group>"; };
-		79EEE8722792E15D71C22DA3 /* SwipeableMonthView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwipeableMonthView.swift; sourceTree = "<group>"; };
 		3CDACB5BDD447438F8D60BAE /* LOGITScreenshots.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LOGITScreenshots.swift; sourceTree = "<group>"; };
 		4845CEF582EB23AB447C90B2 /* WorkoutDTO.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkoutDTO.swift; sourceTree = "<group>"; };
 		4B6F634C95B552C305EA0055 /* WorkoutLiveActivitySnapshotBuilder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkoutLiveActivitySnapshotBuilder.swift; sourceTree = "<group>"; };
@@ -374,9 +374,6 @@
 		6923C33A92504E5287236332 /* OneRepMaxCalculating.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OneRepMaxCalculating.swift; sourceTree = "<group>"; };
 		7907FDE9289E99B1006AF271 /* CloudKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CloudKit.framework; path = System/Library/Frameworks/CloudKit.framework; sourceTree = SDKROOT; };
 		792A3FF22AB478F000C6A097 /* DatabaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseTests.swift; sourceTree = "<group>"; };
-		80SE00092F70CC0100SE0009 /* SetEntryMigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetEntryMigrationTests.swift; sourceTree = "<group>"; };
-		80SE000A2F70CC0100SE000A /* LOGIT-v7-legacy.sqlite */ = {isa = PBXFileReference; lastKnownFileType = file; path = "LOGIT-v7-legacy.sqlite"; sourceTree = "<group>"; };
-		80SE000B2F70CC0100SE000B /* make_v7_fixture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = make_v7_fixture.swift; sourceTree = "<group>"; };
 		792D522B27F1160800B08813 /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
 		794A8E5C2ACC211D006087EA /* TemplateServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateServiceTests.swift; sourceTree = "<group>"; };
 		794A8E5F2ACC2184006087EA /* athleanx_total_body_A.jpeg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = athleanx_total_body_A.jpeg; sourceTree = "<group>"; };
@@ -385,6 +382,7 @@
 		79D10973BCE1A0618D3256CD /* LOGITWidgetExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = LOGITWidgetExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		79E849072A7EA28000C0DF95 /* LOGITTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LOGITTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		79E849092A7EA28000C0DF95 /* ExerciseServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseServiceTests.swift; sourceTree = "<group>"; };
+		79EEE8722792E15D71C22DA3 /* SwipeableMonthView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwipeableMonthView.swift; sourceTree = "<group>"; };
 		7F8CD271000D75928FAE0887 /* StatPeriodTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatPeriodTests.swift; sourceTree = "<group>"; };
 		80036CDA2EFEF98C00B7C7B4 /* GlobalSearchScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalSearchScreen.swift; sourceTree = "<group>"; };
 		80036CDD2EFEF9CE00B7C7B4 /* FuzzySearchService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FuzzySearchService.swift; sourceTree = "<group>"; };
@@ -455,13 +453,11 @@
 		801BBCE52DF7338A00CDB1FB /* WorkoutSetGroupPredicateFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutSetGroupPredicateFactory.swift; sourceTree = "<group>"; };
 		801BBCE62DF7338A00CDB1FB /* WorkoutSetPredicateFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutSetPredicateFactory.swift; sourceTree = "<group>"; };
 		801BBCEA2DF7338A00CDB1FB /* ExerciseRepetitionsTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseRepetitionsTile.swift; sourceTree = "<group>"; };
-		80DU00012F70CC0100DU0001 /* ExerciseDurationTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseDurationTile.swift; sourceTree = "<group>"; };
 		801BBCEB2DF7338A00CDB1FB /* ExerciseVolumeTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseVolumeTile.swift; sourceTree = "<group>"; };
 		801BBCEC2DF7338A00CDB1FB /* ExerciseWeightTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseWeightTile.swift; sourceTree = "<group>"; };
 		801BBCEE2DF7338A00CDB1FB /* ExerciseDetailScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseDetailScreen.swift; sourceTree = "<group>"; };
 		801BBCEF2DF7338A00CDB1FB /* ExerciseHistoryScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseHistoryScreen.swift; sourceTree = "<group>"; };
 		801BBCF02DF7338A00CDB1FB /* ExerciseRepetitionsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseRepetitionsScreen.swift; sourceTree = "<group>"; };
-		80DU00032F70CC0100DU0003 /* ExerciseDurationScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseDurationScreen.swift; sourceTree = "<group>"; };
 		801BBCF12DF7338A00CDB1FB /* ExerciseVolumeScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseVolumeScreen.swift; sourceTree = "<group>"; };
 		801BBCF22DF7338A00CDB1FB /* ExerciseWeightScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseWeightScreen.swift; sourceTree = "<group>"; };
 		801BBCF42DF7338A00CDB1FB /* ExerciseCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseCell.swift; sourceTree = "<group>"; };
@@ -505,7 +501,6 @@
 		801BBD382DF7338A00CDB1FB /* PieGraph.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PieGraph.swift; sourceTree = "<group>"; };
 		801BBD3A2DF7338A00CDB1FB /* BlockedWithoutProModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockedWithoutProModifier.swift; sourceTree = "<group>"; };
 		801BBD3B2DF7338A00CDB1FB /* CanEditModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanEditModifier.swift; sourceTree = "<group>"; };
-		80AB10042F15AA0100AB1004 /* RecorderPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecorderPresentation.swift; sourceTree = "<group>"; };
 		801BBD3D2DF7338A00CDB1FB /* EmptyPlaceholderModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyPlaceholderModifier.swift; sourceTree = "<group>"; };
 		801BBD3E2DF7338A00CDB1FB /* NoDataPlaceholderModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoDataPlaceholderModifier.swift; sourceTree = "<group>"; };
 		801BBD3F2DF7338A00CDB1FB /* OnDeleteModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnDeleteModifier.swift; sourceTree = "<group>"; };
@@ -559,12 +554,15 @@
 		80AA10022F5CAA0200AA1002 /* DeterministicUUID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeterministicUUID.swift; sourceTree = "<group>"; };
 		80AA10042F5CAA0200AA1004 /* DefaultTemplateService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultTemplateService.swift; sourceTree = "<group>"; };
 		80AA10062F5CAA0200AA1006 /* default_templates.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = default_templates.json; sourceTree = "<group>"; };
+		80AB10042F15AA0100AB1004 /* RecorderPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecorderPresentation.swift; sourceTree = "<group>"; };
 		80B387BA2EBA187100AD7EFC /* DecimalField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecimalField.swift; sourceTree = "<group>"; };
 		80BEEP022EF0000000000001 /* beep.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = beep.wav; sourceTree = "<group>"; };
 		80C7068F531DB65831E8FA8F /* MuscleTargetSplitScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MuscleTargetSplitScreen.swift; sourceTree = "<group>"; };
 		80CBE1D22ED7AFD500DDE1C5 /* MeasurementDetailScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeasurementDetailScreen.swift; sourceTree = "<group>"; };
 		80CBE1D32ED7AFD500DDE1C5 /* MeasurementsEditSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeasurementsEditSheet.swift; sourceTree = "<group>"; };
 		80CBE1D42ED7AFD500DDE1C5 /* MeasurementTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeasurementTile.swift; sourceTree = "<group>"; };
+		80DU00012F70CC0100DU0001 /* ExerciseDurationTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseDurationTile.swift; sourceTree = "<group>"; };
+		80DU00032F70CC0100DU0003 /* ExerciseDurationScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseDurationScreen.swift; sourceTree = "<group>"; };
 		80NEWSHAR002 /* WorkoutActivityItemSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutActivityItemSource.swift; sourceTree = "<group>"; };
 		80NEWTEST002 /* TestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestHelpers.swift; sourceTree = "<group>"; };
 		80NEWTEST004 /* WeightConvertingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeightConvertingTests.swift; sourceTree = "<group>"; };
@@ -572,9 +570,18 @@
 		80NEWTEST008 /* EntityExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntityExtensionTests.swift; sourceTree = "<group>"; };
 		80NEWTEST00A /* ServicesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServicesTests.swift; sourceTree = "<group>"; };
 		80NEWTEST00C /* WorkoutSharingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutSharingTests.swift; sourceTree = "<group>"; };
+		80SE00022F70CC0100SE0002 /* SetMeasurementType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetMeasurementType.swift; sourceTree = "<group>"; };
+		80SE00042F70CC0100SE0004 /* SetEntry+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SetEntry+.swift"; sourceTree = "<group>"; };
+		80SE00062F70CC0100SE0006 /* TemplateSetEntry+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TemplateSetEntry+.swift"; sourceTree = "<group>"; };
+		80SE00082F70CC0100SE0008 /* Database+SetEntryBackfill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Database+SetEntryBackfill.swift"; sourceTree = "<group>"; };
+		80SE00092F70CC0100SE0009 /* SetEntryMigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetEntryMigrationTests.swift; sourceTree = "<group>"; };
+		80SE000A2F70CC0100SE000A /* LOGIT-v7-legacy.sqlite */ = {isa = PBXFileReference; lastKnownFileType = file; path = "LOGIT-v7-legacy.sqlite"; sourceTree = "<group>"; };
+		80SE000B2F70CC0100SE000B /* make_v7_fixture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = make_v7_fixture.swift; sourceTree = "<group>"; };
+		80SE00122F70CC0100SE0012 /* SetEntryFieldsRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetEntryFieldsRow.swift; sourceTree = "<group>"; };
 		829F12D41C231764936B6B83 /* WorkoutLiveActivityAttributes.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkoutLiveActivityAttributes.swift; sourceTree = "<group>"; };
 		8571CBB4B50589F1F8F36F44 /* StatPeriod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatPeriod.swift; sourceTree = "<group>"; };
 		8BA376FF1C58639B7542A334 /* WorkoutGoalScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutGoalScreen.swift; sourceTree = "<group>"; };
+		8E740E99321E2590B08B80A0 /* HealthKitSyncManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HealthKitSyncManager.swift; sourceTree = "<group>"; };
 		8F4A3C012E5A9B0100D4E5F1 /* SetVolumeBarChart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetVolumeBarChart.swift; sourceTree = "<group>"; };
 		9D2E7A012F30AA0100C1D2E1 /* DemoWorkoutSeeder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DemoWorkoutSeeder.swift; sourceTree = "<group>"; };
 		A10000000000000000000002 /* LocalizedMarkdown.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizedMarkdown.swift; sourceTree = "<group>"; };
@@ -617,11 +624,6 @@
 		D1D1D1000000000000000F01 /* MetricTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetricTile.swift; sourceTree = "<group>"; };
 		DC42311A655A248061E11238 /* SummaryEmptyStates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryEmptyStates.swift; sourceTree = "<group>"; };
 		DD50531C168D4EDFB527D76A /* SetEntityClasses.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetEntityClasses.swift; sourceTree = "<group>"; };
-		80SE00122F70CC0100SE0012 /* SetEntryFieldsRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetEntryFieldsRow.swift; sourceTree = "<group>"; };
-		80SE00022F70CC0100SE0002 /* SetMeasurementType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SetMeasurementType.swift"; sourceTree = "<group>"; };
-		80SE00042F70CC0100SE0004 /* SetEntry+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SetEntry+.swift"; sourceTree = "<group>"; };
-		80SE00062F70CC0100SE0006 /* TemplateSetEntry+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TemplateSetEntry+.swift"; sourceTree = "<group>"; };
-		80SE00082F70CC0100SE0008 /* Database+SetEntryBackfill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Database+SetEntryBackfill.swift"; sourceTree = "<group>"; };
 		DD6EBE9FCA104B46ACA995DE /* ScenarioScreenshots.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ScenarioScreenshots.swift; sourceTree = "<group>"; };
 		DE557E27ADC9A2C02BE79DBE /* SummaryStatScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryStatScreen.swift; sourceTree = "<group>"; };
 		E1E1E1000000000000000F01 /* ExerciseE1RMTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseE1RMTile.swift; sourceTree = "<group>"; };
@@ -735,15 +737,6 @@
 				794A8E5F2ACC2184006087EA /* athleanx_total_body_A.jpeg */,
 			);
 			path = WorkoutImages;
-			sourceTree = "<group>";
-		};
-		80SE000E2F70CC0100SE000E /* Fixtures */ = {
-			isa = PBXGroup;
-			children = (
-				80SE000A2F70CC0100SE000A /* LOGIT-v7-legacy.sqlite */,
-				80SE000B2F70CC0100SE000B /* make_v7_fixture.swift */,
-			);
-			path = Fixtures;
 			sourceTree = "<group>";
 		};
 		79E849082A7EA28000C0DF95 /* LOGITTests */ = {
@@ -890,6 +883,7 @@
 				801BBCBE2DF7338A00CDB1FB /* VolumeCalculating.swift */,
 				6923C33A92504E5287236332 /* OneRepMaxCalculating.swift */,
 				801BBCBF2DF7338A00CDB1FB /* WeightConverting.swift */,
+				8E740E99321E2590B08B80A0 /* HealthKitSyncManager.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -1353,6 +1347,15 @@
 				80AA10062F5CAA0200AA1006 /* default_templates.json */,
 			);
 			path = Resources;
+			sourceTree = "<group>";
+		};
+		80SE000E2F70CC0100SE000E /* Fixtures */ = {
+			isa = PBXGroup;
+			children = (
+				80SE000A2F70CC0100SE000A /* LOGIT-v7-legacy.sqlite */,
+				80SE000B2F70CC0100SE000B /* make_v7_fixture.swift */,
+			);
+			path = Fixtures;
 			sourceTree = "<group>";
 		};
 		EA52A20BCC1C70E881C6C5C2 /* LOGITWidgetExtension */ = {
@@ -1837,6 +1840,7 @@
 				5F6C92E180BAAEC435086790 /* PeriodHistoryChart.swift in Sources */,
 				A10F7CBC23FBD8F36CC4A1D6 /* TestScenarios.swift in Sources */,
 				99A5C6A814E6BD98F45BDFF1 /* CapabilityChartView.swift in Sources */,
+				09A688DA944843286D5190DB /* HealthKitSyncManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2288,20 +2292,20 @@
 				kind = branch;
 			};
 		};
-		80C2B98D2EC9362A00118FE2 /* XCRemoteSwiftPackageReference "ColorfulX" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/Lakr233/ColorfulX.git";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 6.0.1;
-			};
-		};
 		80AB10012F15AA0100AB1001 /* XCRemoteSwiftPackageReference "Transmission" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/nathantannar4/Transmission";
 			requirement = {
 				kind = upToNextMajorVersion;
 				minimumVersion = 2.9.3;
+			};
+		};
+		80C2B98D2EC9362A00118FE2 /* XCRemoteSwiftPackageReference "ColorfulX" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Lakr233/ColorfulX.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 6.0.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
@@ -2327,15 +2331,15 @@
 			package = 80036CDF2EFEFFD100B7C7B4 /* XCRemoteSwiftPackageReference "Ifrit" */;
 			productName = Ifrit;
 		};
-		80C2B98E2EC9362A00118FE2 /* ColorfulX */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 80C2B98D2EC9362A00118FE2 /* XCRemoteSwiftPackageReference "ColorfulX" */;
-			productName = ColorfulX;
-		};
 		80AB10022F15AA0100AB1002 /* Transmission */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 80AB10012F15AA0100AB1001 /* XCRemoteSwiftPackageReference "Transmission" */;
 			productName = Transmission;
+		};
+		80C2B98E2EC9362A00118FE2 /* ColorfulX */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 80C2B98D2EC9362A00118FE2 /* XCRemoteSwiftPackageReference "ColorfulX" */;
+			productName = ColorfulX;
 		};
 /* End XCSwiftPackageProductDependency section */
 

--- a/LOGIT/App/Info.plist
+++ b/LOGIT/App/Info.plist
@@ -92,6 +92,8 @@
 	<true/>
 	<key>NSCameraUsageDescription</key>
 	<string>We need access to the camera to scan workouts.</string>
+	<key>NSHealthUpdateUsageDescription</key>
+	<string>LOGIT saves your finished workouts to Apple Health so they appear alongside your other activity.</string>
 	<key>NSSupportsLiveActivities</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>

--- a/LOGIT/App/LOGIT.entitlements
+++ b/LOGIT/App/LOGIT.entitlements
@@ -8,6 +8,10 @@
 	<array>
 		<string>Default</string>
 	</array>
+	<key>com.apple.developer.healthkit</key>
+	<true/>
+	<key>com.apple.developer.healthkit.access</key>
+	<array/>
 	<key>com.apple.developer.icloud-container-identifiers</key>
 	<array>
 		<string>iCloud.com.kaibel.cloudKitTest</string>

--- a/LOGIT/App/LOGITApp.swift
+++ b/LOGIT/App/LOGITApp.swift
@@ -34,6 +34,7 @@ struct LOGIT: App {
     @StateObject private var defaultExerciseService: DefaultExerciseService
     @StateObject private var defaultTemplateService: DefaultTemplateService
     @StateObject private var exerciseSuggestionService: ExerciseSuggestionService
+    @StateObject private var healthKitSyncManager: HealthKitSyncManager
 
     @State private var selectedTab: TabType = .home
     @State private var isShowingWelcome = false
@@ -97,7 +98,9 @@ struct LOGIT: App {
         _database = StateObject(wrappedValue: database)
         _templateService = StateObject(wrappedValue: TemplateService(database: database))
         _measurementController = StateObject(wrappedValue: measurementController)
-        let workoutRecorder = WorkoutRecorder(database: database)
+        let healthKitSyncManager = HealthKitSyncManager()
+        _healthKitSyncManager = StateObject(wrappedValue: healthKitSyncManager)
+        let workoutRecorder = WorkoutRecorder(database: database, healthKitSync: healthKitSyncManager)
         _workoutRecorder = StateObject(wrappedValue: workoutRecorder)
         let chronograph = Chronograph()
         _chronograph = StateObject(wrappedValue: chronograph)
@@ -176,6 +179,7 @@ struct LOGIT: App {
                 .environmentObject(homeNavigationCoordinator)
                 .environmentObject(chronograph)
                 .environmentObject(exerciseSuggestionService)
+                .environmentObject(healthKitSyncManager)
                 .environment(\.goHome) { selectedTab = .home }
                 .environment(\.presentWorkoutRecorder, showWorkoutRecorder)
                 .sheet(isPresented: $isShowingWelcome) {
@@ -269,6 +273,7 @@ struct LOGIT: App {
                     .environmentObject(homeNavigationCoordinator)
                     .environmentObject(chronograph)
                     .environmentObject(exerciseSuggestionService)
+                    .environmentObject(healthKitSyncManager)
                     .interactiveDismissDisabled()
                     .onDisappear {
                         // Clean up if dismissed without saving
@@ -462,6 +467,7 @@ struct LOGIT: App {
             .environmentObject(homeNavigationCoordinator)
             .environmentObject(chronograph)
             .environmentObject(exerciseSuggestionService)
+            .environmentObject(healthKitSyncManager)
             .environment(\.managedObjectContext, database.context)
             .environment(\.goHome) { selectedTab = .home }
             .environment(\.dismissWorkoutRecorder) { dismissWorkoutRecorder() }

--- a/LOGIT/Core/Environment/de.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/de.lproj/Localizable.strings
@@ -1052,3 +1052,16 @@
 "basis" = "Werte";
 
 "buildingYourTrend" = "Dein Trend entsteht";
+
+// MARK: - Apple Health
+
+"appleHealth" = "Apple Health";
+"appleHealthAccessDeniedMessage" = "LOGIT hat keine Berechtigung, Workouts in Apple Health zu speichern. Du kannst sie jederzeit unter Einstellungen → Health → Datenzugriff & Geräte → LOGIT erlauben.";
+"appleHealthAccessDeniedTitle" = "Kein Health-Zugriff";
+"appleHealthAccessMissing" = "Der Health-Zugriff ist deaktiviert. Erlaube ihn unter Einstellungen → Health → Datenzugriff & Geräte → LOGIT.";
+"appleHealthSyncDescription" = "Abgeschlossene Workouts werden automatisch als Krafttraining in Apple Health gespeichert.";
+"exportPastWorkouts" = "Bisherige Workouts exportieren";
+"exportPastWorkoutsDescription" = "Fügt deinen gesamten Trainingsverlauf zu Apple Health hinzu. Ein erneuter Export aktualisiert Einträge, statt sie zu duplizieren.";
+"syncToAppleHealth" = "Mit Apple Health synchronisieren";
+"workoutsExportedToHealth" = "%d Workouts exportiert.";
+"workoutsSkippedNoDuration" = "%d übersprungen (keine Dauer).";

--- a/LOGIT/Core/Environment/en.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/en.lproj/Localizable.strings
@@ -1056,3 +1056,16 @@
 "basis" = "Values";
 
 "buildingYourTrend" = "Building your trend";
+
+// MARK: - Apple Health
+
+"appleHealth" = "Apple Health";
+"appleHealthAccessDeniedMessage" = "LOGIT has no permission to save workouts to Apple Health. You can allow it anytime in Settings → Health → Data Access & Devices → LOGIT.";
+"appleHealthAccessDeniedTitle" = "No Health Access";
+"appleHealthAccessMissing" = "Health access is off. Allow it in Settings → Health → Data Access & Devices → LOGIT.";
+"appleHealthSyncDescription" = "Finished workouts are automatically saved to Apple Health as strength training.";
+"exportPastWorkouts" = "Export Past Workouts";
+"exportPastWorkoutsDescription" = "Adds your entire workout history to Apple Health. Re-exporting updates entries instead of duplicating them.";
+"syncToAppleHealth" = "Sync to Apple Health";
+"workoutsExportedToHealth" = "%d workouts exported.";
+"workoutsSkippedNoDuration" = "%d skipped (no duration).";

--- a/LOGIT/Core/Environment/es.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/es.lproj/Localizable.strings
@@ -1056,3 +1056,16 @@
 "basis" = "Valores";
 
 "buildingYourTrend" = "Creando tu tendencia";
+
+// MARK: - Apple Health
+
+"appleHealth" = "Apple Salud";
+"appleHealthAccessDeniedMessage" = "LOGIT no tiene permiso para guardar entrenamientos en Apple Salud. Puedes permitirlo en cualquier momento en Ajustes → Salud → Acceso a datos y dispositivos → LOGIT.";
+"appleHealthAccessDeniedTitle" = "Sin acceso a Salud";
+"appleHealthAccessMissing" = "El acceso a Salud está desactivado. Permítelo en Ajustes → Salud → Acceso a datos y dispositivos → LOGIT.";
+"appleHealthSyncDescription" = "Los entrenamientos terminados se guardan automáticamente en Apple Salud como entrenamiento de fuerza.";
+"exportPastWorkouts" = "Exportar entrenamientos anteriores";
+"exportPastWorkoutsDescription" = "Añade todo tu historial de entrenamiento a Apple Salud. Volver a exportar actualiza las entradas en lugar de duplicarlas.";
+"syncToAppleHealth" = "Sincronizar con Apple Salud";
+"workoutsExportedToHealth" = "%d entrenamientos exportados.";
+"workoutsSkippedNoDuration" = "%d omitidos (sin duración).";

--- a/LOGIT/Core/Environment/fr.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/fr.lproj/Localizable.strings
@@ -1056,3 +1056,16 @@
 "basis" = "Valeurs";
 
 "buildingYourTrend" = "Tendance en cours";
+
+// MARK: - Apple Health
+
+"appleHealth" = "Apple Santé";
+"appleHealthAccessDeniedMessage" = "LOGIT n'est pas autorisé à enregistrer des entraînements dans Apple Santé. Tu peux l'autoriser à tout moment dans Réglages → Santé → Accès aux données et appareils → LOGIT.";
+"appleHealthAccessDeniedTitle" = "Pas d'accès à Santé";
+"appleHealthAccessMissing" = "L'accès à Santé est désactivé. Autorise-le dans Réglages → Santé → Accès aux données et appareils → LOGIT.";
+"appleHealthSyncDescription" = "Les entraînements terminés sont automatiquement enregistrés dans Apple Santé comme renforcement musculaire.";
+"exportPastWorkouts" = "Exporter les entraînements passés";
+"exportPastWorkoutsDescription" = "Ajoute tout ton historique d'entraînement à Apple Santé. Un nouvel export met à jour les entrées au lieu de les dupliquer.";
+"syncToAppleHealth" = "Synchroniser avec Apple Santé";
+"workoutsExportedToHealth" = "%d entraînements exportés.";
+"workoutsSkippedNoDuration" = "%d ignorés (aucune durée).";

--- a/LOGIT/Core/Environment/it.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/it.lproj/Localizable.strings
@@ -1056,3 +1056,16 @@
 "basis" = "Valori";
 
 "buildingYourTrend" = "Creazione del trend";
+
+// MARK: - Apple Health
+
+"appleHealth" = "Apple Salute";
+"appleHealthAccessDeniedMessage" = "LOGIT non ha il permesso di salvare gli allenamenti in Apple Salute. Puoi consentirlo in qualsiasi momento in Impostazioni → Salute → Accesso ai dati e dispositivi → LOGIT.";
+"appleHealthAccessDeniedTitle" = "Nessun accesso a Salute";
+"appleHealthAccessMissing" = "L'accesso a Salute è disattivato. Consentilo in Impostazioni → Salute → Accesso ai dati e dispositivi → LOGIT.";
+"appleHealthSyncDescription" = "Gli allenamenti completati vengono salvati automaticamente in Apple Salute come allenamento di forza.";
+"exportPastWorkouts" = "Esporta allenamenti passati";
+"exportPastWorkoutsDescription" = "Aggiunge l'intera cronologia degli allenamenti ad Apple Salute. Una nuova esportazione aggiorna le voci senza duplicarle.";
+"syncToAppleHealth" = "Sincronizza con Apple Salute";
+"workoutsExportedToHealth" = "%d allenamenti esportati.";
+"workoutsSkippedNoDuration" = "%d saltati (nessuna durata).";

--- a/LOGIT/Core/Environment/ja.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/ja.lproj/Localizable.strings
@@ -1056,3 +1056,16 @@
 "basis" = "値";
 
 "buildingYourTrend" = "トレンドを作成中";
+
+// MARK: - Apple Health
+
+"appleHealth" = "Appleヘルスケア";
+"appleHealthAccessDeniedMessage" = "LOGITにはヘルスケアへワークアウトを保存する権限がありません。「設定」→「ヘルスケア」→「データアクセスとデバイス」→「LOGIT」でいつでも許可できます。";
+"appleHealthAccessDeniedTitle" = "ヘルスケアへのアクセスなし";
+"appleHealthAccessMissing" = "ヘルスケアへのアクセスがオフです。「設定」→「ヘルスケア」→「データアクセスとデバイス」→「LOGIT」で許可してください。";
+"appleHealthSyncDescription" = "完了したワークアウトは筋力トレーニングとして自動的にヘルスケアに保存されます。";
+"exportPastWorkouts" = "過去のワークアウトを書き出す";
+"exportPastWorkoutsDescription" = "ワークアウト履歴全体をヘルスケアに追加します。再書き出しでは既存の項目が更新され、重複しません。";
+"syncToAppleHealth" = "ヘルスケアと同期";
+"workoutsExportedToHealth" = "%d件のワークアウトを書き出しました。";
+"workoutsSkippedNoDuration" = "%d件をスキップしました（時間なし）。";

--- a/LOGIT/Core/Environment/ko.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/ko.lproj/Localizable.strings
@@ -1056,3 +1056,16 @@
 "basis" = "값";
 
 "buildingYourTrend" = "추세 만드는 중";
+
+// MARK: - Apple Health
+
+"appleHealth" = "Apple 건강";
+"appleHealthAccessDeniedMessage" = "LOGIT에 운동을 건강 앱에 저장할 권한이 없습니다. 설정 → 건강 → 데이터 접근 및 기기 → LOGIT에서 언제든지 허용할 수 있습니다.";
+"appleHealthAccessDeniedTitle" = "건강 앱 접근 권한 없음";
+"appleHealthAccessMissing" = "건강 앱 접근이 꺼져 있습니다. 설정 → 건강 → 데이터 접근 및 기기 → LOGIT에서 허용하세요.";
+"appleHealthSyncDescription" = "완료된 운동은 근력 운동으로 건강 앱에 자동 저장됩니다.";
+"exportPastWorkouts" = "지난 운동 내보내기";
+"exportPastWorkoutsDescription" = "전체 운동 기록을 건강 앱에 추가합니다. 다시 내보내면 항목이 중복되지 않고 업데이트됩니다.";
+"syncToAppleHealth" = "Apple 건강과 동기화";
+"workoutsExportedToHealth" = "운동 %d개를 내보냈습니다.";
+"workoutsSkippedNoDuration" = "%d개 건너뜀(운동 시간 없음).";

--- a/LOGIT/Core/Environment/pt-BR.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/pt-BR.lproj/Localizable.strings
@@ -1056,3 +1056,16 @@
 "basis" = "Valores";
 
 "buildingYourTrend" = "Criando sua tendência";
+
+// MARK: - Apple Health
+
+"appleHealth" = "Apple Saúde";
+"appleHealthAccessDeniedMessage" = "O LOGIT não tem permissão para salvar treinos no Apple Saúde. Você pode permitir a qualquer momento em Ajustes → Saúde → Acesso a Dados e Dispositivos → LOGIT.";
+"appleHealthAccessDeniedTitle" = "Sem acesso ao Saúde";
+"appleHealthAccessMissing" = "O acesso ao app Saúde está desativado. Permita em Ajustes → Saúde → Acesso a Dados e Dispositivos → LOGIT.";
+"appleHealthSyncDescription" = "Treinos concluídos são salvos automaticamente no Apple Saúde como treino de força.";
+"exportPastWorkouts" = "Exportar treinos anteriores";
+"exportPastWorkoutsDescription" = "Adiciona todo o seu histórico de treinos ao Apple Saúde. Exportar novamente atualiza as entradas em vez de duplicá-las.";
+"syncToAppleHealth" = "Sincronizar com o Apple Saúde";
+"workoutsExportedToHealth" = "%d treinos exportados.";
+"workoutsSkippedNoDuration" = "%d ignorados (sem duração).";

--- a/LOGIT/Core/Utilities/HealthKitSyncManager.swift
+++ b/LOGIT/Core/Utilities/HealthKitSyncManager.swift
@@ -1,0 +1,215 @@
+//
+//  HealthKitSyncManager.swift
+//  LOGIT
+//
+//  Created by Lukas Kaibel on 21.07.26.
+//
+
+import Foundation
+import HealthKit
+import OSLog
+
+/// Mirrors finished LOGIT workouts into Apple Health.
+///
+/// Sync is write-only and one-directional: a workout finished, edited or deleted in LOGIT is
+/// pushed to HealthKit, nothing is ever read back. Every exported workout carries the LOGIT
+/// workout's UUID as its HealthKit sync identifier, which makes exports idempotent upserts —
+/// re-exporting (an edit, or a second backfill run) replaces the Health entry instead of
+/// duplicating it, and deletion can target exactly the one exported object.
+///
+/// All hooks are fire-and-forget and best-effort: recording and saving a workout must never
+/// fail or stall because Health access is missing, so failures are only logged.
+final class HealthKitSyncManager: ObservableObject {
+    /// The data HealthKit needs from a workout. Captured on the Core Data context's queue
+    /// (see `Workout.healthKitPayload`) so the export itself is free to run anywhere.
+    struct WorkoutPayload: Sendable {
+        let id: UUID
+        let name: String?
+        let start: Date
+        let end: Date
+    }
+
+    enum BackfillState: Equatable {
+        case idle
+        case running(completed: Int, total: Int)
+        case finished(exported: Int, skipped: Int)
+    }
+
+    // MARK: - Constants
+
+    /// UserDefaults key for the user-facing sync opt-in (see `SettingsScreen`).
+    static let syncEnabledKey = "appleHealthSyncEnabled"
+
+    private static let logger = Logger(subsystem: ".com.lukaskbl.LOGIT", category: "HealthKitSyncManager")
+
+    // MARK: - Published
+
+    /// Drives the settings screen's "Export Past Workouts" progress and result label.
+    @Published var backfillState: BackfillState = .idle
+
+    // MARK: - Private
+
+    private let healthStore = HKHealthStore()
+
+    // MARK: - Availability & Authorization
+
+    /// `false` on devices without a Health store — the settings section hides itself there.
+    var isHealthDataAvailable: Bool {
+        HKHealthStore.isHealthDataAvailable()
+    }
+
+    var isSyncEnabled: Bool {
+        UserDefaults.standard.bool(forKey: Self.syncEnabledKey)
+    }
+
+    /// Share authorization for workouts. Unlike read access, HealthKit does expose whether
+    /// writing was denied, so the settings toggle can react to it.
+    var isAuthorized: Bool {
+        healthStore.authorizationStatus(for: .workoutType()) == .sharingAuthorized
+    }
+
+    /// Presents the system Health access sheet (only the first time; later calls are no-ops)
+    /// and reports whether write access ended up granted.
+    func requestAuthorization() async -> Bool {
+        guard isHealthDataAvailable else { return false }
+        do {
+            try await healthStore.requestAuthorization(toShare: [.workoutType()], read: [])
+        } catch {
+            Self.logger.error(
+                "Requesting Health authorization failed: \(String(describing: error), privacy: .public)"
+            )
+            return false
+        }
+        return isAuthorized
+    }
+
+    // MARK: - Sync Hooks
+
+    /// Exports a workout that was finished or edited on this device. Fire-and-forget.
+    func syncWorkout(_ payload: WorkoutPayload?) {
+        guard let payload, isSyncEnabled, isAuthorized else { return }
+        Task {
+            do {
+                try await export(payload)
+            } catch {
+                Self.logger.error(
+                    "Exporting workout \(payload.id, privacy: .public) to Apple Health failed: \(String(describing: error), privacy: .public)"
+                )
+            }
+        }
+    }
+
+    /// Removes the exported counterpart of a workout deleted on this device. Fire-and-forget;
+    /// deleting a workout that was never exported is a harmless no-op.
+    func removeWorkout(id: UUID) {
+        guard isSyncEnabled, isAuthorized else { return }
+        Task {
+            do {
+                try await deleteExportedWorkout(id: id)
+            } catch {
+                // Also lands here when there was nothing to delete (HKError.errorNoData).
+                Self.logger.info(
+                    "Removing workout \(id, privacy: .public) from Apple Health failed: \(String(describing: error), privacy: .public)"
+                )
+            }
+        }
+    }
+
+    // MARK: - Backfill
+
+    /// Exports the given payloads sequentially, publishing progress for the settings UI.
+    /// Idempotent thanks to the sync identifiers — running it twice never duplicates.
+    /// `alreadySkipped` counts workouts dropped before export (no logged duration) so the
+    /// result reflects the whole history, not just the exportable part.
+    @MainActor
+    func exportAll(_ payloads: [WorkoutPayload], alreadySkipped: Int = 0) async {
+        var exported = 0
+        var skipped = alreadySkipped
+        backfillState = .running(completed: 0, total: payloads.count)
+        for (index, payload) in payloads.enumerated() {
+            do {
+                try await export(payload)
+                exported += 1
+            } catch {
+                skipped += 1
+                Self.logger.error(
+                    "Backfill: exporting workout \(payload.id, privacy: .public) failed: \(String(describing: error), privacy: .public)"
+                )
+            }
+            backfillState = .running(completed: index + 1, total: payloads.count)
+        }
+        backfillState = .finished(exported: exported, skipped: skipped)
+    }
+
+    // MARK: - Export Rules
+
+    /// Whether a workout's dates can be represented as a HealthKit workout: it needs an actual
+    /// duration, and HealthKit rejects samples that end in the future (the date editor allows
+    /// picking one).
+    static func isExportable(start: Date?, end: Date?, now: Date = .now) -> Bool {
+        guard let start, let end else { return false }
+        return start < end && end <= now
+    }
+
+    // MARK: - HealthKit Plumbing
+
+    private func export(_ payload: WorkoutPayload) async throws {
+        guard Self.isExportable(start: payload.start, end: payload.end) else {
+            throw HKError(.errorInvalidArgument)
+        }
+
+        let configuration = HKWorkoutConfiguration()
+        configuration.activityType = .traditionalStrengthTraining
+        configuration.locationType = .indoor
+
+        var metadata: [String: Any] = [
+            HKMetadataKeySyncIdentifier: payload.id.uuidString,
+            // Any strictly increasing value works; milliseconds keep two saves of the same
+            // workout in quick succession (finish, then an immediate edit) distinguishable.
+            HKMetadataKeySyncVersion: Int(Date.now.timeIntervalSince1970 * 1000),
+        ]
+        if let name = payload.name, !name.isEmpty {
+            metadata[HKMetadataKeyWorkoutBrandName] = name
+        }
+
+        let builder = HKWorkoutBuilder(healthStore: healthStore, configuration: configuration, device: .local())
+        do {
+            try await builder.beginCollection(at: payload.start)
+            try await builder.addMetadata(metadata)
+            try await builder.endCollection(at: payload.end)
+            _ = try await builder.finishWorkout()
+        } catch {
+            builder.discardWorkout()
+            throw error
+        }
+    }
+
+    private func deleteExportedWorkout(id: UUID) async throws {
+        let predicate = HKQuery.predicateForObjects(
+            withMetadataKey: HKMetadataKeySyncIdentifier,
+            allowedValues: [id.uuidString]
+        )
+        _ = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Int, Error>) in
+            healthStore.deleteObjects(of: .workoutType(), predicate: predicate) { _, deletedCount, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume(returning: deletedCount)
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Workout + Payload
+
+extension Workout {
+    /// The workout's HealthKit export payload, or `nil` while it cannot be represented in
+    /// Health (no id, or no logged duration). Must be read on the context's queue.
+    var healthKitPayload: HealthKitSyncManager.WorkoutPayload? {
+        guard let id, let date, let endDate,
+              HealthKitSyncManager.isExportable(start: date, end: endDate)
+        else { return nil }
+        return HealthKitSyncManager.WorkoutPayload(id: id, name: name, start: date, end: endDate)
+    }
+}

--- a/LOGIT/Features/SettingsScreen.swift
+++ b/LOGIT/Features/SettingsScreen.swift
@@ -10,6 +10,8 @@ import SwiftUI
 
 struct SettingsScreen: View {
     @EnvironmentObject private var purchaseManager: PurchaseManager
+    @EnvironmentObject private var database: Database
+    @EnvironmentObject private var healthKitSyncManager: HealthKitSyncManager
     @Environment(\.requestReview) private var requestReview
 
     // MARK: - UserDefaults
@@ -17,12 +19,14 @@ struct SettingsScreen: View {
     @AppStorage("weightUnit") var weightUnit: WeightUnit = .kg
     @AppStorage("preventAutoLock") var preventAutoLock: Bool = true
     @AppStorage("timerIsMuted") var timerIsMuted: Bool = false
+    @AppStorage(HealthKitSyncManager.syncEnabledKey) var appleHealthSyncEnabled: Bool = false
 
     // MARK: - State
 
     @State private var isShowingUpgradeToPro = false
     @State private var isShowingPrivacyPolicy = false
     @State private var isShowingTermsAndConditions = false
+    @State private var isShowingHealthAccessDeniedAlert = false
 
     // MARK: - Body
 
@@ -31,6 +35,9 @@ struct SettingsScreen: View {
             VStack(spacing: SECTION_SPACING) {
                 generalSection
                 workoutSection
+                if healthKitSyncManager.isHealthDataAvailable {
+                    appleHealthSection
+                }
                 feedbackSection
                 aboutSection
                 subscriptionSection
@@ -41,6 +48,14 @@ struct SettingsScreen: View {
         .navigationBarTitleDisplayMode(.large)
         .sheet(isPresented: $isShowingUpgradeToPro) {
             UpgradeToProScreen()
+        }
+        .alert(
+            NSLocalizedString("appleHealthAccessDeniedTitle", comment: ""),
+            isPresented: $isShowingHealthAccessDeniedAlert
+        ) {
+            Button(NSLocalizedString("ok", comment: ""), role: .cancel) {}
+        } message: {
+            Text(NSLocalizedString("appleHealthAccessDeniedMessage", comment: ""))
         }
         .sheet(isPresented: $isShowingPrivacyPolicy) {
             NavigationStack {
@@ -112,6 +127,128 @@ struct SettingsScreen: View {
                     .padding(CELL_PADDING)
                     .tileStyle()
             }
+        }
+    }
+
+    private var appleHealthSection: some View {
+        section(NSLocalizedString("appleHealth", comment: "")) {
+            VStack(spacing: CELL_SPACING) {
+                VStack(alignment: .leading) {
+                    Toggle(NSLocalizedString("syncToAppleHealth", comment: ""), isOn: appleHealthSyncBinding)
+                    Text(NSLocalizedString("appleHealthSyncDescription", comment: ""))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    if appleHealthSyncEnabled && !healthKitSyncManager.isAuthorized {
+                        Text(NSLocalizedString("appleHealthAccessMissing", comment: ""))
+                            .font(.caption)
+                            .foregroundStyle(.orange)
+                    }
+                }
+                .padding(CELL_PADDING)
+                .tileStyle()
+                if appleHealthSyncEnabled {
+                    exportPastWorkoutsTile
+                }
+            }
+        }
+    }
+
+    /// The sync opt-in only sticks once Health write access is actually granted; flipping it on
+    /// runs the system authorization sheet first and reports a denial instead of silently
+    /// enabling a toggle that could never sync anything.
+    private var appleHealthSyncBinding: Binding<Bool> {
+        Binding(
+            get: { appleHealthSyncEnabled },
+            set: { newValue in
+                guard newValue else {
+                    appleHealthSyncEnabled = false
+                    return
+                }
+                Task {
+                    if await healthKitSyncManager.requestAuthorization() {
+                        appleHealthSyncEnabled = true
+                    } else {
+                        appleHealthSyncEnabled = false
+                        isShowingHealthAccessDeniedAlert = true
+                    }
+                }
+            }
+        )
+    }
+
+    private var exportPastWorkoutsTile: some View {
+        Button {
+            exportPastWorkouts()
+        } label: {
+            VStack(alignment: .leading) {
+                HStack(spacing: 12) {
+                    Image(systemName: "arrow.up.heart.fill")
+                        .foregroundStyle(Color.accentColor)
+                        .frame(width: 24)
+                    Text(NSLocalizedString("exportPastWorkouts", comment: ""))
+                        .foregroundStyle(Color.label)
+                    Spacer()
+                    switch healthKitSyncManager.backfillState {
+                    case .idle:
+                        EmptyView()
+                    case let .running(completed, total):
+                        HStack(spacing: 8) {
+                            Text("\(completed)/\(total)")
+                                .foregroundStyle(.secondary)
+                                .monospacedDigit()
+                            ProgressView()
+                        }
+                    case .finished:
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundStyle(.green)
+                    }
+                }
+                Text(backfillCaption)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .padding(CELL_PADDING)
+            .tileStyle()
+        }
+        .disabled(isBackfillRunning)
+    }
+
+    private var isBackfillRunning: Bool {
+        if case .running = healthKitSyncManager.backfillState { return true }
+        return false
+    }
+
+    private var backfillCaption: String {
+        switch healthKitSyncManager.backfillState {
+        case .idle, .running:
+            return NSLocalizedString("exportPastWorkoutsDescription", comment: "")
+        case let .finished(exported, skipped):
+            var caption = String(
+                format: NSLocalizedString("workoutsExportedToHealth", comment: ""), exported
+            )
+            if skipped > 0 {
+                caption += " " + String(
+                    format: NSLocalizedString("workoutsSkippedNoDuration", comment: ""), skipped
+                )
+            }
+            return caption
+        }
+    }
+
+    private func exportPastWorkouts() {
+        // The in-progress workout is excluded — it reaches Health through the regular
+        // finish-workout sync once it is done. Filtered in memory: most stored workouts
+        // have a NULL isCurrentWorkout, which a `!= true` predicate would exclude too.
+        let workouts = ((database.fetch(
+            Workout.self,
+            sortingKey: "date",
+            ascending: true
+        ) as? [Workout]) ?? [])
+        .filter { !$0.isCurrentWorkout }
+        let payloads = workouts.compactMap(\.healthKitPayload)
+        let skipped = workouts.count - payloads.count
+        Task {
+            await healthKitSyncManager.exportAll(payloads, alreadySkipped: skipped)
         }
     }
 
@@ -233,5 +370,7 @@ struct ProfileView_Previews: PreviewProvider {
             SettingsScreen()
         }
         .environmentObject(PurchaseManager())
+        .environmentObject(HealthKitSyncManager())
+        .environmentObject(Database(isPreview: true))
     }
 }

--- a/LOGIT/Features/Workout/WorkoutDetailScreen.swift
+++ b/LOGIT/Features/Workout/WorkoutDetailScreen.swift
@@ -21,6 +21,7 @@ struct WorkoutDetailScreen: View {
     @Environment(\.dismiss) var dismiss
     @EnvironmentObject private var database: Database
     @EnvironmentObject private var muscleGroupService: MuscleGroupService
+    @EnvironmentObject private var healthKitSyncManager: HealthKitSyncManager
 
     // MARK: - State
 
@@ -157,6 +158,9 @@ struct WorkoutDetailScreen: View {
                     titleVisibility: .visible
                 ) {
                     Button(NSLocalizedString("deleteWorkout", comment: ""), role: .destructive) {
+                        if let workoutID = workout.id {
+                            healthKitSyncManager.removeWorkout(id: workoutID)
+                        }
                         database.delete(workout, saveContext: true)
                         dismiss()
                     }

--- a/LOGIT/Features/Workout/WorkoutEditorScreen.swift
+++ b/LOGIT/Features/Workout/WorkoutEditorScreen.swift
@@ -21,6 +21,7 @@ struct WorkoutEditorScreen: View {
     // MARK: - Environment
 
     @EnvironmentObject var database: Database
+    @EnvironmentObject var healthKitSyncManager: HealthKitSyncManager
     @Environment(\.dismiss) var dismiss
 
     // MARK: - State
@@ -280,6 +281,9 @@ struct WorkoutEditorScreen: View {
                             database.unflagAsTemporary(workout)
                         }
                         database.save()
+                        // Covers manual additions, imports, and edits alike — the export is an
+                        // idempotent upsert, so re-saving replaces the Health entry.
+                        healthKitSyncManager.syncWorkout(workout.healthKitPayload)
                         dismiss()
                     }
                     .fontWeight(.bold)

--- a/LOGIT/Features/Workout/WorkoutRecorder/WorkoutRecorder.swift
+++ b/LOGIT/Features/Workout/WorkoutRecorder/WorkoutRecorder.swift
@@ -31,13 +31,15 @@ final class WorkoutRecorder: ObservableObject {
     // MARK: - Private Variables
 
     private let database: Database
+    private let healthKitSync: HealthKitSyncManager?
     private var workoutSetTemplateSetDictionary = [WorkoutSet: TemplateSet]()
     private var cancellable: AnyCancellable?
 
     // MARK: - Init
 
-    init(database: Database) {
+    init(database: Database, healthKitSync: HealthKitSyncManager? = nil) {
         self.database = database
+        self.healthKitSync = healthKitSync
         workout = (database.fetch(Workout.self, predicate: NSPredicate(format: "isCurrentWorkout == true")) as? [Workout])?.first
     }
 
@@ -96,6 +98,7 @@ final class WorkoutRecorder: ObservableObject {
                 Self.logger.error("Failed to clean up workout after finish: self already uninitialized")
                 return
             }
+            let healthKitSync = self?.healthKitSync
 
             if workoutCopy.name?.isEmpty ?? true {
                 workoutCopy.name = Workout.getStandardName(for: workoutCopy.date!)
@@ -117,6 +120,8 @@ final class WorkoutRecorder: ObservableObject {
             database.context.perform {
                 if workoutCopy.isEmpty {
                     database.delete(workoutCopy, saveContext: true)
+                } else {
+                    healthKitSync?.syncWorkout(workoutCopy.healthKitPayload)
                 }
                 database.save()
             }

--- a/LOGIT/SharedUI/Modifiers/PreviewEnvironmentObjects.swift
+++ b/LOGIT/SharedUI/Modifiers/PreviewEnvironmentObjects.swift
@@ -19,6 +19,7 @@ struct PreviewEnvironmentObjects: ViewModifier {
     @StateObject private var homeNavigationCoordinator: HomeNavigationCoordinator
     @StateObject private var chronograph: Chronograph
     @StateObject private var exerciseSuggestionService: ExerciseSuggestionService
+    @StateObject private var healthKitSyncManager = HealthKitSyncManager()
 
     init() {
         let db = Database(isPreview: true)
@@ -48,6 +49,7 @@ struct PreviewEnvironmentObjects: ViewModifier {
             .environmentObject(homeNavigationCoordinator)
             .environmentObject(chronograph)
             .environmentObject(exerciseSuggestionService)
+            .environmentObject(healthKitSyncManager)
             .task {
                 Task {
                     do {

--- a/LOGITTests/ServicesTests.swift
+++ b/LOGITTests/ServicesTests.swift
@@ -1041,3 +1041,72 @@ final class DefaultTemplateServiceTests: XCTestCase {
         XCTAssertNil(custom.displayDescription)
     }
 }
+
+// MARK: - HealthKitSyncManagerTests
+
+final class HealthKitSyncManagerTests: XCTestCase {
+
+    private var database: Database!
+
+    override func setUp() {
+        super.setUp()
+        database = Database(isPreview: true)
+    }
+
+    override func tearDown() {
+        database = nil
+        super.tearDown()
+    }
+
+    func testIsExportableRequiresBothDates() {
+        XCTAssertFalse(HealthKitSyncManager.isExportable(start: nil, end: nil))
+        XCTAssertFalse(HealthKitSyncManager.isExportable(start: .now, end: nil))
+        XCTAssertFalse(HealthKitSyncManager.isExportable(start: nil, end: .now))
+    }
+
+    func testIsExportableRequiresPositiveDuration() {
+        let now = Date()
+        XCTAssertFalse(HealthKitSyncManager.isExportable(start: now, end: now, now: now))
+        XCTAssertFalse(
+            HealthKitSyncManager.isExportable(start: now, end: now.addingTimeInterval(-60), now: now)
+        )
+        XCTAssertTrue(
+            HealthKitSyncManager.isExportable(
+                start: now.addingTimeInterval(-3600), end: now.addingTimeInterval(-60), now: now
+            )
+        )
+    }
+
+    func testIsExportableRejectsFutureEndDates() {
+        // The date editor allows picking an end date in the future; HealthKit rejects such samples.
+        let now = Date()
+        XCTAssertFalse(
+            HealthKitSyncManager.isExportable(
+                start: now.addingTimeInterval(-3600), end: now.addingTimeInterval(600), now: now
+            )
+        )
+    }
+
+    func testHealthKitPayloadCapturesWorkoutFields() {
+        let workout = database.newWorkout()
+        workout.id = UUID()
+        workout.name = "Push Day"
+        workout.date = Date(timeIntervalSinceNow: -7200)
+        workout.endDate = Date(timeIntervalSinceNow: -3600)
+
+        let payload = workout.healthKitPayload
+        XCTAssertEqual(payload?.id, workout.id)
+        XCTAssertEqual(payload?.name, "Push Day")
+        XCTAssertEqual(payload?.start, workout.date)
+        XCTAssertEqual(payload?.end, workout.endDate)
+    }
+
+    func testHealthKitPayloadIsNilWithoutLoggedDuration() {
+        let workout = database.newWorkout()
+        workout.id = UUID()
+        workout.date = Date(timeIntervalSinceNow: -3600)
+        workout.endDate = nil
+
+        XCTAssertNil(workout.healthKitPayload)
+    }
+}


### PR DESCRIPTION
Phases 1 & 2 of the Apple Health integration: mirror LOGIT workouts into Apple Health, and backfill the full history.

## What's in it

- **Live sync** — finishing a workout in the recorder, saving one in the editor (manual adds and imports included), or deleting one from the detail screen mirrors the change into Apple Health as a **Traditional Strength Training** session. The workout name becomes the brand name; LOGIT is the source app.
- **Idempotent upsert** — the LOGIT workout UUID is the HealthKit sync identifier, so edits replace the Health entry, the backfill never duplicates, and deletes target exactly the exported object.
- **Backfill** — a new **Apple Health** section in Settings: a sync toggle that only sticks once write access is granted (a denial flips it back and points to the Settings path), plus an "Export Past Workouts" action with live progress and a result caption.
- Best-effort and write-only: recording a workout never fails or stalls on Health access, and nothing is ever read back.

## Boundaries

- Sync is device-local by design — workouts arriving via iCloud from another device aren't re-exported (two devices exporting the same workout would duplicate it in Health).
- Workouts with no logged duration (or a future end date) are skipped and counted; HealthKit rejects both.
- The settings section hides itself on devices without a Health store.

## Housekeeping

- New `com.apple.developer.healthkit` entitlement + `NSHealthUpdateUsageDescription`. On the next Xcode device build, automatic signing adds the HealthKit capability to the App ID.
- Strings localized in all 8 languages.

## Verification

- 5 new unit tests for the export-eligibility rules — all green.
- Standing empty/one/many/free scenario screenshot suite passes.
- Drove the whole flow end-to-end in the iOS 26.4 simulator: enabled sync through the real Health access sheet, backfilled 60 history workouts, and confirmed they appear in the Health app down to the per-entry detail (source = LOGIT, name = "Arm Day", sync identifier = the workout UUID).
- Caught and fixed a bug in the process: the backfill fetch used `isCurrentWorkout != true`, but that attribute is NULL on stored workouts and SQL three-valued logic excludes NULL rows from `!=`, so it matched nothing. Now filtered in memory.

Follow-ups (not in this PR): phase 3 effort score (1–10, feeds Training Load), Move-ring energy estimate, and an accessibility fix for the Summary settings button (filed separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)