### PR TITLE
Distance metric: distance, distance+duration & weight+distance set types

### DIFF
--- a/LOGIT.xcodeproj/project.pbxproj
+++ b/LOGIT.xcodeproj/project.pbxproj
@@ -96,6 +96,8 @@
 		801BBD892DF7338A00CDB1FB /* Exercise+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBCD12DF7338A00CDB1FB /* Exercise+.swift */; };
 		801BBD8C2DF7338A00CDB1FB /* ExerciseVolumeTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBCEB2DF7338A00CDB1FB /* ExerciseVolumeTile.swift */; };
 		801BBD8D2DF7338A00CDB1FB /* WeightUnit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBCA32DF7338A00CDB1FB /* WeightUnit.swift */; };
+		80DI00022F84DD0100DI0002 /* DistanceUnit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80DI00012F84DD0100DI0001 /* DistanceUnit.swift */; };
+		80DI00042F84DD0100DI0004 /* DistanceConverting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80DI00032F84DD0100DI0003 /* DistanceConverting.swift */; };
 		801BBD902DF7338A00CDB1FB /* CanEditModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBD3B2DF7338A00CDB1FB /* CanEditModifier.swift */; };
 		801BBD912DF7338A00CDB1FB /* GenerationScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBD2D2DF7338A00CDB1FB /* GenerationScreen.swift */; };
 		801BBD922DF7338A00CDB1FB /* SettingsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBD302DF7338A00CDB1FB /* SettingsScreen.swift */; };
@@ -172,6 +174,8 @@
 		801BBDE52DF7338A00CDB1FB /* WeightConverting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBCBF2DF7338A00CDB1FB /* WeightConverting.swift */; };
 		801BBDE62DF7338A00CDB1FB /* ExerciseRepetitionsTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBCEA2DF7338A00CDB1FB /* ExerciseRepetitionsTile.swift */; };
 		80DU00022F70CC0100DU0002 /* ExerciseDurationTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80DU00012F70CC0100DU0001 /* ExerciseDurationTile.swift */; };
+		80DI00062F84DD0100DI0006 /* ExerciseDistanceTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80DI00052F84DD0100DI0005 /* ExerciseDistanceTile.swift */; };
+		80DI00082F84DD0100DI0008 /* ExerciseDistanceScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80DI00072F84DD0100DI0007 /* ExerciseDistanceScreen.swift */; };
 		801BBDE72DF7338A00CDB1FB /* UIConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBCAB2DF7338A00CDB1FB /* UIConstants.swift */; };
 		801BBDE82DF7338A00CDB1FB /* ExerciseHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBD4F2DF7338A00CDB1FB /* ExerciseHeader.swift */; };
 		801BBDE92DF7338A00CDB1FB /* UIScreen+ScreenCorners.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBCB42DF7338A00CDB1FB /* UIScreen+ScreenCorners.swift */; };
@@ -401,6 +405,8 @@
 		801BBCA12DF7338A00CDB1FB /* MeasurementEntryType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeasurementEntryType.swift; sourceTree = "<group>"; };
 		801BBCA22DF7338A00CDB1FB /* MuscleGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MuscleGroup.swift; sourceTree = "<group>"; };
 		801BBCA32DF7338A00CDB1FB /* WeightUnit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeightUnit.swift; sourceTree = "<group>"; };
+		80DI00012F84DD0100DI0001 /* DistanceUnit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DistanceUnit.swift; sourceTree = "<group>"; };
+		80DI00032F84DD0100DI0003 /* DistanceConverting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DistanceConverting.swift; sourceTree = "<group>"; };
 		801BBCA72DF7338A00CDB1FB /* EnvironmentValues+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EnvironmentValues+.swift"; sourceTree = "<group>"; };
 		801BBCA82DF7338A00CDB1FB /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
 		801BBCA92DF7338A00CDB1FB /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -456,6 +462,8 @@
 		801BBCE62DF7338A00CDB1FB /* WorkoutSetPredicateFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutSetPredicateFactory.swift; sourceTree = "<group>"; };
 		801BBCEA2DF7338A00CDB1FB /* ExerciseRepetitionsTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseRepetitionsTile.swift; sourceTree = "<group>"; };
 		80DU00012F70CC0100DU0001 /* ExerciseDurationTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseDurationTile.swift; sourceTree = "<group>"; };
+		80DI00052F84DD0100DI0005 /* ExerciseDistanceTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseDistanceTile.swift; sourceTree = "<group>"; };
+		80DI00072F84DD0100DI0007 /* ExerciseDistanceScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseDistanceScreen.swift; sourceTree = "<group>"; };
 		801BBCEB2DF7338A00CDB1FB /* ExerciseVolumeTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseVolumeTile.swift; sourceTree = "<group>"; };
 		801BBCEC2DF7338A00CDB1FB /* ExerciseWeightTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseWeightTile.swift; sourceTree = "<group>"; };
 		801BBCEE2DF7338A00CDB1FB /* ExerciseDetailScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseDetailScreen.swift; sourceTree = "<group>"; };
@@ -554,6 +562,7 @@
 		80AA00072F3A000100AA0001 /* RestDurationEditorSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestDurationEditorSheet.swift; sourceTree = "<group>"; };
 		80AA00072F5CAA0100AA0007 /* LOGIT 7.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "LOGIT 7.0.xcdatamodel"; sourceTree = "<group>"; };
 		80AA00082F70CC0100AA0008 /* LOGIT 8.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "LOGIT 8.0.xcdatamodel"; sourceTree = "<group>"; };
+		80AA00092F84DD0100AA0009 /* LOGIT 9.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "LOGIT 9.0.xcdatamodel"; sourceTree = "<group>"; };
 		80AA00092F3A000100AA0001 /* WorkoutRecorderFloatingTimerButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutRecorderFloatingTimerButton.swift; sourceTree = "<group>"; };
 		80AA000B2F3A000100AA0001 /* WorkoutRecorderFloatingStopwatchStopButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutRecorderFloatingStopwatchStopButton.swift; sourceTree = "<group>"; };
 		80AA10022F5CAA0200AA1002 /* DeterministicUUID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeterministicUUID.swift; sourceTree = "<group>"; };
@@ -846,6 +855,7 @@
 				8571CBB4B50589F1F8F36F44 /* StatPeriod.swift */,
 				80SE00022F70CC0100SE0002 /* SetMeasurementType.swift */,
 				801BBCA32DF7338A00CDB1FB /* WeightUnit.swift */,
+				80DI00012F84DD0100DI0001 /* DistanceUnit.swift */,
 				C82BC4F48812B4D49D4E38E2 /* ChartRange.swift */,
 			);
 			path = Enums;
@@ -890,6 +900,7 @@
 				801BBCBE2DF7338A00CDB1FB /* VolumeCalculating.swift */,
 				6923C33A92504E5287236332 /* OneRepMaxCalculating.swift */,
 				801BBCBF2DF7338A00CDB1FB /* WeightConverting.swift */,
+				80DI00032F84DD0100DI0003 /* DistanceConverting.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -986,6 +997,7 @@
 			children = (
 				801BBCEA2DF7338A00CDB1FB /* ExerciseRepetitionsTile.swift */,
 				80DU00012F70CC0100DU0001 /* ExerciseDurationTile.swift */,
+				80DI00052F84DD0100DI0005 /* ExerciseDistanceTile.swift */,
 				801BBCEB2DF7338A00CDB1FB /* ExerciseVolumeTile.swift */,
 				E1E1E1000000000000000F10 /* ExerciseSetsTile.swift */,
 				E1E1E1000000000000000F08 /* ExerciseMetricTile.swift */,
@@ -1005,6 +1017,7 @@
 				801BBCEF2DF7338A00CDB1FB /* ExerciseHistoryScreen.swift */,
 				801BBCF02DF7338A00CDB1FB /* ExerciseRepetitionsScreen.swift */,
 				80DU00032F70CC0100DU0003 /* ExerciseDurationScreen.swift */,
+				80DI00072F84DD0100DI0007 /* ExerciseDistanceScreen.swift */,
 				801BBCF12DF7338A00CDB1FB /* ExerciseVolumeScreen.swift */,
 				E1E1E1000000000000000F11 /* ExerciseSetsScreen.swift */,
 				801BBCF22DF7338A00CDB1FB /* ExerciseWeightScreen.swift */,
@@ -1642,6 +1655,7 @@
 				E1E1E1000000000000000B06 /* ExerciseSetVolumeScreen.swift in Sources */,
 				801BBD822DF7338A00CDB1FB /* ExerciseRepetitionsScreen.swift in Sources */,
 				80DU00042F70CC0100DU0004 /* ExerciseDurationScreen.swift in Sources */,
+				80DI00082F84DD0100DI0008 /* ExerciseDistanceScreen.swift in Sources */,
 				801BBD832DF7338A00CDB1FB /* Secrets.swift in Sources */,
 				801BBD842DF7338A00CDB1FB /* LogitProLogo.swift in Sources */,
 				801BBD852DF7338A00CDB1FB /* StopwatchView.swift in Sources */,
@@ -1653,6 +1667,7 @@
 				E1E1E1000000000000000B10 /* ExerciseSetsTile.swift in Sources */,
 				E1E1E1000000000000000B08 /* ExerciseMetricTile.swift in Sources */,
 				801BBD8D2DF7338A00CDB1FB /* WeightUnit.swift in Sources */,
+				80DI00022F84DD0100DI0002 /* DistanceUnit.swift in Sources */,
 				801BBD902DF7338A00CDB1FB /* CanEditModifier.swift in Sources */,
 				801BBD912DF7338A00CDB1FB /* GenerationScreen.swift in Sources */,
 				801BBD922DF7338A00CDB1FB /* SettingsScreen.swift in Sources */,
@@ -1765,8 +1780,10 @@
 				8C2580F9D7A5C52A72312A9A /* StatPeriod.swift in Sources */,
 				801BBDE42DF7338A00CDB1FB /* NoDataPlaceholderModifier.swift in Sources */,
 				801BBDE52DF7338A00CDB1FB /* WeightConverting.swift in Sources */,
+				80DI00042F84DD0100DI0004 /* DistanceConverting.swift in Sources */,
 				801BBDE62DF7338A00CDB1FB /* ExerciseRepetitionsTile.swift in Sources */,
 				80DU00022F70CC0100DU0002 /* ExerciseDurationTile.swift in Sources */,
+				80DI00062F84DD0100DI0006 /* ExerciseDistanceTile.swift in Sources */,
 				801BBDE72DF7338A00CDB1FB /* UIConstants.swift in Sources */,
 				801BBDE82DF7338A00CDB1FB /* ExerciseHeader.swift in Sources */,
 				801BBDE92DF7338A00CDB1FB /* UIScreen+ScreenCorners.swift in Sources */,
@@ -2343,6 +2360,7 @@
 		801BBCC92DF7338A00CDB1FB /* LOGIT.xcdatamodeld */ = {
 			isa = XCVersionGroup;
 			children = (
+				80AA00092F84DD0100AA0009 /* LOGIT 9.0.xcdatamodel */,
 				80AA00082F70CC0100AA0008 /* LOGIT 8.0.xcdatamodel */,
 				80AA00072F5CAA0100AA0007 /* LOGIT 7.0.xcdatamodel */,
 				80AA00052F3A000100AA0001 /* LOGIT 6.0.xcdatamodel */,
@@ -2352,7 +2370,7 @@
 				801BBD602DF7338A00CDB1FB /* LOGIT 3.0.xcdatamodel */,
 				801BBD612DF7338A00CDB1FB /* WorkoutDiary.xcdatamodel */,
 			);
-			currentVersion = 80AA00082F70CC0100AA0008 /* LOGIT 8.0.xcdatamodel */;
+			currentVersion = 80AA00092F84DD0100AA0009 /* LOGIT 9.0.xcdatamodel */;
 			path = LOGIT.xcdatamodeld;
 			sourceTree = "<group>";
 			versionGroupType = wrapper.xcdatamodel;

--- a/LOGIT/App/LOGITApp.swift
+++ b/LOGIT/App/LOGITApp.swift
@@ -116,6 +116,7 @@ struct LOGIT: App {
 
         UserDefaults.standard.register(defaults: [
             "weightUnit": WeightUnit.defaultFromLocale.rawValue,
+            "distanceUnit": DistanceUnit.defaultFromLocale.rawValue,
             "workoutPerWeekTarget": -1,
             "setupDone": false,
         ])

--- a/LOGIT/App/TestScenarios.swift
+++ b/LOGIT/App/TestScenarios.swift
@@ -169,15 +169,20 @@ enum TestScenario: String {
         let pullExercises = [deadlift, rows, latPulldowns, bicepsCurls]
         let baseWeights = [60000, 40000, 45000, 25000, 120000, 70000, 55000, 30000]
 
-        // Non-rep measurement types: a timed hold and a weighted carry — typed like their
-        // default-library counterparts so the recorder, detail tiles, and badge can be
-        // verified against duration data.
+        // Non-rep measurement types: a timed hold, a weighted carry, a cardio distance
+        // exercise, and a weighted distance carry — typed like their default-library
+        // counterparts so the recorder, detail tiles, and badge can be verified against
+        // duration and distance data.
         let plank = exercise("_default.exercise.plank", "Plank", .abdominals, database)
         plank.measurementType = .duration
         let farmersCarry = exercise(
             "_default.exercise.farmersWalk", "Farmers Carry", .shoulders, database
         )
         farmersCarry.measurementType = .weightAndDuration
+        let treadmillRun = exercise("_default.exercise.running", "Treadmill Run", .cardio, database)
+        treadmillRun.measurementType = .distanceAndDuration
+        let sledPush = exercise("_default.exercise.sledPush", "Sled Push", .legs, database)
+        sledPush.measurementType = .weightAndDistance
 
         let calendar = Calendar.current
         let sessionCount = 208 // 2 years, 2 sessions/week
@@ -222,6 +227,21 @@ enum TestScenario: String {
                     plankSet.entries.first?.duration =
                         Int64(45 + (session - (sessionCount - 12)) * 3 - setIndex * 5)
                 }
+            }
+            // Recent pull sessions end with a treadmill run, giving the distance metric
+            // the same real history the plank gives duration: a climbing current best,
+            // previous-set references, and distance detail-tile data.
+            if !isPush, session >= sessionCount - 12 {
+                let runGroup = database.newWorkoutSetGroup(
+                    createFirstSetAutomatically: false,
+                    exercise: treadmillRun,
+                    workout: workout
+                )
+                let runSet = database.newStandardSet(setGroup: runGroup)
+                runSet.entries.first?.distance =
+                    Int64(3000 + (session - (sessionCount - 12)) * 100)
+                runSet.entries.first?.duration =
+                    Int64(1100 + (session - (sessionCount - 12)) * 20)
             }
         }
 
@@ -271,6 +291,34 @@ enum TestScenario: String {
             if setIndex == 0 {
                 carrySet.entries.first?.weight = 40000
                 carrySet.entries.first?.duration = 45
+            }
+        }
+
+        // Distance measurement types, also appended last: the treadmill run (distance in
+        // km + duration) with one entered and one open set, and the sled push (weight +
+        // distance in meters) with its first set entered.
+        let runGroup = database.newWorkoutSetGroup(
+            createFirstSetAutomatically: false,
+            exercise: treadmillRun,
+            workout: current
+        )
+        for setIndex in 0 ..< 2 {
+            let runSet = database.newStandardSet(setGroup: runGroup)
+            if setIndex == 0 {
+                runSet.entries.first?.distance = 4200
+                runSet.entries.first?.duration = 1320
+            }
+        }
+        let sledGroup = database.newWorkoutSetGroup(
+            createFirstSetAutomatically: false,
+            exercise: sledPush,
+            workout: current
+        )
+        for setIndex in 0 ..< 2 {
+            let sledSet = database.newStandardSet(setGroup: sledGroup)
+            if setIndex == 0 {
+                sledSet.entries.first?.weight = 60000
+                sledSet.entries.first?.distance = 20
             }
         }
 

--- a/LOGIT/App/TestScenarios.swift
+++ b/LOGIT/App/TestScenarios.swift
@@ -62,6 +62,7 @@ enum TestScenario: String {
         // Skip onboarding, keep units deterministic across sim locales.
         overrides["setupDone"] = true
         overrides["weightUnit"] = WeightUnit.kg.rawValue
+        overrides["distanceUnit"] = DistanceUnit.km.rawValue
         // `empty` shows the no-goal state, the other scenarios a realistic goal.
         overrides["workoutPerWeekTarget"] = self == .empty ? -1 : self == .stress ? 2 : 4
         // Per-user layout state stored as Data (object URIs / JSON) must not

--- a/LOGIT/Core/Enums/DistanceUnit.swift
+++ b/LOGIT/Core/Enums/DistanceUnit.swift
@@ -1,0 +1,38 @@
+//
+//  DistanceUnit.swift
+//  LOGIT
+//
+//  Created by Lukas Kaibel on 21.07.26.
+//
+
+import Foundation
+
+/// The user's distance unit system, chosen in Settings like `WeightUnit`. Each system carries
+/// two display units matching the two `SetMeasurementType.DistanceStyle` scales: the long unit
+/// for kilometer-scale cardio (km/mi) and the short unit for meter-scale carries (m/yd).
+enum DistanceUnit: String, Codable, Identifiable {
+    case km, mi
+
+    static var used: DistanceUnit {
+        DistanceUnit(rawValue: UserDefaults.standard.string(forKey: "distanceUnit") ?? "")
+            ?? .defaultFromLocale
+    }
+
+    /// Returns the appropriate distance unit based on user's locale.
+    /// Returns .mi for US measurement system, .km for metric.
+    static var defaultFromLocale: DistanceUnit {
+        Locale.current.measurementSystem == .us ? .mi : .km
+    }
+
+    /// The meter-scale sibling unit (m/yd), used wherever `DistanceStyle.short` applies.
+    var shortUnit: String {
+        switch self {
+        case .km: return NSLocalizedString("meters.short", comment: "")
+        case .mi: return NSLocalizedString("yards.short", comment: "")
+        }
+    }
+
+    var id: String {
+        rawValue
+    }
+}

--- a/LOGIT/Core/Enums/SetMeasurementType.swift
+++ b/LOGIT/Core/Enums/SetMeasurementType.swift
@@ -16,6 +16,9 @@ enum SetMeasurementType: String, CaseIterable, Codable, Identifiable {
     case repsOnly
     case duration
     case weightAndDuration
+    case distance
+    case distanceAndDuration
+    case weightAndDistance
 
     var id: String { rawValue }
 
@@ -24,11 +27,35 @@ enum SetMeasurementType: String, CaseIterable, Codable, Identifiable {
     }
 
     var usesWeight: Bool {
-        self == .repsAndWeight || self == .weightAndDuration
+        self == .repsAndWeight || self == .weightAndDuration || self == .weightAndDistance
     }
 
     var usesDuration: Bool {
-        self == .duration || self == .weightAndDuration
+        self == .duration || self == .weightAndDuration || self == .distanceAndDuration
+    }
+
+    var usesDistance: Bool {
+        self == .distance || self == .distanceAndDuration || self == .weightAndDistance
+    }
+
+    /// How the distance field is entered and displayed. One unit can't serve both distance
+    /// scales: cardio efforts are kilometer-scale (a 5 km treadmill run), gym-floor efforts are
+    /// meter-scale (a 40 m farmer's walk) — 0.04 km would be unusable. The cardio pair uses the
+    /// long unit (km/mi, decimal entry); the carry pair and the bare distance type use the short
+    /// one (m/yd, whole numbers) — bare distance serves shuttle runs and crawls, while km-scale
+    /// efforts always fit distance+duration, where the time field can simply stay empty.
+    enum DistanceStyle {
+        case long
+        case short
+    }
+
+    /// Nil for types without a distance field.
+    var distanceStyle: DistanceStyle? {
+        switch self {
+        case .distanceAndDuration: return .long
+        case .distance, .weightAndDistance: return .short
+        case .repsAndWeight, .repsOnly, .duration, .weightAndDuration: return nil
+        }
     }
 
     /// How many numeric input fields the recorder shows for one entry of this type — one per
@@ -39,6 +66,9 @@ enum SetMeasurementType: String, CaseIterable, Codable, Identifiable {
         case .repsOnly: return 1
         case .duration: return 1
         case .weightAndDuration: return 2
+        case .distance: return 1
+        case .distanceAndDuration: return 2
+        case .weightAndDistance: return 2
         }
     }
 

--- a/LOGIT/Core/Enums/SetMeasurementType.swift
+++ b/LOGIT/Core/Enums/SetMeasurementType.swift
@@ -38,18 +38,20 @@ enum SetMeasurementType: String, CaseIterable, Codable, Identifiable {
         self == .distance || self == .distanceAndDuration || self == .weightAndDistance
     }
 
-    /// How the distance field is entered and displayed. One unit can't serve both distance
-    /// scales: cardio efforts are kilometer-scale (a 5 km treadmill run), gym-floor efforts are
-    /// meter-scale (a 40 m farmer's walk) — 0.04 km would be unusable. The cardio pair uses the
-    /// long unit (km/mi, decimal entry); the carry pair and the bare distance type use the short
-    /// one (m/yd, whole numbers) — bare distance serves shuttle runs and crawls, while km-scale
-    /// efforts always fit distance+duration, where the time field can simply stay empty.
-    enum DistanceStyle {
+    /// The scale a distance field is entered and displayed in. One scale can't serve every
+    /// exercise: cardio efforts are kilometer-scale (a 5 km treadmill run), gym-floor efforts
+    /// are meter-scale (a 40 m farmer's walk) — 0.04 km would be unusable. Values are always
+    /// STORED in meters; the style only decides the display/entry unit: `.long` is km/mi with
+    /// decimal entry, `.short` whole m/yd. Each measurement type carries a sensible default
+    /// (`distanceStyle` below) and the user can override it per exercise
+    /// (`Exercise.distanceStyle`) — resolve through `distanceStyle(for:)`, never the raw default.
+    enum DistanceStyle: String, CaseIterable {
         case long
         case short
     }
 
-    /// Nil for types without a distance field.
+    /// The type's *default* scale — nil for types without a distance field. Display and entry
+    /// sites must use `distanceStyle(for:)`, which lets the exercise's own choice win.
     var distanceStyle: DistanceStyle? {
         switch self {
         case .distanceAndDuration: return .long

--- a/LOGIT/Core/Environment/de.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/de.lproj/Localizable.strings
@@ -334,6 +334,10 @@
 "sec" = "sek";
 "meters.short" = "m";
 "yards.short" = "yd";
+"unitKilometers" = "Kilometer (km)";
+"unitMeters" = "Meter (m)";
+"unitMiles" = "Meilen (mi)";
+"unitYards" = "Yards (yd)";
 "selectDuration" = "Dauer auswählen";
 "selectExercise" = "Übung auswählen";
 "selectMuscleGroup" = "Muskelgruppe auswählen";

--- a/LOGIT/Core/Environment/de.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/de.lproj/Localizable.strings
@@ -332,6 +332,8 @@
 "noSearchResultsFor" = "Keine Ergebnisse für \"%@\"";
 "showMoreResults" = "%d weitere Ergebnisse anzeigen";
 "sec" = "sek";
+"meters.short" = "m";
+"yards.short" = "yd";
 "selectDuration" = "Dauer auswählen";
 "selectExercise" = "Übung auswählen";
 "selectMuscleGroup" = "Muskelgruppe auswählen";
@@ -431,7 +433,8 @@
 
 // MARK: - U
 
-"unit" = "Einheit";
+"unit" = "Gewichtseinheit";
+"distanceUnit" = "Distanzeinheit";
 "unitDescription" = "Wähle eine Einheit. Alle vorherigen Eingaben werden konvertiert.";
 "unpinned" = "Nicht Angepinnt";
 "unused" = "Unbenutzt";
@@ -720,6 +723,14 @@
 "_default.exercise.ringDips" = "Ring Dips";
 "_default.exercise.ringPushups" = "Ring Liegestütze";
 "_default.exercise.ringRows" = "Ring Rudern";
+"_default.exercise.walking" = "Gehen";
+"_default.exercise.inclineTreadmillWalk" = "Laufband-Gehen mit Steigung";
+"_default.exercise.rucking" = "Rucking";
+"_default.exercise.suitcaseCarry" = "Suitcase Carry";
+"_default.exercise.overheadCarry" = "Überkopf-Tragen";
+"_default.exercise.yokeCarry" = "Yoke Carry";
+"_default.exercise.sandbagCarry" = "Sandsack-Tragen";
+"_default.exercise.shuttleRun" = "Pendellauf";
 
 // MARK: - Default Template Names & Descriptions
 
@@ -1043,9 +1054,13 @@
 "measurementType.repsOnly" = "Nur Wdh.";
 "measurementType.duration" = "Dauer";
 "measurementType.weightAndDuration" = "Gewicht & Dauer";
+"measurementType.distance" = "Distanz";
+"measurementType.distanceAndDuration" = "Distanz & Dauer";
+"measurementType.weightAndDistance" = "Gewicht & Distanz";
 "measurementTypeChangeInfo" = "Bestehende Sätze behalten ihre aufgezeichneten Werte. Nur neue Sätze verwenden die neue Messung.";
 
 "metricInfoDuration" = "Deine längste aufgezeichnete Dauer für diese Übung.";
+"metricInfoDistance" = "Deine längste aufgezeichnete Distanz für diese Übung.";
 // Per-workout vs total basis (Summary stat tiles + detail toggle)
 "perWorkout" = "pro Workout";
 "perWorkoutBasis" = "Pro Workout";

--- a/LOGIT/Core/Environment/en.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/en.lproj/Localizable.strings
@@ -336,6 +336,8 @@
 "noSearchResultsFor" = "No results found for \"%@\"";
 "showMoreResults" = "Show %d more results";
 "sec" = "sec";
+"meters.short" = "m";
+"yards.short" = "yd";
 "selectDuration" = "Select Duration";
 "selectExercise" = "Select Exercise";
 "selectMuscleGroup" = "Select Muscle Group";
@@ -435,7 +437,8 @@
 
 // MARK: - U
 
-"unit" = "Unit";
+"unit" = "Weight Unit";
+"distanceUnit" = "Distance Unit";
 "unitDescription" = "Select the unit you want to use. Any previous entries will be converted on change.";
 "unpinned" = "Unpinned";
 "unused" = "Unused";
@@ -724,6 +727,14 @@
 "_default.exercise.ringDips" = "Ring Dips";
 "_default.exercise.ringPushups" = "Ring Push-ups";
 "_default.exercise.ringRows" = "Ring Rows";
+"_default.exercise.walking" = "Walking";
+"_default.exercise.inclineTreadmillWalk" = "Incline Treadmill Walk";
+"_default.exercise.rucking" = "Rucking";
+"_default.exercise.suitcaseCarry" = "Suitcase Carry";
+"_default.exercise.overheadCarry" = "Overhead Carry";
+"_default.exercise.yokeCarry" = "Yoke Carry";
+"_default.exercise.sandbagCarry" = "Sandbag Carry";
+"_default.exercise.shuttleRun" = "Shuttle Run";
 
 // MARK: - Default Template Names & Descriptions
 
@@ -1047,9 +1058,13 @@
 "measurementType.repsOnly" = "Reps Only";
 "measurementType.duration" = "Duration";
 "measurementType.weightAndDuration" = "Weight & Duration";
+"measurementType.distance" = "Distance";
+"measurementType.distanceAndDuration" = "Distance & Duration";
+"measurementType.weightAndDistance" = "Weight & Distance";
 "measurementTypeChangeInfo" = "Existing sets keep the values they were recorded with. Only new sets use the new measurement.";
 
 "metricInfoDuration" = "Your longest recorded duration for this exercise.";
+"metricInfoDistance" = "Your longest recorded distance for this exercise.";
 // Per-workout vs total basis (Summary stat tiles + detail toggle)
 "perWorkout" = "per workout";
 "perWorkoutBasis" = "Per Workout";

--- a/LOGIT/Core/Environment/en.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/en.lproj/Localizable.strings
@@ -338,6 +338,10 @@
 "sec" = "sec";
 "meters.short" = "m";
 "yards.short" = "yd";
+"unitKilometers" = "Kilometers (km)";
+"unitMeters" = "Meters (m)";
+"unitMiles" = "Miles (mi)";
+"unitYards" = "Yards (yd)";
 "selectDuration" = "Select Duration";
 "selectExercise" = "Select Exercise";
 "selectMuscleGroup" = "Select Muscle Group";

--- a/LOGIT/Core/Environment/es.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/es.lproj/Localizable.strings
@@ -336,6 +336,8 @@
 "noSearchResultsFor" = "No se han encontrado resultados para \"%@\"";
 "showMoreResults" = "Mostrar %d más resultados";
 "sec" = "segundo";
+"meters.short" = "m";
+"yards.short" = "yd";
 "selectDuration" = "Seleccionar duración";
 "selectExercise" = "Seleccionar ejercicio";
 "selectMuscleGroup" = "Seleccionar grupo de músculos";
@@ -435,7 +437,8 @@
 
 // MARK: - U
 
-"unit" = "Unidad";
+"unit" = "Unidad de peso";
+"distanceUnit" = "Unidad de distancia";
 "unitDescription" = "Seleccione la unidad que desea utilizar. Cualquier entrada anterior se convertirá en caso de cambio.";
 "unpinned" = "Desanclar";
 "unused" = "No usado";
@@ -724,6 +727,14 @@
 "_default.exercise.ringDips" = "Inmersiones de anillo";
 "_default.exercise.ringPushups" = "Flexiones de anillo";
 "_default.exercise.ringRows" = "Filas de anillos";
+"_default.exercise.walking" = "Caminata";
+"_default.exercise.inclineTreadmillWalk" = "Caminata inclinada en cinta";
+"_default.exercise.rucking" = "Rucking";
+"_default.exercise.suitcaseCarry" = "Acarreo de maleta";
+"_default.exercise.overheadCarry" = "Acarreo por encima de la cabeza";
+"_default.exercise.yokeCarry" = "Acarreo de yugo";
+"_default.exercise.sandbagCarry" = "Acarreo de saco de arena";
+"_default.exercise.shuttleRun" = "Carrera de ida y vuelta";
 
 // MARK: - Default Template Names & Descriptions
 
@@ -1047,9 +1058,13 @@
 "measurementType.repsOnly" = "Solo reps";
 "measurementType.duration" = "Duración";
 "measurementType.weightAndDuration" = "Peso y duración";
+"measurementType.distance" = "Distancia";
+"measurementType.distanceAndDuration" = "Distancia y duración";
+"measurementType.weightAndDistance" = "Peso y distancia";
 "measurementTypeChangeInfo" = "Las series existentes conservan sus valores registrados. Solo las series nuevas usan la nueva medición.";
 
 "metricInfoDuration" = "Tu duración más larga registrada para este ejercicio.";
+"metricInfoDistance" = "Tu distancia más larga registrada para este ejercicio.";
 // Per-workout vs total basis (Summary stat tiles + detail toggle)
 "perWorkout" = "por entrenamiento";
 "perWorkoutBasis" = "Por entrenamiento";

--- a/LOGIT/Core/Environment/es.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/es.lproj/Localizable.strings
@@ -338,6 +338,10 @@
 "sec" = "segundo";
 "meters.short" = "m";
 "yards.short" = "yd";
+"unitKilometers" = "Kilómetros (km)";
+"unitMeters" = "Metros (m)";
+"unitMiles" = "Millas (mi)";
+"unitYards" = "Yardas (yd)";
 "selectDuration" = "Seleccionar duración";
 "selectExercise" = "Seleccionar ejercicio";
 "selectMuscleGroup" = "Seleccionar grupo de músculos";

--- a/LOGIT/Core/Environment/fr.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/fr.lproj/Localizable.strings
@@ -338,6 +338,10 @@
 "sec" = "seconde";
 "meters.short" = "m";
 "yards.short" = "yd";
+"unitKilometers" = "Kilomètres (km)";
+"unitMeters" = "Mètres (m)";
+"unitMiles" = "Miles (mi)";
+"unitYards" = "Yards (yd)";
 "selectDuration" = "Sélectionnez la durée";
 "selectExercise" = "Sélectionnez l'exercice";
 "selectMuscleGroup" = "Sélectionnez un groupe musculaire";

--- a/LOGIT/Core/Environment/fr.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/fr.lproj/Localizable.strings
@@ -336,6 +336,8 @@
 "noSearchResultsFor" = "Aucun résultat trouvé pour \"%@\"";
 "showMoreResults" = "Afficher %d plus de résultats";
 "sec" = "seconde";
+"meters.short" = "m";
+"yards.short" = "yd";
 "selectDuration" = "Sélectionnez la durée";
 "selectExercise" = "Sélectionnez l'exercice";
 "selectMuscleGroup" = "Sélectionnez un groupe musculaire";
@@ -435,7 +437,8 @@
 
 // MARK: - U
 
-"unit" = "Unité";
+"unit" = "Unité de poids";
+"distanceUnit" = "Unité de distance";
 "unitDescription" = "Sélectionnez l'unité que vous souhaitez utiliser. Toutes les entrées précédentes seront converties en cas de modification.";
 "unpinned" = "Désépinglé";
 "unused" = "Inutilisé";
@@ -724,6 +727,14 @@
 "_default.exercise.ringDips" = "Trempettes en anneau";
 "_default.exercise.ringPushups" = "Pompes à anneaux";
 "_default.exercise.ringRows" = "Rangées d'anneaux";
+"_default.exercise.walking" = "Marche";
+"_default.exercise.inclineTreadmillWalk" = "Marche inclinée sur tapis";
+"_default.exercise.rucking" = "Rucking";
+"_default.exercise.suitcaseCarry" = "Portée de valise";
+"_default.exercise.overheadCarry" = "Portée au-dessus de la tête";
+"_default.exercise.yokeCarry" = "Portée de joug";
+"_default.exercise.sandbagCarry" = "Portée de sac de sable";
+"_default.exercise.shuttleRun" = "Course navette";
 
 // MARK: - Default Template Names & Descriptions
 
@@ -1047,9 +1058,13 @@
 "measurementType.repsOnly" = "Rép. uniquement";
 "measurementType.duration" = "Durée";
 "measurementType.weightAndDuration" = "Poids et durée";
+"measurementType.distance" = "Distance";
+"measurementType.distanceAndDuration" = "Distance et durée";
+"measurementType.weightAndDistance" = "Poids et distance";
 "measurementTypeChangeInfo" = "Les séries existantes conservent leurs valeurs enregistrées. Seules les nouvelles séries utilisent la nouvelle mesure.";
 
 "metricInfoDuration" = "Votre durée enregistrée la plus longue pour cet exercice.";
+"metricInfoDistance" = "Votre distance enregistrée la plus longue pour cet exercice.";
 // Per-workout vs total basis (Summary stat tiles + detail toggle)
 "perWorkout" = "par séance";
 "perWorkoutBasis" = "Par séance";

--- a/LOGIT/Core/Environment/it.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/it.lproj/Localizable.strings
@@ -336,6 +336,8 @@
 "noSearchResultsFor" = "Nessun risultato trovato per \"%@\"";
 "showMoreResults" = "Mostra %d più risultati";
 "sec" = "sez";
+"meters.short" = "m";
+"yards.short" = "yd";
 "selectDuration" = "Seleziona Durata";
 "selectExercise" = "Seleziona Esercizio";
 "selectMuscleGroup" = "Seleziona gruppo muscolare";
@@ -435,7 +437,8 @@
 
 // MARK: - U
 
-"unit" = "Unità";
+"unit" = "Unità di peso";
+"distanceUnit" = "Unità di distanza";
 "unitDescription" = "Seleziona l'unità che desideri utilizzare. Eventuali voci precedenti verranno convertite in caso di modifica.";
 "unpinned" = "Sbloccato";
 "unused" = "Inutilizzato";
@@ -724,6 +727,14 @@
 "_default.exercise.ringDips" = "Immersioni nell'anello";
 "_default.exercise.ringPushups" = "Push-up ad anello";
 "_default.exercise.ringRows" = "Righe ad anello";
+"_default.exercise.walking" = "Camminata";
+"_default.exercise.inclineTreadmillWalk" = "Camminata in salita sul tapis roulant";
+"_default.exercise.rucking" = "Rucking";
+"_default.exercise.suitcaseCarry" = "Trasporto a valigia";
+"_default.exercise.overheadCarry" = "Trasporto sopra la testa";
+"_default.exercise.yokeCarry" = "Trasporto del giogo";
+"_default.exercise.sandbagCarry" = "Trasporto del sacco di sabbia";
+"_default.exercise.shuttleRun" = "Navetta";
 
 // MARK: - Default Template Names & Descriptions
 
@@ -1047,9 +1058,13 @@
 "measurementType.repsOnly" = "Solo rip.";
 "measurementType.duration" = "Durata";
 "measurementType.weightAndDuration" = "Peso e durata";
+"measurementType.distance" = "Distanza";
+"measurementType.distanceAndDuration" = "Distanza e durata";
+"measurementType.weightAndDistance" = "Peso e distanza";
 "measurementTypeChangeInfo" = "Le serie esistenti mantengono i valori registrati. Solo le nuove serie usano la nuova misurazione.";
 
 "metricInfoDuration" = "La durata più lunga registrata per questo esercizio.";
+"metricInfoDistance" = "La distanza più lunga registrata per questo esercizio.";
 // Per-workout vs total basis (Summary stat tiles + detail toggle)
 "perWorkout" = "per allenamento";
 "perWorkoutBasis" = "Per allenamento";

--- a/LOGIT/Core/Environment/it.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/it.lproj/Localizable.strings
@@ -338,6 +338,10 @@
 "sec" = "sez";
 "meters.short" = "m";
 "yards.short" = "yd";
+"unitKilometers" = "Chilometri (km)";
+"unitMeters" = "Metri (m)";
+"unitMiles" = "Miglia (mi)";
+"unitYards" = "Iarde (yd)";
 "selectDuration" = "Seleziona Durata";
 "selectExercise" = "Seleziona Esercizio";
 "selectMuscleGroup" = "Seleziona gruppo muscolare";

--- a/LOGIT/Core/Environment/ja.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/ja.lproj/Localizable.strings
@@ -336,6 +336,8 @@
 "noSearchResultsFor" = "\"%@\" に一致する結果はありませんでした";
 "showMoreResults" = "%d の結果をさらに表示";
 "sec" = "秒";
+"meters.short" = "m";
+"yards.short" = "yd";
 "selectDuration" = "期間を選択してください";
 "selectExercise" = "エクササイズを選択してください";
 "selectMuscleGroup" = "筋肉グループの選択";
@@ -435,7 +437,8 @@
 
 // MARK: - U
 
-"unit" = "ユニット";
+"unit" = "重量の単位";
+"distanceUnit" = "距離の単位";
 "unitDescription" = "使用する単位を選択します。以前のエントリは変更時に変換されます。";
 "unpinned" = "固定されていない";
 "unused" = "未使用";
@@ -724,6 +727,14 @@
 "_default.exercise.ringDips" = "リングディップス";
 "_default.exercise.ringPushups" = "リングプッシュアップ";
 "_default.exercise.ringRows" = "リングロウ";
+"_default.exercise.walking" = "ウォーキング";
+"_default.exercise.inclineTreadmillWalk" = "傾斜トレッドミルウォーク";
+"_default.exercise.rucking" = "ラッキング";
+"_default.exercise.suitcaseCarry" = "スーツケースキャリー";
+"_default.exercise.overheadCarry" = "オーバーヘッドキャリー";
+"_default.exercise.yokeCarry" = "ヨークキャリー";
+"_default.exercise.sandbagCarry" = "サンドバッグキャリー";
+"_default.exercise.shuttleRun" = "シャトルラン";
 
 // MARK: - Default Template Names & Descriptions
 
@@ -1047,9 +1058,13 @@
 "measurementType.repsOnly" = "回数のみ";
 "measurementType.duration" = "時間";
 "measurementType.weightAndDuration" = "重量と時間";
+"measurementType.distance" = "距離";
+"measurementType.distanceAndDuration" = "距離と時間";
+"measurementType.weightAndDistance" = "重量と距離";
 "measurementTypeChangeInfo" = "既存のセットは記録された値を保持します。新しいセットのみ新しい測定方法を使用します。";
 
 "metricInfoDuration" = "このエクササイズで記録された最長時間です。";
+"metricInfoDistance" = "このエクササイズで記録された最長距離です。";
 // Per-workout vs total basis (Summary stat tiles + detail toggle)
 "perWorkout" = "ワークアウトあたり";
 "perWorkoutBasis" = "ワークアウトあたり";

--- a/LOGIT/Core/Environment/ja.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/ja.lproj/Localizable.strings
@@ -338,6 +338,10 @@
 "sec" = "秒";
 "meters.short" = "m";
 "yards.short" = "yd";
+"unitKilometers" = "キロメートル (km)";
+"unitMeters" = "メートル (m)";
+"unitMiles" = "マイル (mi)";
+"unitYards" = "ヤード (yd)";
 "selectDuration" = "期間を選択してください";
 "selectExercise" = "エクササイズを選択してください";
 "selectMuscleGroup" = "筋肉グループの選択";

--- a/LOGIT/Core/Environment/ko.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/ko.lproj/Localizable.strings
@@ -338,6 +338,10 @@
 "sec" = "비서";
 "meters.short" = "m";
 "yards.short" = "yd";
+"unitKilometers" = "킬로미터 (km)";
+"unitMeters" = "미터 (m)";
+"unitMiles" = "마일 (mi)";
+"unitYards" = "야드 (yd)";
 "selectDuration" = "기간 선택";
 "selectExercise" = "운동 선택";
 "selectMuscleGroup" = "근육 그룹 선택";

--- a/LOGIT/Core/Environment/ko.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/ko.lproj/Localizable.strings
@@ -336,6 +336,8 @@
 "noSearchResultsFor" = "\"%@\"에 대한 검색결과가 없습니다.";
 "showMoreResults" = "%d 더 많은 결과 표시";
 "sec" = "비서";
+"meters.short" = "m";
+"yards.short" = "yd";
 "selectDuration" = "기간 선택";
 "selectExercise" = "운동 선택";
 "selectMuscleGroup" = "근육 그룹 선택";
@@ -435,7 +437,8 @@
 
 // MARK: - U
 
-"unit" = "단위";
+"unit" = "무게 단위";
+"distanceUnit" = "거리 단위";
 "unitDescription" = "사용할 단위를 선택하세요. 이전 항목은 변경 시 변환됩니다.";
 "unpinned" = "고정 해제됨";
 "unused" = "미사용";
@@ -724,6 +727,14 @@
 "_default.exercise.ringDips" = "링 딥";
 "_default.exercise.ringPushups" = "링 푸쉬업";
 "_default.exercise.ringRows" = "링 로우";
+"_default.exercise.walking" = "걷기";
+"_default.exercise.inclineTreadmillWalk" = "경사 트레드밀 걷기";
+"_default.exercise.rucking" = "러킹";
+"_default.exercise.suitcaseCarry" = "수트케이스 캐리";
+"_default.exercise.overheadCarry" = "오버헤드 캐리";
+"_default.exercise.yokeCarry" = "요크 캐리";
+"_default.exercise.sandbagCarry" = "샌드백 캐리";
+"_default.exercise.shuttleRun" = "셔틀런";
 
 // MARK: - Default Template Names & Descriptions
 
@@ -1047,9 +1058,13 @@
 "measurementType.repsOnly" = "횟수만";
 "measurementType.duration" = "시간";
 "measurementType.weightAndDuration" = "무게와 시간";
+"measurementType.distance" = "거리";
+"measurementType.distanceAndDuration" = "거리와 시간";
+"measurementType.weightAndDistance" = "무게와 거리";
 "measurementTypeChangeInfo" = "기존 세트는 기록된 값을 유지합니다. 새 세트만 새 측정 방식을 사용합니다.";
 
 "metricInfoDuration" = "이 운동에서 기록된 가장 긴 시간입니다.";
+"metricInfoDistance" = "이 운동에서 기록된 가장 긴 거리입니다.";
 // Per-workout vs total basis (Summary stat tiles + detail toggle)
 "perWorkout" = "운동당";
 "perWorkoutBasis" = "운동당";

--- a/LOGIT/Core/Environment/pt-BR.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/pt-BR.lproj/Localizable.strings
@@ -336,6 +336,8 @@
 "noSearchResultsFor" = "Nenhum resultado encontrado para \"%@\"";
 "showMoreResults" = "Mostrar mais resultados para %d";
 "sec" = "segundo";
+"meters.short" = "m";
+"yards.short" = "yd";
 "selectDuration" = "Selecione Duração";
 "selectExercise" = "Selecione Exercício";
 "selectMuscleGroup" = "Selecione o grupo muscular";
@@ -435,7 +437,8 @@
 
 // MARK: - U
 
-"unit" = "Unidade";
+"unit" = "Unidade de peso";
+"distanceUnit" = "Unidade de distância";
 "unitDescription" = "Selecione a unidade que deseja usar. Quaisquer entradas anteriores serão convertidas mediante alteração.";
 "unpinned" = "Desafixado";
 "unused" = "Não utilizado";
@@ -724,6 +727,14 @@
 "_default.exercise.ringDips" = "Mergulhos de anel";
 "_default.exercise.ringPushups" = "Flexões de anel";
 "_default.exercise.ringRows" = "Linhas de anel";
+"_default.exercise.walking" = "Caminhada";
+"_default.exercise.inclineTreadmillWalk" = "Caminhada inclinada na esteira";
+"_default.exercise.rucking" = "Rucking";
+"_default.exercise.suitcaseCarry" = "Carregamento de mala";
+"_default.exercise.overheadCarry" = "Carregamento acima da cabeça";
+"_default.exercise.yokeCarry" = "Carregamento de canga";
+"_default.exercise.sandbagCarry" = "Carregamento de saco de areia";
+"_default.exercise.shuttleRun" = "Corrida de vaivém";
 
 // MARK: - Default Template Names & Descriptions
 
@@ -1047,9 +1058,13 @@
 "measurementType.repsOnly" = "Só reps";
 "measurementType.duration" = "Duração";
 "measurementType.weightAndDuration" = "Peso e duração";
+"measurementType.distance" = "Distância";
+"measurementType.distanceAndDuration" = "Distância e duração";
+"measurementType.weightAndDistance" = "Peso e distância";
 "measurementTypeChangeInfo" = "As séries existentes mantêm os valores registrados. Apenas as novas séries usam a nova medição.";
 
 "metricInfoDuration" = "Sua duração mais longa registrada para este exercício.";
+"metricInfoDistance" = "Sua distância mais longa registrada para este exercício.";
 // Per-workout vs total basis (Summary stat tiles + detail toggle)
 "perWorkout" = "por treino";
 "perWorkoutBasis" = "Por treino";

--- a/LOGIT/Core/Environment/pt-BR.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/pt-BR.lproj/Localizable.strings
@@ -338,6 +338,10 @@
 "sec" = "segundo";
 "meters.short" = "m";
 "yards.short" = "yd";
+"unitKilometers" = "Quilômetros (km)";
+"unitMeters" = "Metros (m)";
+"unitMiles" = "Milhas (mi)";
+"unitYards" = "Jardas (yd)";
 "selectDuration" = "Selecione Duração";
 "selectExercise" = "Selecione Exercício";
 "selectMuscleGroup" = "Selecione o grupo muscular";

--- a/LOGIT/Core/Utilities/DistanceConverting.swift
+++ b/LOGIT/Core/Utilities/DistanceConverting.swift
@@ -95,3 +95,14 @@ func distanceUnitTitle(for style: SetMeasurementType.DistanceStyle) -> String {
     case .short: return DistanceUnit.used.shortUnit
     }
 }
+
+/// The full menu label for choosing `style` in the user's unit system — "Kilometers (km)" /
+/// "Meters (m)", or "Miles (mi)" / "Yards (yd)".
+func distanceStyleTitle(for style: SetMeasurementType.DistanceStyle) -> String {
+    switch (DistanceUnit.used, style) {
+    case (.km, .long): return NSLocalizedString("unitKilometers", comment: "")
+    case (.km, .short): return NSLocalizedString("unitMeters", comment: "")
+    case (.mi, .long): return NSLocalizedString("unitMiles", comment: "")
+    case (.mi, .short): return NSLocalizedString("unitYards", comment: "")
+    }
+}

--- a/LOGIT/Core/Utilities/DistanceConverting.swift
+++ b/LOGIT/Core/Utilities/DistanceConverting.swift
@@ -1,0 +1,97 @@
+//
+//  DistanceConverting.swift
+//  LOGIT
+//
+//  Created by Lukas Kaibel on 21.07.26.
+//
+
+import Foundation
+
+private let KM_TO_METERS: Double = 1000.0
+private let MI_TO_METERS: Double = 1609.344
+private let YD_TO_METERS: Double = 0.9144
+
+// MARK: - Long Distances (km/mi, decimal — cardio-scale)
+
+/// Converts a distance from display units (km or mi) to storage units (meters).
+/// - Parameter value: Distance in km or mi (as displayed to user)
+/// - Returns: Distance in meters (for storage in database)
+public func convertDistanceForStoring(_ value: Double) -> Int64 {
+    switch DistanceUnit.used {
+    case .km: return Int64(round(value * KM_TO_METERS))
+    case .mi: return Int64(round(value * MI_TO_METERS))
+    }
+}
+
+/// Converts a distance from storage units (meters) to display units (km or mi)
+/// with up to 2 decimal places.
+public func convertDistanceForDisplayingDecimal(_ value: Int64) -> Double {
+    let result: Double
+    switch DistanceUnit.used {
+    case .km: result = Double(value) / KM_TO_METERS
+    case .mi: result = Double(value) / MI_TO_METERS
+    }
+    return round(result * 100) / 100
+}
+
+/// Formats a distance from storage units (meters) to a display string in km or mi,
+/// showing decimals only when needed.
+public func formatDistanceForDisplay(_ value: Int64) -> String {
+    let distance = convertDistanceForDisplayingDecimal(value)
+    if distance == 0 {
+        return "0"
+    }
+
+    let formatter = NumberFormatter()
+    formatter.numberStyle = .decimal
+    formatter.minimumFractionDigits = 0
+    formatter.maximumFractionDigits = 2
+    formatter.decimalSeparator = "."
+    formatter.groupingSeparator = ""
+
+    return formatter.string(from: NSNumber(value: distance)) ?? "0"
+}
+
+public func formatDistanceForDisplay(_ value: Int) -> String {
+    formatDistanceForDisplay(Int64(value))
+}
+
+// MARK: - Short Distances (m/yd, whole numbers — carry-scale)
+
+/// Converts a short distance from display units (m or yd) to storage units (meters).
+public func convertShortDistanceForStoring(_ value: Int64) -> Int64 {
+    switch DistanceUnit.used {
+    case .km: return value
+    case .mi: return Int64(round(Double(value) * YD_TO_METERS))
+    }
+}
+
+/// Converts a short distance from storage units (meters) to display units (m or yd).
+public func convertShortDistanceForDisplaying(_ value: Int64) -> Int64 {
+    switch DistanceUnit.used {
+    case .km: return value
+    case .mi: return Int64(round(Double(value) / YD_TO_METERS))
+    }
+}
+
+// MARK: - Style Dispatch
+
+/// Formats a stored distance (meters) for display in the unit matching `style` — long
+/// distances in km/mi with decimals, short ones as whole m/yd. The single entry point for
+/// read-only distance text (history rows, badges, Live Activity), so every surface agrees.
+func formatDistanceForDisplay(
+    _ value: Int64, style: SetMeasurementType.DistanceStyle
+) -> String {
+    switch style {
+    case .long: return formatDistanceForDisplay(value)
+    case .short: return String(convertShortDistanceForDisplaying(value))
+    }
+}
+
+/// The display unit string for `style` — "km"/"mi" for long distances, "m"/"yd" for short.
+func distanceUnitTitle(for style: SetMeasurementType.DistanceStyle) -> String {
+    switch style {
+    case .long: return DistanceUnit.used.rawValue
+    case .short: return DistanceUnit.used.shortUnit
+    }
+}

--- a/LOGIT/Data/DTOs/WorkoutDTO.swift
+++ b/LOGIT/Data/DTOs/WorkoutDTO.swift
@@ -123,6 +123,9 @@ struct SetEntryDTO: Codable {
     let repetitions: Int?
     let weight: Int?
     let duration: Int?
+    /// Meters. Additive on top of format version 2 — receivers without distance support
+    /// decode leniently and ignore it.
+    let distance: Int?
     /// Index into the set group's exercises (0 = primary); meaningful for compound sets.
     let exerciseIndex: Int?
 
@@ -131,6 +134,7 @@ struct SetEntryDTO: Codable {
         self.repetitions = Int(values.repetitions)
         self.weight = Int(values.weight)
         self.duration = Int(values.duration)
+        self.distance = Int(values.distance)
         self.exerciseIndex = exerciseIndex
     }
 }

--- a/LOGIT/Data/Database/LOGIT.xcdatamodeld/.xccurrentversion
+++ b/LOGIT/Data/Database/LOGIT.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>LOGIT 8.0.xcdatamodel</string>
+	<string>LOGIT 9.0.xcdatamodel</string>
 </dict>
 </plist>

--- a/LOGIT/Data/Database/LOGIT.xcdatamodeld/LOGIT 9.0.xcdatamodel/contents
+++ b/LOGIT/Data/Database/LOGIT.xcdatamodeld/LOGIT 9.0.xcdatamodel/contents
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="24299" systemVersion="25B78" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithCloudKit="YES" userDefinedModelVersionIdentifier="">
+    <entity name="DropSet" representedClassName="DropSet" parentEntity="WorkoutSet" syncable="YES" codeGenerationType="category">
+        <attribute name="repetitions" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[Int64]"/>
+        <attribute name="weights" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[Int64]"/>
+    </entity>
+    <entity name="Exercise" representedClassName="Exercise" syncable="YES" codeGenerationType="class">
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="instructions" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromDataTransformerName" customClassName="[String]"/>
+        <attribute name="measurementTypeString" optional="YES" attributeType="String"/>
+        <attribute name="muscleGroupString" optional="YES" attributeType="String" customClassName="MuscleGroup"/>
+        <attribute name="name" optional="YES" attributeType="String" elementID="name"/>
+        <attribute name="setGroupOrder" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromDataTransformerName" customClassName="[UUID]"/>
+        <attribute name="templateSetGroupOrder" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromDataTransformerName" customClassName="[UUID]"/>
+        <relationship name="setEntries_" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="SetEntry" inverseName="exercise" inverseEntity="SetEntry"/>
+        <relationship name="setGroups_" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="WorkoutSetGroup" inverseName="exercises_" inverseEntity="WorkoutSetGroup"/>
+        <relationship name="templateSetEntries_" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="TemplateSetEntry" inverseName="exercise" inverseEntity="TemplateSetEntry"/>
+        <relationship name="templateSetGroups_" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="TemplateSetGroup" inverseName="exercises_" inverseEntity="TemplateSetGroup"/>
+    </entity>
+    <entity name="MeasurementEntry" representedClassName="MeasurementEntry" syncable="YES" codeGenerationType="class">
+        <attribute name="date" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="type_" optional="YES" attributeType="String"/>
+        <attribute name="value_" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+    </entity>
+    <entity name="SetEntry" representedClassName="SetEntry" syncable="YES" codeGenerationType="class">
+        <attribute name="distance" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="duration" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="order" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="repetitions" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="typeString" optional="YES" attributeType="String"/>
+        <attribute name="weight" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="exercise" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Exercise" inverseName="setEntries_" inverseEntity="Exercise"/>
+        <relationship name="workoutSet" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="WorkoutSet" inverseName="entries_" inverseEntity="WorkoutSet"/>
+    </entity>
+    <entity name="StandardSet" representedClassName="StandardSet" parentEntity="WorkoutSet" syncable="YES" codeGenerationType="category">
+        <attribute name="repetitions" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="weight" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+    </entity>
+    <entity name="SuperSet" representedClassName="SuperSet" parentEntity="WorkoutSet" syncable="YES" codeGenerationType="category">
+        <attribute name="repetitionsFirstExercise" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="repetitionsSecondExercise" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="weightFirstExercise" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="weightSecondExercise" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+    </entity>
+    <entity name="Template" representedClassName="Template" syncable="YES" codeGenerationType="class">
+        <attribute name="creationDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="descriptionText" optional="YES" attributeType="String"/>
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="templateSetGroupOrder" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromDataTransformerName" customClassName="[UUID]"/>
+        <relationship name="setGroups_" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="TemplateSetGroup" inverseName="workout" inverseEntity="TemplateSetGroup"/>
+        <relationship name="workouts_" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Workout" inverseName="template" inverseEntity="Workout"/>
+    </entity>
+    <entity name="TemplateDropSet" representedClassName="TemplateDropSet" parentEntity="TemplateSet" syncable="YES" codeGenerationType="category">
+        <attribute name="repetitions" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[Int64]"/>
+        <attribute name="weights" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[Int64]"/>
+    </entity>
+    <entity name="TemplateSet" representedClassName="TemplateSet" isAbstract="YES" syncable="YES" codeGenerationType="class">
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="restDuration" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="entries_" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="TemplateSetEntry" inverseName="templateSet" inverseEntity="TemplateSetEntry"/>
+        <relationship name="setGroup" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="TemplateSetGroup" inverseName="sets_" inverseEntity="TemplateSetGroup"/>
+    </entity>
+    <entity name="TemplateSetEntry" representedClassName="TemplateSetEntry" syncable="YES" codeGenerationType="class">
+        <attribute name="distance" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="duration" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="order" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="repetitions" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="typeString" optional="YES" attributeType="String"/>
+        <attribute name="weight" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="exercise" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Exercise" inverseName="templateSetEntries_" inverseEntity="Exercise"/>
+        <relationship name="templateSet" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="TemplateSet" inverseName="entries_" inverseEntity="TemplateSet"/>
+    </entity>
+    <entity name="TemplateSetGroup" representedClassName="TemplateSetGroup" syncable="YES" codeGenerationType="class">
+        <attribute name="exerciseOrder" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromDataTransformerName" customClassName="[UUID]"/>
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="setOrder" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromDataTransformerName" customClassName="[UUID]"/>
+        <relationship name="exercises_" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Exercise" inverseName="templateSetGroups_" inverseEntity="Exercise"/>
+        <relationship name="sets_" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="TemplateSet" inverseName="setGroup" inverseEntity="TemplateSet"/>
+        <relationship name="workout" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Template" inverseName="setGroups_" inverseEntity="Template"/>
+    </entity>
+    <entity name="TemplateStandardSet" representedClassName="TemplateStandardSet" parentEntity="TemplateSet" syncable="YES" codeGenerationType="category">
+        <attribute name="repetitions" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="weight" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+    </entity>
+    <entity name="TemplateSuperSet" representedClassName="TemplateSuperSet" parentEntity="TemplateSet" syncable="YES" codeGenerationType="category">
+        <attribute name="repetitionsFirstExercise" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="repetitionsSecondExercise" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="weightFirstExercise" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="weightSecondExercise" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+    </entity>
+    <entity name="Widget" representedClassName="Widget" syncable="YES" codeGenerationType="class">
+        <attribute name="id" optional="YES" attributeType="String"/>
+        <attribute name="isAdded" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <relationship name="collection" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="WidgetCollection" inverseName="items_" inverseEntity="WidgetCollection"/>
+    </entity>
+    <entity name="WidgetCollection" representedClassName="WidgetCollection" syncable="YES" codeGenerationType="class">
+        <attribute name="id" optional="YES" attributeType="String"/>
+        <attribute name="itemOrder" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromDataTransformerName" customClassName="[String]"/>
+        <relationship name="items_" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Widget" inverseName="collection" inverseEntity="Widget"/>
+    </entity>
+    <entity name="Workout" representedClassName="Workout" syncable="YES" codeGenerationType="class">
+        <attribute name="date" optional="YES" attributeType="Date" defaultDateTimeInterval="646345140" usesScalarValueType="NO"/>
+        <attribute name="endDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="isCurrentWorkout" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" defaultValueString=""/>
+        <attribute name="setGroupOrder" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromDataTransformerName" customClassName="[UUID]"/>
+        <relationship name="setGroups_" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="WorkoutSetGroup" inverseName="workout" inverseEntity="WorkoutSetGroup"/>
+        <relationship name="template" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Template" inverseName="workouts_" inverseEntity="Template"/>
+    </entity>
+    <entity name="WorkoutSet" representedClassName="WorkoutSet" isAbstract="YES" syncable="YES" codeGenerationType="class">
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="restDuration" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="entries_" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="SetEntry" inverseName="workoutSet" inverseEntity="SetEntry"/>
+        <relationship name="setGroup" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="WorkoutSetGroup" inverseName="sets_" inverseEntity="WorkoutSetGroup"/>
+    </entity>
+    <entity name="WorkoutSetGroup" representedClassName="WorkoutSetGroup" syncable="YES" codeGenerationType="class">
+        <attribute name="exerciseOrder" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromDataTransformerName" customClassName="[UUID]"/>
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="note" optional="YES" attributeType="String"/>
+        <attribute name="setOrder" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromDataTransformerName" customClassName="[UUID]"/>
+        <relationship name="exercises_" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Exercise" inverseName="setGroups_" inverseEntity="Exercise"/>
+        <relationship name="sets_" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="WorkoutSet" inverseName="setGroup" inverseEntity="WorkoutSet"/>
+        <relationship name="workout" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Workout" inverseName="setGroups_" inverseEntity="Workout"/>
+    </entity>
+</model>

--- a/LOGIT/Data/Database/LOGIT.xcdatamodeld/LOGIT 9.0.xcdatamodel/contents
+++ b/LOGIT/Data/Database/LOGIT.xcdatamodeld/LOGIT 9.0.xcdatamodel/contents
@@ -7,6 +7,7 @@
     <entity name="Exercise" representedClassName="Exercise" syncable="YES" codeGenerationType="class">
         <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="instructions" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromDataTransformerName" customClassName="[String]"/>
+        <attribute name="distanceStyleString" optional="YES" attributeType="String"/>
         <attribute name="measurementTypeString" optional="YES" attributeType="String"/>
         <attribute name="muscleGroupString" optional="YES" attributeType="String" customClassName="MuscleGroup"/>
         <attribute name="name" optional="YES" attributeType="String" elementID="name"/>

--- a/LOGIT/Data/EntityExtensions/Exercise+.swift
+++ b/LOGIT/Data/EntityExtensions/Exercise+.swift
@@ -52,6 +52,21 @@ extension Exercise {
         set { measurementTypeString = newValue.rawValue }
     }
 
+    /// The user's explicit distance scale for this exercise, or nil while they've never chosen
+    /// one — then the measurement type's default applies (see `distanceStyle`).
+    var distanceStyleOverride: SetMeasurementType.DistanceStyle? {
+        get { SetMeasurementType.DistanceStyle(rawValue: distanceStyleString ?? "") }
+        set { distanceStyleString = newValue?.rawValue }
+    }
+
+    /// The distance scale this exercise displays and enters distances in — the user's choice
+    /// when they made one, else the measurement type's default (cardio → km, carries → m).
+    /// Distances are always stored in meters; this only picks the display/entry unit.
+    var distanceStyle: SetMeasurementType.DistanceStyle {
+        get { distanceStyleOverride ?? measurementType.distanceStyle ?? .long }
+        set { distanceStyleOverride = newValue }
+    }
+
     var setGroups: [WorkoutSetGroup] {
         resolvedOrder(of: setGroups_, by: setGroupOrder)
     }
@@ -72,6 +87,18 @@ extension Exercise {
         return result
     }
 
+}
+
+extension SetMeasurementType {
+    /// The distance scale for an entry of this type trained with `exercise` — the ONE
+    /// resolution every distance display and entry site goes through: the exercise's explicit
+    /// choice wins; otherwise the entry type's own default decides (so a one-off
+    /// weight+distance set on a cardio exercise still enters meters). Nil for types without a
+    /// distance field.
+    func distanceStyle(for exercise: Exercise?) -> DistanceStyle? {
+        guard usesDistance else { return nil }
+        return exercise?.distanceStyleOverride ?? distanceStyle
+    }
 }
 
 // MARK: - Current Best

--- a/LOGIT/Data/EntityExtensions/Exercise+.swift
+++ b/LOGIT/Data/EntityExtensions/Exercise+.swift
@@ -117,6 +117,7 @@ extension Exercise {
             case .weight: return workoutSet.maximum(.weight, for: self)
             case .repetitions: return workoutSet.maximum(.repetitions, for: self)
             case .duration: return workoutSet.maximum(.duration, for: self)
+            case .distance: return workoutSet.maximum(.distance, for: self)
             }
         }
 
@@ -147,6 +148,7 @@ extension Exercise {
             case .weight: return workoutSet.maximum(.weight, for: self)
             case .repetitions: return workoutSet.maximum(.repetitions, for: self)
             case .duration: return workoutSet.maximum(.duration, for: self)
+            case .distance: return workoutSet.maximum(.distance, for: self)
             }
         }
     }
@@ -185,6 +187,7 @@ enum ExercisePrimaryMetric: String, CaseIterable {
     case weight
     case repetitions
     case duration
+    case distance
 
     /// Short, localized label for the picker and accessibility.
     var title: String {
@@ -193,6 +196,7 @@ enum ExercisePrimaryMetric: String, CaseIterable {
         case .weight: return NSLocalizedString("weight", comment: "")
         case .repetitions: return NSLocalizedString("repetitions", comment: "")
         case .duration: return NSLocalizedString("measurementType.duration", comment: "")
+        case .distance: return NSLocalizedString("measurementType.distance", comment: "")
         }
     }
 
@@ -204,6 +208,9 @@ enum ExercisePrimaryMetric: String, CaseIterable {
         case .repsOnly: return [.repetitions]
         case .duration: return [.duration]
         case .weightAndDuration: return [.weight, .duration]
+        case .distance: return [.distance]
+        case .distanceAndDuration: return [.distance, .duration]
+        case .weightAndDistance: return [.weight, .distance]
         }
     }
 

--- a/LOGIT/Data/EntityExtensions/SetEntry+.swift
+++ b/LOGIT/Data/EntityExtensions/SetEntry+.swift
@@ -26,14 +26,17 @@ extension SetEntry {
         (type.usesRepetitions && repetitions > 0)
             || (type.usesWeight && weight > 0)
             || (type.usesDuration && duration > 0)
+            || (type.usesDistance && distance > 0)
     }
 
     /// True when the entry's primary performance field is filled — repetitions for rep-based
-    /// types, the duration for time-based ones. This is the "set was performed" signal the
-    /// recorder's rest timer and the Live Activity react to.
+    /// types, the duration or distance for time/distance-based ones (either counts, so logging
+    /// only the distance of a run still marks the set performed). This is the "set was
+    /// performed" signal the recorder's rest timer and the Live Activity react to.
     var hasPerformanceValue: Bool {
         if type.usesRepetitions { return repetitions > 0 }
-        if type.usesDuration { return duration > 0 }
+        if type.usesDuration && duration > 0 { return true }
+        if type.usesDistance && distance > 0 { return true }
         return false
     }
 
@@ -41,5 +44,6 @@ extension SetEntry {
         repetitions = 0
         weight = 0
         duration = 0
+        distance = 0
     }
 }

--- a/LOGIT/Data/EntityExtensions/TemplateSet+.swift
+++ b/LOGIT/Data/EntityExtensions/TemplateSet+.swift
@@ -41,6 +41,7 @@ public extension TemplateSet {
                     repetitions: $0.repetitions,
                     weight: $0.weight,
                     duration: $0.duration,
+                    distance: $0.distance,
                     exercise: owningExercise(of: $0)
                 )
             }
@@ -130,6 +131,7 @@ public extension TemplateSet {
         entry.repetitions = values.repetitions
         entry.weight = values.weight
         entry.duration = values.duration
+        entry.distance = values.distance
         entry.exercise = values.exercise
         entry.templateSet = self
         return entry
@@ -175,6 +177,7 @@ public extension TemplateSet {
                     repetitions: 0,
                     weight: 0,
                     duration: 0,
+                    distance: 0,
                     exercise: positionalExercise(forOrder: value.order) ?? value.exercise
                 )
             )

--- a/LOGIT/Data/EntityExtensions/WorkoutSet+.swift
+++ b/LOGIT/Data/EntityExtensions/WorkoutSet+.swift
@@ -20,19 +20,23 @@ struct SetEntryValues: Equatable {
     var repetitions: Int64
     var weight: Int64
     var duration: Int64
+    /// Defaulted because only distance-tracking types ever set it — legacy derivations and
+    /// reps/weight factories have no distance to pass.
+    var distance: Int64 = 0
     var exercise: Exercise?
 
     /// Mirror of `SetEntry.hasPerformanceValue` for value-level reads.
     var hasPerformanceValue: Bool {
         if type.usesRepetitions { return repetitions > 0 }
-        if type.usesDuration { return duration > 0 }
+        if type.usesDuration && duration > 0 { return true }
+        if type.usesDistance && distance > 0 { return true }
         return false
     }
 }
 
 public extension WorkoutSet {
     enum Attribute: String {
-        case repetitions, weight, duration
+        case repetitions, weight, duration, distance
     }
 
     static func == (lhs: WorkoutSet, rhs: WorkoutSet) -> Bool {
@@ -84,6 +88,7 @@ public extension WorkoutSet {
                     repetitions: $0.repetitions,
                     weight: $0.weight,
                     duration: $0.duration,
+                    distance: $0.distance,
                     exercise: owningExercise(of: $0)
                 )
             }
@@ -182,6 +187,7 @@ public extension WorkoutSet {
         entry.repetitions = values.repetitions
         entry.weight = values.weight
         entry.duration = values.duration
+        entry.distance = values.distance
         entry.exercise = values.exercise
         entry.workoutSet = self
         return entry
@@ -223,6 +229,7 @@ public extension WorkoutSet {
                 case .repetitions: return Int(value.repetitions)
                 case .weight: return Int(value.weight)
                 case .duration: return Int(value.duration)
+                case .distance: return Int(value.distance)
                 }
             }
             .max() ?? 0
@@ -338,6 +345,7 @@ public extension WorkoutSet {
                     repetitions: 0,
                     weight: 0,
                     duration: 0,
+                    distance: 0,
                     exercise: positionalExercise(forOrder: value.order) ?? value.exercise
                 )
             )

--- a/LOGIT/Features/Exercise/ExerciseDetail/ExerciseAttemptCell.swift
+++ b/LOGIT/Features/Exercise/ExerciseDetail/ExerciseAttemptCell.swift
@@ -153,7 +153,7 @@ private struct DropSetEntryRows: View {
 // MARK: - Entry Value Columns
 
 /// One entry's recorded values as unit columns, laid out by measurement type in the same
-/// field order the recorder uses: reps → weight, or weight → duration.
+/// field order the recorder uses: reps → weight, weight → distance, or distance → duration.
 private struct EntryValueColumns: View {
     let value: SetEntryValues
 
@@ -172,6 +172,15 @@ private struct EntryValueColumns: View {
                 UnitView(
                     value: formattedWeight(value.weight),
                     unit: WeightUnit.used.rawValue,
+                    configuration: .normal,
+                    unitColor: .secondaryLabel
+                )
+                .frame(minWidth: SET_GROUP_FIRST_COLUMN_WIDTH, alignment: .trailing)
+            }
+            if let distanceStyle = value.type.distanceStyle {
+                UnitView(
+                    value: formatDistanceForDisplay(value.distance, style: distanceStyle),
+                    unit: distanceUnitTitle(for: distanceStyle),
                     configuration: .normal,
                     unitColor: .secondaryLabel
                 )

--- a/LOGIT/Features/Exercise/ExerciseDetail/ExerciseAttemptCell.swift
+++ b/LOGIT/Features/Exercise/ExerciseDetail/ExerciseAttemptCell.swift
@@ -177,7 +177,7 @@ private struct EntryValueColumns: View {
                 )
                 .frame(minWidth: SET_GROUP_FIRST_COLUMN_WIDTH, alignment: .trailing)
             }
-            if let distanceStyle = value.type.distanceStyle {
+            if let distanceStyle = value.type.distanceStyle(for: value.exercise) {
                 UnitView(
                     value: formatDistanceForDisplay(value.distance, style: distanceStyle),
                     unit: distanceUnitTitle(for: distanceStyle),

--- a/LOGIT/Features/Exercise/ExerciseDetail/ExerciseDetailScreen.swift
+++ b/LOGIT/Features/Exercise/ExerciseDetail/ExerciseDetailScreen.swift
@@ -341,13 +341,13 @@ struct ExerciseDetailScreen: View {
                         distanceTile(workoutSets: workoutSets)
                         durationTile(workoutSets: workoutSets)
                     }
-                    setsTile(workoutSets: workoutSets)
+                    trailingSetsRow(workoutSets: workoutSets, spacing: spacing)
                 } else if isWeightAndDistance {
                     HStack(alignment: .top, spacing: spacing) {
                         weightTile(workoutSets: workoutSets)
                         distanceTile(workoutSets: workoutSets)
                     }
-                    setsTile(workoutSets: workoutSets)
+                    trailingSetsRow(workoutSets: workoutSets, spacing: spacing)
                 } else if isDistanceOnly {
                     HStack(alignment: .top, spacing: spacing) {
                         distanceTile(workoutSets: workoutSets)
@@ -363,7 +363,7 @@ struct ExerciseDetailScreen: View {
                         weightTile(workoutSets: workoutSets)
                         durationTile(workoutSets: workoutSets)
                     }
-                    setsTile(workoutSets: workoutSets)
+                    trailingSetsRow(workoutSets: workoutSets, spacing: spacing)
                 } else if isRepsOnly {
                     HStack(alignment: .top, spacing: spacing) {
                         repetitionsTile(workoutSets: workoutSets)
@@ -432,6 +432,16 @@ struct ExerciseDetailScreen: View {
             ExerciseDistanceTile(exercise: exercise, workoutSets: workoutSets)
         }
         .buttonStyle(TileButtonStyle())
+    }
+
+    /// The sets tile as the odd third tile of a 3-tile layout (weight+duration, distance+duration,
+    /// weight+distance): kept to a leading half with an empty trailing slot, so it lines up with the
+    /// half-width pair above it instead of stretching to full width.
+    private func trailingSetsRow(workoutSets: [WorkoutSet], spacing: CGFloat) -> some View {
+        HStack(alignment: .top, spacing: spacing) {
+            setsTile(workoutSets: workoutSets)
+            Color.clear.frame(maxWidth: .infinity)
+        }
     }
 
     private func setVolumeTile(workoutSets: [WorkoutSet]) -> some View {

--- a/LOGIT/Features/Exercise/ExerciseDetail/ExerciseDetailScreen.swift
+++ b/LOGIT/Features/Exercise/ExerciseDetail/ExerciseDetailScreen.swift
@@ -27,6 +27,7 @@ struct ExerciseDetailScreen: View {
     @State private var isShowingE1RMScreen = false
     @State private var isShowingRepetitionsScreen = false
     @State private var isShowingDurationScreen = false
+    @State private var isShowingDistanceScreen = false
     @State private var isShowingVolumeScreen = false
     @State private var isShowingSetVolumeScreen = false
     @State private var isShowingSetsScreen = false
@@ -223,6 +224,9 @@ struct ExerciseDetailScreen: View {
             .navigationDestination(isPresented: $isShowingDurationScreen) {
                 ExerciseDurationScreen(exercise: exercise, workoutSets: workoutSets)
             }
+            .navigationDestination(isPresented: $isShowingDistanceScreen) {
+                ExerciseDistanceScreen(exercise: exercise, workoutSets: workoutSets)
+            }
             .navigationDestination(isPresented: $isShowingVolumeScreen) {
                 ExerciseVolumeScreen(exercise: exercise, workoutSets: workoutSets)
             }
@@ -241,6 +245,7 @@ struct ExerciseDetailScreen: View {
                         case .weight: isShowingWeightScreen = true
                         case .repetitions: isShowingRepetitionsScreen = true
                         case .duration: isShowingDurationScreen = true
+                        case .distance: isShowingDistanceScreen = true
                         }
                     }
                 }
@@ -268,6 +273,10 @@ struct ExerciseDetailScreen: View {
     /// Duration exercises adapt the same way: a duration-only exercise (plank, dead hang, …) keeps
     /// just duration and sets, and a weight-and-duration exercise (weighted carry, …) keeps weight,
     /// duration, and sets — the reps-derived tiles (reps, e1RM, both volumes) would only show zeros.
+    ///
+    /// Distance exercises follow the same shapes: distance-and-duration (treadmill, rower, …)
+    /// keeps distance, duration, and sets; weight-and-distance (loaded carries) keeps weight,
+    /// distance, and sets; a distance-only exercise keeps distance and sets.
     @ViewBuilder
     private func metricTiles(workoutSets: [WorkoutSet]) -> some View {
         let spacing: CGFloat = 10
@@ -286,14 +295,29 @@ struct ExerciseDetailScreen: View {
             // so a freshly switched exercise adapts before its first duration set, and recorded
             // history keeps its tiles after a switch away. Same rule for weight.
             let tracksDuration = exercise.measurementType.usesDuration || loggedSets.contains { $0.maximum(.duration, for: exercise) > 0 }
+            let tracksDistance = exercise.measurementType.usesDistance || loggedSets.contains { $0.maximum(.distance, for: exercise) > 0 }
             let tracksWeight = exercise.measurementType.usesWeight || hasWeightEntry
             let tracksReps = exercise.measurementType.usesRepetitions || hasRepetitionEntry
+            let isDistanceAndDuration = tracksDistance && tracksDuration
+            let isWeightAndDistance = tracksDistance && tracksWeight
+            let isDistanceOnly = tracksDistance && !tracksWeight && !tracksDuration && !tracksReps
             let isWeightAndDuration = tracksDuration && tracksWeight
             let isDurationOnly = tracksDuration && !tracksWeight && !tracksReps
             VStack(spacing: spacing) {
                 if dynamicTypeSize.isAccessibilitySize {
                     // One column: accessibility text sizes can't fit half-width tiles.
-                    if isDurationOnly {
+                    if isDistanceAndDuration {
+                        distanceTile(workoutSets: workoutSets)
+                        durationTile(workoutSets: workoutSets)
+                        setsTile(workoutSets: workoutSets)
+                    } else if isWeightAndDistance {
+                        weightTile(workoutSets: workoutSets)
+                        distanceTile(workoutSets: workoutSets)
+                        setsTile(workoutSets: workoutSets)
+                    } else if isDistanceOnly {
+                        distanceTile(workoutSets: workoutSets)
+                        setsTile(workoutSets: workoutSets)
+                    } else if isDurationOnly {
                         durationTile(workoutSets: workoutSets)
                         setsTile(workoutSets: workoutSets)
                     } else if isWeightAndDuration {
@@ -310,6 +334,23 @@ struct ExerciseDetailScreen: View {
                             setVolumeTile(workoutSets: workoutSets)
                             volumeTile(workoutSets: workoutSets)
                         }
+                        setsTile(workoutSets: workoutSets)
+                    }
+                } else if isDistanceAndDuration {
+                    HStack(alignment: .top, spacing: spacing) {
+                        distanceTile(workoutSets: workoutSets)
+                        durationTile(workoutSets: workoutSets)
+                    }
+                    setsTile(workoutSets: workoutSets)
+                } else if isWeightAndDistance {
+                    HStack(alignment: .top, spacing: spacing) {
+                        weightTile(workoutSets: workoutSets)
+                        distanceTile(workoutSets: workoutSets)
+                    }
+                    setsTile(workoutSets: workoutSets)
+                } else if isDistanceOnly {
+                    HStack(alignment: .top, spacing: spacing) {
+                        distanceTile(workoutSets: workoutSets)
                         setsTile(workoutSets: workoutSets)
                     }
                 } else if isDurationOnly {
@@ -380,6 +421,15 @@ struct ExerciseDetailScreen: View {
             isShowingDurationScreen = true
         } label: {
             ExerciseDurationTile(exercise: exercise, workoutSets: workoutSets)
+        }
+        .buttonStyle(TileButtonStyle())
+    }
+
+    private func distanceTile(workoutSets: [WorkoutSet]) -> some View {
+        Button {
+            isShowingDistanceScreen = true
+        } label: {
+            ExerciseDistanceTile(exercise: exercise, workoutSets: workoutSets)
         }
         .buttonStyle(TileButtonStyle())
     }

--- a/LOGIT/Features/Exercise/ExerciseDetail/ExerciseDistanceScreen.swift
+++ b/LOGIT/Features/Exercise/ExerciseDetail/ExerciseDistanceScreen.swift
@@ -1,0 +1,134 @@
+//
+//  ExerciseDistanceScreen.swift
+//  LOGIT
+//
+//  Created by Lukas Kaibel on 21.07.26.
+//
+
+import Charts
+import SwiftUI
+
+/// Max distance per day for a single exercise — the detail screen behind the Distance tile.
+/// Structurally the twin of `ExerciseDurationScreen`; distances are stored in meters and shown
+/// in the exercise's distance scale (km/mi for cardio, m/yd for carries). The chart, scrolling,
+/// selection and header live in `CapabilityChartView`.
+struct ExerciseDistanceScreen: View {
+    /// Y-axis caps in display units: km-scale for cardio, meter-scale for carries.
+    private static let longYAxisMaxValues = [1, 2, 5, 10, 20, 50, 100]
+    private static let shortYAxisMaxValues = [20, 50, 100, 200, 500, 1000]
+
+    let exercise: Exercise
+    let workoutSets: [WorkoutSet]
+
+    private let distanceStyle: SetMeasurementType.DistanceStyle
+    private let points: [CapabilityChartView.Point]
+    private let firstDataDate: Date?
+    private let bestAnchor: (value: Int, date: Date?, isLapsed: Bool)?
+    private let yScaleMax: Int
+
+    init(exercise: Exercise, workoutSets: [WorkoutSet]) {
+        self.exercise = exercise
+        self.workoutSets = workoutSets
+        let style = exercise.measurementType.distanceStyle ?? .long
+        self.distanceStyle = style
+        let daily = Self.dailyMaxDistanceSets(in: workoutSets, for: exercise)
+        self.firstDataDate = daily.first?.workout?.date
+        self.points = daily.enumerated().map { index, set in
+            let raw = set.maximum(.distance, for: exercise)
+            return CapabilityChartView.Point(
+                id: index,
+                date: set.workout?.date ?? .now,
+                value: distanceChartValue(raw, style: style),
+                raw: raw,
+                formatted: formatDistanceForDisplay(Int64(raw), style: style)
+            )
+        }
+        let pr = points.map(\.value).max() ?? 0
+        self.yScaleMax = Self.chartYScaleMax(maxYValue: pr, style: style)
+        self.bestAnchor = Self.bestAnchor(for: exercise, in: workoutSets)
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: SECTION_SPACING) {
+                CapabilityChartView(
+                    points: points,
+                    firstDataDate: firstDataDate,
+                    bestAnchor: bestAnchor,
+                    yScaleMax: yScaleMax,
+                    color: exerciseMuscleGroupColor,
+                    unit: distanceUnitTitle(for: distanceStyle),
+                    valueLabel: NSLocalizedString("measurementType.distance", comment: ""),
+                    formatValue: { formatDistanceForDisplay(Int64($0), style: distanceStyle) }
+                )
+            }
+            .padding(.top)
+            .padding(.bottom, SCROLLVIEW_BOTTOM_PADDING)
+        }
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .principal) {
+                VStack {
+                    Text("\(NSLocalizedString("measurementType.distance", comment: ""))")
+                        .font(.headline)
+                    Text(exercise.displayName)
+                        .foregroundStyle(.secondary)
+                        .font(.footnote)
+                }
+            }
+        }
+    }
+
+    // MARK: - Data
+
+    private var exerciseMuscleGroupColor: Color {
+        exercise.muscleGroup?.color ?? Color.accentColor
+    }
+
+    private static func dailyMaxDistanceSets(in workoutSets: [WorkoutSet], for exercise: Exercise) -> [WorkoutSet] {
+        let groupedSets = Dictionary(grouping: workoutSets) {
+            Calendar.current.startOfDay(for: $0.workout?.date ?? .now)
+        }.sorted { $0.key < $1.key }
+            .map { $0.1 }
+        return groupedSets
+            .compactMap { setsPerDay -> WorkoutSet? in
+                setsPerDay.max(by: { $0.maximum(.distance, for: exercise) < $1.maximum(.distance, for: exercise) })
+            }
+            .filter { $0.maximum(.distance, for: exercise) > 0 }
+    }
+
+    private static func chartYScaleMax(maxYValue: Double, style: SetMeasurementType.DistanceStyle) -> Int {
+        let candidates = style == .long ? longYAxisMaxValues : shortYAxisMaxValues
+        let nextBiggerYAxisMaxValue = candidates.filter { Double($0) > maxYValue }.min()
+        return nextBiggerYAxisMaxValue ?? Int(maxYValue.rounded(.up))
+    }
+
+    /// The fixed right-hand anchor of the header scoreboard — see `ExerciseDurationScreen.bestAnchor`.
+    private static func bestAnchor(for exercise: Exercise, in workoutSets: [WorkoutSet]) -> (value: Int, date: Date?, isLapsed: Bool)? {
+        if let best = exercise.currentBestSet(for: .distance, in: workoutSets) {
+            return (best.maximum(.distance, for: exercise), best.workout?.date, false)
+        }
+        if let last = exercise.lastBestSet(for: .distance, in: workoutSets) {
+            return (last.maximum(.distance, for: exercise), last.workout?.date, true)
+        }
+        return nil
+    }
+}
+
+private struct PreviewWrapperView: View {
+    @EnvironmentObject private var database: Database
+
+    var body: some View {
+        let exercise = database.getExercises().first!
+        NavigationView {
+            ExerciseDistanceScreen(exercise: exercise, workoutSets: exercise.sets)
+        }
+    }
+}
+
+struct ExerciseDistanceScreen_Previews: PreviewProvider {
+    static var previews: some View {
+        PreviewWrapperView()
+            .previewEnvironmentObjects()
+    }
+}

--- a/LOGIT/Features/Exercise/ExerciseDetail/ExerciseDistanceScreen.swift
+++ b/LOGIT/Features/Exercise/ExerciseDetail/ExerciseDistanceScreen.swift
@@ -29,7 +29,7 @@ struct ExerciseDistanceScreen: View {
     init(exercise: Exercise, workoutSets: [WorkoutSet]) {
         self.exercise = exercise
         self.workoutSets = workoutSets
-        let style = exercise.measurementType.distanceStyle ?? .long
+        let style = exercise.distanceStyle
         self.distanceStyle = style
         let daily = Self.dailyMaxDistanceSets(in: workoutSets, for: exercise)
         self.firstDataDate = daily.first?.workout?.date

--- a/LOGIT/Features/Exercise/ExerciseDetail/Tiles/ExerciseDistanceTile.swift
+++ b/LOGIT/Features/Exercise/ExerciseDetail/Tiles/ExerciseDistanceTile.swift
@@ -13,13 +13,8 @@ struct ExerciseDistanceTile: View {
     /// Leads the tile with the exercise name (the pinned Summary grid); see `ExerciseBestMetricTile`.
     var showsExerciseName: Bool = false
 
-    /// The exercise's distance scale (km for cardio, m for carries); values are stored in meters.
-    private var distanceStyle: SetMeasurementType.DistanceStyle {
-        exercise.measurementType.distanceStyle ?? .long
-    }
-
     var body: some View {
-        let style = distanceStyle
+        let style = exercise.distanceStyle
         ExerciseBestMetricTile(
             exercise: exercise,
             workoutSets: workoutSets,

--- a/LOGIT/Features/Exercise/ExerciseDetail/Tiles/ExerciseDistanceTile.swift
+++ b/LOGIT/Features/Exercise/ExerciseDetail/Tiles/ExerciseDistanceTile.swift
@@ -1,0 +1,61 @@
+//
+//  ExerciseDistanceTile.swift
+//  LOGIT
+//
+//  Created by Lukas Kaibel on 21.07.26.
+//
+
+import SwiftUI
+
+struct ExerciseDistanceTile: View {
+    let exercise: Exercise
+    let workoutSets: [WorkoutSet]
+    /// Leads the tile with the exercise name (the pinned Summary grid); see `ExerciseBestMetricTile`.
+    var showsExerciseName: Bool = false
+
+    /// The exercise's distance scale (km for cardio, m for carries); values are stored in meters.
+    private var distanceStyle: SetMeasurementType.DistanceStyle {
+        exercise.measurementType.distanceStyle ?? .long
+    }
+
+    var body: some View {
+        let style = distanceStyle
+        ExerciseBestMetricTile(
+            exercise: exercise,
+            workoutSets: workoutSets,
+            title: ExercisePrimaryMetric.distance.shortTitle,
+            unit: distanceUnitTitle(for: style),
+            showsExerciseName: showsExerciseName,
+            metricValue: { $0.maximum(.distance, for: exercise) },
+            formattedValue: { formatDistanceForDisplay(Int64($0), style: style) },
+            chartValue: { distanceChartValue($0, style: style) }
+        )
+    }
+}
+
+/// A stored distance (meters) as the number the charts plot — km/mi decimal for the long scale,
+/// whole m/yd for the short one, matching the formatted values beside the chart.
+func distanceChartValue(_ meters: Int, style: SetMeasurementType.DistanceStyle) -> Double {
+    switch style {
+    case .long: return convertDistanceForDisplayingDecimal(Int64(meters))
+    case .short: return Double(convertShortDistanceForDisplaying(Int64(meters)))
+    }
+}
+
+private struct PreviewWrapperView: View {
+    @EnvironmentObject private var database: Database
+
+    var body: some View {
+        NavigationStack {
+            ExerciseDistanceTile(exercise: database.getExercises().first!, workoutSets: database.getExercises().flatMap { $0.sets })
+        }
+    }
+}
+
+struct ExerciseDistanceTileView_Previews: PreviewProvider {
+    static var previews: some View {
+        PreviewWrapperView()
+            .previewEnvironmentObjects()
+            .padding()
+    }
+}

--- a/LOGIT/Features/Exercise/ExerciseEditScreen.swift
+++ b/LOGIT/Features/Exercise/ExerciseEditScreen.swift
@@ -18,6 +18,7 @@ struct ExerciseEditScreen: View {
     @State private var exerciseName: String
     @State private var muscleGroup: MuscleGroup
     @State private var measurementType: SetMeasurementType
+    @State private var distanceStyle: SetMeasurementType.DistanceStyle
     @State private var primaryMetric: ExercisePrimaryMetric
     @State private var showingExerciseExistsAlert: Bool = false
     @State private var showingExerciseNameEmptyAlert: Bool = false
@@ -43,6 +44,11 @@ struct ExerciseEditScreen: View {
         _exerciseName = State(initialValue: initialExerciseName ?? exerciseToEdit?.displayName ?? "")
         _muscleGroup = State(initialValue: exerciseToEdit?.muscleGroup ?? initialMuscleGroup)
         _measurementType = State(initialValue: exerciseToEdit?.measurementType ?? .repsAndWeight)
+        _distanceStyle = State(
+            initialValue: exerciseToEdit?.distanceStyle
+                ?? (exerciseToEdit?.measurementType ?? .repsAndWeight).distanceStyle
+                ?? .long
+        )
         _primaryMetric = State(initialValue: exerciseToEdit?.primaryMetric ?? .defaultMetric)
     }
 
@@ -92,6 +98,31 @@ struct ExerciseEditScreen: View {
                             .font(.footnote)
                             .foregroundStyle(.secondary)
                             .padding(.horizontal)
+                    }
+                }
+
+                // Distance scale (km vs m, mi vs yd) — a display choice; distances are always
+                // stored in meters, so switching never touches recorded values.
+                if measurementType.usesDistance {
+                    VStack(alignment: .leading) {
+                        Text(NSLocalizedString("distanceUnit", comment: ""))
+                            .fontWeight(.semibold)
+                            .foregroundColor(.secondary)
+                            .padding(.horizontal)
+                        Picker(NSLocalizedString("distanceUnit", comment: ""), selection: $distanceStyle) {
+                            ForEach(SetMeasurementType.DistanceStyle.allCases, id: \.self) { style in
+                                Text(distanceStyleTitle(for: style)).tag(style)
+                            }
+                        }
+                        .pickerStyle(.segmented)
+                        .padding(.horizontal)
+                        .onChange(of: measurementType) { _, newType in
+                            // A newly chosen measurement resets the scale to its natural
+                            // default — the user can still flip it right here.
+                            if let defaultStyle = newType.distanceStyle {
+                                distanceStyle = defaultStyle
+                            }
+                        }
                     }
                 }
 
@@ -202,6 +233,9 @@ struct ExerciseEditScreen: View {
                 muscleGroup: muscleGroup,
                 measurementType: measurementType
             )
+        }
+        if measurementType.usesDistance {
+            exercise.distanceStyle = distanceStyle
         }
         database.save()
         exercise.primaryMetric = primaryMetric

--- a/LOGIT/Features/Home/SummaryProgressTab.swift
+++ b/LOGIT/Features/Home/SummaryProgressTab.swift
@@ -350,7 +350,7 @@ struct ProgressHighlightsTile: View {
 
     private func hero(_ record: WorkoutProgressReport.PRRecord) -> some View {
         let color = record.exercise.muscleGroup?.color ?? .accentColor
-        let display = personalRecordDisplay(record.value, metric: record.metric)
+        let display = personalRecordDisplay(record.value, metric: record.metric, exercise: record.exercise)
         let gain: Double? = record.previousBest > 0
             ? (Double(record.value) - Double(record.previousBest)) / Double(record.previousBest) * 100
             : nil

--- a/LOGIT/Features/SettingsScreen.swift
+++ b/LOGIT/Features/SettingsScreen.swift
@@ -15,6 +15,7 @@ struct SettingsScreen: View {
     // MARK: - UserDefaults
 
     @AppStorage("weightUnit") var weightUnit: WeightUnit = .kg
+    @AppStorage("distanceUnit") var distanceUnit: DistanceUnit = .km
     @AppStorage("preventAutoLock") var preventAutoLock: Bool = true
     @AppStorage("timerIsMuted") var timerIsMuted: Bool = false
 
@@ -84,16 +85,28 @@ struct SettingsScreen: View {
 
     private var generalSection: some View {
         section(NSLocalizedString("general", comment: "")) {
-            HStack {
-                Text(NSLocalizedString("unit", comment: ""))
-                Spacer()
-                Picker(NSLocalizedString("unit", comment: ""), selection: $weightUnit) {
-                    Text("kg").tag(WeightUnit.kg)
-                    Text("lbs").tag(WeightUnit.lbs)
+            VStack(spacing: CELL_SPACING) {
+                HStack {
+                    Text(NSLocalizedString("unit", comment: ""))
+                    Spacer()
+                    Picker(NSLocalizedString("unit", comment: ""), selection: $weightUnit) {
+                        Text("kg").tag(WeightUnit.kg)
+                        Text("lbs").tag(WeightUnit.lbs)
+                    }
                 }
+                .padding(CELL_PADDING)
+                .tileStyle()
+                HStack {
+                    Text(NSLocalizedString("distanceUnit", comment: ""))
+                    Spacer()
+                    Picker(NSLocalizedString("distanceUnit", comment: ""), selection: $distanceUnit) {
+                        Text("km").tag(DistanceUnit.km)
+                        Text("mi").tag(DistanceUnit.mi)
+                    }
+                }
+                .padding(CELL_PADDING)
+                .tileStyle()
             }
-            .padding(CELL_PADDING)
-            .tileStyle()
         }
     }
 

--- a/LOGIT/Features/Template/Cells/TemplateSetCells/TemplateSetCell.swift
+++ b/LOGIT/Features/Template/Cells/TemplateSetCells/TemplateSetCell.swift
@@ -144,6 +144,26 @@ struct TemplateSetCell: View {
                             }
                         }
                     }
+                    // Distance scale — an exercise-wide display choice (values stay meters),
+                    // offered here too so a re-typed set can fix its unit in the same menu.
+                    if templateSet.measurementType.usesDistance, let exercise = templateSet.exercise {
+                        Section {
+                            ForEach(SetMeasurementType.DistanceStyle.allCases, id: \.self) { style in
+                                Button {
+                                    exercise.distanceStyle = style
+                                } label: {
+                                    HStack {
+                                        Text(distanceStyleTitle(for: style))
+                                        if templateSet.measurementType.distanceStyle(for: exercise) == style {
+                                            Image(systemName: "checkmark")
+                                        }
+                                    }
+                                }
+                            }
+                        } header: {
+                            Text(NSLocalizedString("distanceUnit", comment: ""))
+                        }
+                    }
                 } label: {
                     Label(
                         NSLocalizedString("measurementType", comment: ""),

--- a/LOGIT/Features/Template/Cells/TemplateSetGroupCell.swift
+++ b/LOGIT/Features/Template/Cells/TemplateSetGroupCell.swift
@@ -340,6 +340,26 @@ struct TemplateSetGroupCell: View {
                 } header: {
                     Text(NSLocalizedString("measurementType", comment: ""))
                 }
+                // The distance scale is the user's choice per exercise (km vs m, mi vs yd) —
+                // distances are stored in meters regardless, so switching only changes how
+                // they're shown and entered, everywhere this exercise appears.
+                if setGroup.measurementType.usesDistance, let exercise = setGroup.exercise {
+                    Section {
+                        ForEach(SetMeasurementType.DistanceStyle.allCases, id: \.self) { style in
+                            Button {
+                                exercise.distanceStyle = style
+                            } label: {
+                                Label(
+                                    distanceStyleTitle(for: style),
+                                    systemImage: setGroup.measurementType.distanceStyle(for: exercise) == style
+                                        ? "checkmark" : ""
+                                )
+                            }
+                        }
+                    } header: {
+                        Text(NSLocalizedString("distanceUnit", comment: ""))
+                    }
+                }
             }
         } label: {
             Image(systemName: "ellipsis")

--- a/LOGIT/Features/Workout/Cells/WorkoutSetCells/WorkoutSetCell.swift
+++ b/LOGIT/Features/Workout/Cells/WorkoutSetCells/WorkoutSetCell.swift
@@ -216,6 +216,26 @@ struct WorkoutSetCell: View {
                             }
                         }
                     }
+                    // Distance scale — an exercise-wide display choice (values stay meters),
+                    // offered here too so a re-typed set can fix its unit in the same menu.
+                    if workoutSet.measurementType.usesDistance, let exercise = workoutSet.exercise {
+                        Section {
+                            ForEach(SetMeasurementType.DistanceStyle.allCases, id: \.self) { style in
+                                Button {
+                                    exercise.distanceStyle = style
+                                } label: {
+                                    HStack {
+                                        Text(distanceStyleTitle(for: style))
+                                        if workoutSet.measurementType.distanceStyle(for: exercise) == style {
+                                            Image(systemName: "checkmark")
+                                        }
+                                    }
+                                }
+                            }
+                        } header: {
+                            Text(NSLocalizedString("distanceUnit", comment: ""))
+                        }
+                    }
                 } label: {
                     Label(
                         NSLocalizedString("measurementType", comment: ""),

--- a/LOGIT/Features/Workout/Cells/WorkoutSetGroupCell.swift
+++ b/LOGIT/Features/Workout/Cells/WorkoutSetGroupCell.swift
@@ -693,6 +693,7 @@ private struct SetGroupMetricComparison {
         case .weight: return setGroup.sets.map { $0.maximum(.weight, for: exercise) }.max() ?? 0
         case .repetitions: return setGroup.sets.map { $0.maximum(.repetitions, for: exercise) }.max() ?? 0
         case .duration: return setGroup.sets.map { $0.maximum(.duration, for: exercise) }.max() ?? 0
+        case .distance: return setGroup.sets.map { $0.maximum(.distance, for: exercise) }.max() ?? 0
         }
     }
 
@@ -732,6 +733,7 @@ private struct SetGroupMetricComparison {
             case .weight: return best.maximum(.weight, for: exercise)
             case .repetitions: return best.maximum(.repetitions, for: exercise)
             case .duration: return best.maximum(.duration, for: exercise)
+            case .distance: return best.maximum(.distance, for: exercise)
             }
         }
         // Untrained for over a month → the window is empty. Fall back to the all-time best so there
@@ -743,6 +745,7 @@ private struct SetGroupMetricComparison {
             case .weight: return workoutSet.maximum(.weight, for: exercise)
             case .repetitions: return workoutSet.maximum(.repetitions, for: exercise)
             case .duration: return workoutSet.maximum(.duration, for: exercise)
+            case .distance: return workoutSet.maximum(.distance, for: exercise)
             }
         }
         let allTimeBest = priorSets.map(value).max() ?? 0
@@ -782,6 +785,7 @@ private struct SetGroupMetricComparison {
         case .weight: return priorSets.map { $0.maximum(.weight, for: exercise) }.max() ?? 0
         case .repetitions: return priorSets.map { $0.maximum(.repetitions, for: exercise) }.max() ?? 0
         case .duration: return priorSets.map { $0.maximum(.duration, for: exercise) }.max() ?? 0
+        case .distance: return priorSets.map { $0.maximum(.distance, for: exercise) }.max() ?? 0
         }
     }
 
@@ -1056,7 +1060,19 @@ private struct MetricBadgeView: View {
             return UnitView(value: "\(value)", unit: NSLocalizedString("reps", comment: ""), configuration: .extraSmall)
         case .duration:
             return UnitView(value: "\(value)", unit: NSLocalizedString("sec", comment: ""), configuration: .extraSmall)
+        case .distance:
+            return UnitView(
+                value: formatDistanceForDisplay(Int64(value), style: distanceStyle),
+                unit: distanceUnitTitle(for: distanceStyle),
+                configuration: .extraSmall
+            )
         }
+    }
+
+    /// The distance scale for this exercise's displayed values — from its measurement type,
+    /// defaulting to the cardio (km) scale.
+    private var distanceStyle: SetMeasurementType.DistanceStyle {
+        setGroup.exercise?.measurementType.distanceStyle ?? .long
     }
 
     // MARK: - Trend rendering (math lives in SetGroupMetricComparison)
@@ -1116,6 +1132,8 @@ private struct MetricBadgeView: View {
             return "\(value) \(NSLocalizedString("reps", comment: ""))"
         case .duration:
             return "\(value) \(NSLocalizedString("sec", comment: ""))"
+        case .distance:
+            return "\(formatDistanceForDisplay(Int64(value), style: distanceStyle)) \(distanceUnitTitle(for: distanceStyle))"
         }
     }
 
@@ -1292,7 +1310,12 @@ struct MetricInfoPanel: View {
     var onOpenDetail: ((ExercisePrimaryMetric) -> Void)?
     @State private var selectedMetric: ExercisePrimaryMetric
 
-    private let metrics = ExercisePrimaryMetric.allCases
+    /// Only the metrics that fit how the exercise is measured — five total metrics exist now,
+    /// and a segmented control full of inapplicable ones (an e1RM segment on a plank) helps no
+    /// one. Matches the badge's cycling order and the exercise editor's picker.
+    private var metrics: [ExercisePrimaryMetric] {
+        ExercisePrimaryMetric.allowed(for: setGroup.exercise?.measurementType ?? .repsAndWeight)
+    }
 
     /// Same math as the badge — see the type's doc.
     private var comparison: SetGroupMetricComparison { SetGroupMetricComparison(setGroup: setGroup) }
@@ -1424,6 +1447,7 @@ struct MetricInfoPanel: View {
         case .weight: return NSLocalizedString("metricInfoWeight", comment: "")
         case .repetitions: return NSLocalizedString("metricInfoReps", comment: "")
         case .duration: return NSLocalizedString("metricInfoDuration", comment: "")
+        case .distance: return NSLocalizedString("metricInfoDistance", comment: "")
         }
     }
 
@@ -1442,6 +1466,7 @@ struct MetricInfoPanel: View {
         case .estimatedOneRepMax: return formatEstimatedOneRepMax(value)
         case .weight: return formatWeightForDisplay(value)
         case .repetitions, .duration: return String(value)
+        case .distance: return formatDistanceForDisplay(Int64(value), style: distanceStyle)
         }
     }
 
@@ -1450,7 +1475,13 @@ struct MetricInfoPanel: View {
         case .estimatedOneRepMax, .weight: return WeightUnit.used.rawValue
         case .repetitions: return NSLocalizedString("reps", comment: "")
         case .duration: return NSLocalizedString("sec", comment: "")
+        case .distance: return distanceUnitTitle(for: distanceStyle)
         }
+    }
+
+    /// The distance scale for displayed values — same rule as the badge's.
+    private var distanceStyle: SetMeasurementType.DistanceStyle {
+        setGroup.exercise?.measurementType.distanceStyle ?? .long
     }
 
     // MARK: - Progression chart
@@ -1461,6 +1492,7 @@ struct MetricInfoPanel: View {
         case .weight: return set.maximum(.weight, for: exercise)
         case .repetitions: return set.maximum(.repetitions, for: exercise)
         case .duration: return set.maximum(.duration, for: exercise)
+        case .distance: return set.maximum(.distance, for: exercise)
         }
     }
 
@@ -1468,6 +1500,11 @@ struct MetricInfoPanel: View {
         switch metric {
         case .estimatedOneRepMax, .weight: return convertWeightForDisplayingDecimal(base)
         case .repetitions, .duration: return Double(base)
+        case .distance:
+            switch distanceStyle {
+            case .long: return convertDistanceForDisplayingDecimal(Int64(base))
+            case .short: return Double(convertShortDistanceForDisplaying(Int64(base)))
+            }
         }
     }
 

--- a/LOGIT/Features/Workout/Cells/WorkoutSetGroupCell.swift
+++ b/LOGIT/Features/Workout/Cells/WorkoutSetGroupCell.swift
@@ -472,6 +472,27 @@ struct WorkoutSetGroupCell: View {
                 } header: {
                     Text(NSLocalizedString("measurementType", comment: ""))
                 }
+                // The distance scale is the user's choice per exercise (km vs m, mi vs yd) —
+                // distances are stored in meters regardless, so switching only changes how
+                // they're shown and entered, everywhere this exercise appears.
+                if setGroup.measurementType.usesDistance, let exercise = setGroup.exercise {
+                    Section {
+                        ForEach(SetMeasurementType.DistanceStyle.allCases, id: \.self) { style in
+                            Button {
+                                exercise.distanceStyle = style
+                            } label: {
+                                HStack {
+                                    Text(distanceStyleTitle(for: style))
+                                    if setGroup.measurementType.distanceStyle(for: exercise) == style {
+                                        Image(systemName: "checkmark")
+                                    }
+                                }
+                            }
+                        }
+                    } header: {
+                        Text(NSLocalizedString("distanceUnit", comment: ""))
+                    }
+                }
             }
             if let onReorderSetGroups {
                 Section {
@@ -1072,7 +1093,7 @@ private struct MetricBadgeView: View {
     /// The distance scale for this exercise's displayed values — from its measurement type,
     /// defaulting to the cardio (km) scale.
     private var distanceStyle: SetMeasurementType.DistanceStyle {
-        setGroup.exercise?.measurementType.distanceStyle ?? .long
+        setGroup.exercise?.distanceStyle ?? .long
     }
 
     // MARK: - Trend rendering (math lives in SetGroupMetricComparison)
@@ -1481,7 +1502,7 @@ struct MetricInfoPanel: View {
 
     /// The distance scale for displayed values — same rule as the badge's.
     private var distanceStyle: SetMeasurementType.DistanceStyle {
-        setGroup.exercise?.measurementType.distanceStyle ?? .long
+        setGroup.exercise?.distanceStyle ?? .long
     }
 
     // MARK: - Progression chart

--- a/LOGIT/Features/Workout/LiveActivity/WorkoutLiveActivitySnapshotBuilder.swift
+++ b/LOGIT/Features/Workout/LiveActivity/WorkoutLiveActivitySnapshotBuilder.swift
@@ -235,6 +235,16 @@ enum WorkoutLiveActivitySnapshotBuilder {
         WeightUnit.used.rawValue
     }
 
+    /// The unit label for an entry's performance slot: reps for rep-based entries, the
+    /// distance unit for distance-tracking ones (distance is their primary field on this
+    /// glanceable surface), seconds otherwise.
+    private static func performanceLocalizedUnit(for type: SetMeasurementType?) -> String {
+        guard let type else { return repsLocalizedUnit }
+        if type.usesRepetitions { return repsLocalizedUnit }
+        if let distanceStyle = type.distanceStyle { return distanceUnitTitle(for: distanceStyle) }
+        return secondsLocalizedUnit
+    }
+
     /// The values shown on the "current set" side: for compound sets the first exercise's
     /// entry (the focused-side variant is built inline in `build`), otherwise all entries
     /// (a drop set shows one segment per drop).
@@ -287,6 +297,10 @@ enum WorkoutLiveActivitySnapshotBuilder {
                     ? value.repetitions : (template?.repetitions ?? 0)
                 performanceSegments.append(String(shown))
                 performancePlaceholders.append(value.repetitions == 0)
+            } else if let distanceStyle = value.type.distanceStyle {
+                let shown = value.distance > 0 ? value.distance : (template?.distance ?? 0)
+                performanceSegments.append(formatDistanceForDisplay(shown, style: distanceStyle))
+                performancePlaceholders.append(value.distance == 0)
             } else if value.type.usesDuration {
                 let shown = value.duration > 0 ? value.duration : (template?.duration ?? 0)
                 performanceSegments.append(String(shown))
@@ -298,11 +312,10 @@ enum WorkoutLiveActivitySnapshotBuilder {
                 weightPlaceholders.append(value.weight == 0)
             }
         }
-        let usesRepetitions = values.first?.type.usesRepetitions ?? true
         return ExerciseMetricDisplay(
             repetitionSegments: performanceSegments,
             repetitionSegmentPlaceholders: performancePlaceholders,
-            repetitionsUnit: usesRepetitions ? repsLocalizedUnit : secondsLocalizedUnit,
+            repetitionsUnit: performanceLocalizedUnit(for: values.first?.type),
             weightSegments: weightSegments,
             weightSegmentPlaceholders: weightPlaceholders,
             weightUnit: liveActivityWeightUnit
@@ -352,6 +365,12 @@ enum WorkoutLiveActivitySnapshotBuilder {
         for value in values {
             if value.type.usesRepetitions, value.repetitions > 0 {
                 performanceSegments.append(String(value.repetitions))
+            } else if let distanceStyle = value.type.distanceStyle {
+                // Distance-tracking types show only the distance here — the display carries one
+                // unit for all segments, so a duration fallback would mislabel seconds as km.
+                if value.distance > 0 {
+                    performanceSegments.append(formatDistanceForDisplay(value.distance, style: distanceStyle))
+                }
             } else if value.type.usesDuration, !value.type.usesRepetitions, value.duration > 0 {
                 performanceSegments.append(String(value.duration))
             }
@@ -362,11 +381,10 @@ enum WorkoutLiveActivitySnapshotBuilder {
         guard !performanceSegments.isEmpty || !weightSegments.isEmpty else {
             return .emptyForLiveActivity()
         }
-        let usesRepetitions = values.first?.type.usesRepetitions ?? true
         return ExerciseMetricDisplay(
             repetitionSegments: performanceSegments,
             repetitionSegmentPlaceholders: Array(repeating: false, count: performanceSegments.count),
-            repetitionsUnit: usesRepetitions ? repsLocalizedUnit : secondsLocalizedUnit,
+            repetitionsUnit: performanceLocalizedUnit(for: values.first?.type),
             weightSegments: weightSegments,
             weightSegmentPlaceholders: Array(repeating: false, count: weightSegments.count),
             weightUnit: liveActivityWeightUnit

--- a/LOGIT/Features/Workout/LiveActivity/WorkoutLiveActivitySnapshotBuilder.swift
+++ b/LOGIT/Features/Workout/LiveActivity/WorkoutLiveActivitySnapshotBuilder.swift
@@ -238,10 +238,12 @@ enum WorkoutLiveActivitySnapshotBuilder {
     /// The unit label for an entry's performance slot: reps for rep-based entries, the
     /// distance unit for distance-tracking ones (distance is their primary field on this
     /// glanceable surface), seconds otherwise.
-    private static func performanceLocalizedUnit(for type: SetMeasurementType?) -> String {
-        guard let type else { return repsLocalizedUnit }
-        if type.usesRepetitions { return repsLocalizedUnit }
-        if let distanceStyle = type.distanceStyle { return distanceUnitTitle(for: distanceStyle) }
+    private static func performanceLocalizedUnit(for value: SetEntryValues?) -> String {
+        guard let value else { return repsLocalizedUnit }
+        if value.type.usesRepetitions { return repsLocalizedUnit }
+        if let distanceStyle = value.type.distanceStyle(for: value.exercise) {
+            return distanceUnitTitle(for: distanceStyle)
+        }
         return secondsLocalizedUnit
     }
 
@@ -297,7 +299,7 @@ enum WorkoutLiveActivitySnapshotBuilder {
                     ? value.repetitions : (template?.repetitions ?? 0)
                 performanceSegments.append(String(shown))
                 performancePlaceholders.append(value.repetitions == 0)
-            } else if let distanceStyle = value.type.distanceStyle {
+            } else if let distanceStyle = value.type.distanceStyle(for: value.exercise) {
                 let shown = value.distance > 0 ? value.distance : (template?.distance ?? 0)
                 performanceSegments.append(formatDistanceForDisplay(shown, style: distanceStyle))
                 performancePlaceholders.append(value.distance == 0)
@@ -315,7 +317,7 @@ enum WorkoutLiveActivitySnapshotBuilder {
         return ExerciseMetricDisplay(
             repetitionSegments: performanceSegments,
             repetitionSegmentPlaceholders: performancePlaceholders,
-            repetitionsUnit: performanceLocalizedUnit(for: values.first?.type),
+            repetitionsUnit: performanceLocalizedUnit(for: values.first),
             weightSegments: weightSegments,
             weightSegmentPlaceholders: weightPlaceholders,
             weightUnit: liveActivityWeightUnit
@@ -365,7 +367,7 @@ enum WorkoutLiveActivitySnapshotBuilder {
         for value in values {
             if value.type.usesRepetitions, value.repetitions > 0 {
                 performanceSegments.append(String(value.repetitions))
-            } else if let distanceStyle = value.type.distanceStyle {
+            } else if let distanceStyle = value.type.distanceStyle(for: value.exercise) {
                 // Distance-tracking types show only the distance here — the display carries one
                 // unit for all segments, so a duration fallback would mislabel seconds as km.
                 if value.distance > 0 {
@@ -384,7 +386,7 @@ enum WorkoutLiveActivitySnapshotBuilder {
         return ExerciseMetricDisplay(
             repetitionSegments: performanceSegments,
             repetitionSegmentPlaceholders: Array(repeating: false, count: performanceSegments.count),
-            repetitionsUnit: performanceLocalizedUnit(for: values.first?.type),
+            repetitionsUnit: performanceLocalizedUnit(for: values.first),
             weightSegments: weightSegments,
             weightSegmentPlaceholders: Array(repeating: false, count: weightSegments.count),
             weightUnit: liveActivityWeightUnit

--- a/LOGIT/Features/Workout/WorkoutProgressSection.swift
+++ b/LOGIT/Features/Workout/WorkoutProgressSection.swift
@@ -435,9 +435,7 @@ struct WorkoutPersonalRecordCard: View {
             case .estimatedOneRepMax, .weight: value = convertWeightForDisplayingDecimal(best)
             case .repetitions, .duration: value = Double(best)
             case .distance:
-                value = distanceChartValue(
-                    best, style: record.exercise.measurementType.distanceStyle ?? .long
-                )
+                value = distanceChartValue(best, style: record.exercise.distanceStyle)
             }
             return ExerciseTileSparkline.Point(date: day, value: value)
         }

--- a/LOGIT/Features/Workout/WorkoutProgressSection.swift
+++ b/LOGIT/Features/Workout/WorkoutProgressSection.swift
@@ -92,6 +92,7 @@ struct WorkoutProgressReport {
                 case .weight: return workoutSet.maximum(.weight, for: exercise)
                 case .repetitions: return workoutSet.maximum(.repetitions, for: exercise)
                 case .duration: return workoutSet.maximum(.duration, for: exercise)
+                case .distance: return workoutSet.maximum(.distance, for: exercise)
                 }
             }
 
@@ -179,6 +180,7 @@ private func personalRecordSetValue(_ workoutSet: WorkoutSet, exercise: Exercise
     case .weight: return workoutSet.maximum(.weight, for: exercise)
     case .repetitions: return workoutSet.maximum(.repetitions, for: exercise)
     case .duration: return workoutSet.maximum(.duration, for: exercise)
+    case .distance: return workoutSet.maximum(.distance, for: exercise)
     }
 }
 
@@ -206,6 +208,7 @@ struct WorkoutPersonalBestsTile: View {
             case .estimatedOneRepMax: return 1
             case .repetitions: return 2
             case .duration: return 3
+            case .distance: return 4
             }
         }
         var best: [NSManagedObjectID: WorkoutProgressReport.PRRecord] = [:]
@@ -380,8 +383,8 @@ struct WorkoutPersonalRecordCard: View {
     /// the right, and the percent gain of one over the other in the pill between them — the shared
     /// `MetricComparisonView` the chart-detail headers wear, so this PR jump reads the same way.
     private func comparison(color: Color) -> some View {
-        let previous = personalRecordDisplay(record.previousBest, metric: record.metric)
-        let current = personalRecordDisplay(record.value, metric: record.metric)
+        let previous = personalRecordDisplay(record.previousBest, metric: record.metric, exercise: record.exercise)
+        let current = personalRecordDisplay(record.value, metric: record.metric, exercise: record.exercise)
         let percentChange = record.previousBest > 0
             ? (Double(record.value) - Double(record.previousBest)) / Double(record.previousBest) * 100
             : nil
@@ -431,6 +434,10 @@ struct WorkoutPersonalRecordCard: View {
             switch record.metric {
             case .estimatedOneRepMax, .weight: value = convertWeightForDisplayingDecimal(best)
             case .repetitions, .duration: value = Double(best)
+            case .distance:
+                value = distanceChartValue(
+                    best, style: record.exercise.measurementType.distanceStyle ?? .long
+                )
             }
             return ExerciseTileSparkline.Point(date: day, value: value)
         }

--- a/LOGIT/Resources/default_exercises.json
+++ b/LOGIT/Resources/default_exercises.json
@@ -1,5 +1,5 @@
 {
- "version": 6,
+ "version": 7,
  "exercises": [
   {
    "id": "default_001",
@@ -5254,7 +5254,7 @@
      "Rinfrescati con una corsa più lenta o una camminata dopo."
     ]
    },
-   "measurementType": "duration"
+   "measurementType": "distanceAndDuration"
   },
   {
    "id": "default_077",
@@ -5326,7 +5326,7 @@
      "Mantieni una cadenza costante per tutta la sessione."
     ]
    },
-   "measurementType": "duration"
+   "measurementType": "distanceAndDuration"
   },
   {
    "id": "default_078",
@@ -5398,7 +5398,7 @@
      "Mantieni il movimento fluido e mantieni un ritmo costante."
     ]
    },
-   "measurementType": "duration"
+   "measurementType": "distanceAndDuration"
   },
   {
    "id": "default_079",
@@ -5542,7 +5542,7 @@
      "Mantieni un ritmo costante durante l'allenamento."
     ]
    },
-   "measurementType": "duration"
+   "measurementType": "distanceAndDuration"
   },
   {
    "id": "default_081",
@@ -5686,7 +5686,7 @@
      "Rinfrescati con giri più lenti alla fine della sessione."
     ]
    },
-   "measurementType": "duration"
+   "measurementType": "distanceAndDuration"
   },
   {
    "id": "default_083",
@@ -11343,7 +11343,7 @@
      "Rinfrescati con una corsetta leggera o una camminata successiva."
     ]
    },
-   "measurementType": "duration"
+   "measurementType": "distanceAndDuration"
   },
   {
    "id": "default_166",
@@ -11479,7 +11479,7 @@
      "Mantenere un ritmo costante o uno schema di intervalli."
     ]
    },
-   "measurementType": "duration"
+   "measurementType": "distanceAndDuration"
   },
   {
    "id": "default_168",
@@ -11551,7 +11551,7 @@
      "Mantieni il movimento fluido e mantieni un ritmo costante."
     ]
    },
-   "measurementType": "duration"
+   "measurementType": "distanceAndDuration"
   },
   {
    "id": "default_169",
@@ -11623,7 +11623,7 @@
      "Mantieni un ritmo potente per tutto il tempo."
     ]
    },
-   "measurementType": "duration"
+   "measurementType": "distanceAndDuration"
   },
   {
    "id": "default_170",
@@ -11695,7 +11695,7 @@
      "Abbassa i pesi con controllo."
     ]
    },
-   "measurementType": "weightAndDuration"
+   "measurementType": "weightAndDistance"
   },
   {
    "id": "default_171",
@@ -13250,7 +13250,7 @@
      "Spingi per la distanza desiderata, poi riposa e ripeti."
     ]
    },
-   "measurementType": "weightAndDuration"
+   "measurementType": "weightAndDistance"
   },
   {
    "id": "default_193",
@@ -13322,7 +13322,7 @@
      "Reimpostare e ripetere per i set desiderati."
     ]
    },
-   "measurementType": "weightAndDuration"
+   "measurementType": "weightAndDistance"
   },
   {
    "id": "default_194",
@@ -13818,6 +13818,454 @@
      "Porta il petto agli anelli mentre stringi la schiena.",
      "Abbassati lentamente con controllo.",
      "Mantieni il corpo dritto durante tutto il movimento."
+    ]
+   }
+  },
+  {
+   "id": "default_201",
+   "nameKey": "_default.exercise.walking",
+   "muscleGroup": "cardio",
+   "measurementType": "distanceAndDuration",
+   "instructions": [
+    "Stand tall and walk at a comfortable, steady pace.",
+    "Swing your arms naturally and keep your core lightly engaged.",
+    "Roll through each step from heel to toe.",
+    "Walk for the desired distance or time."
+   ],
+   "localizedInstructions": {
+    "de": [
+     "Stehen Sie aufrecht und gehen Sie in einem angenehmen, gleichmäßigen Tempo.",
+     "Schwingen Sie die Arme natürlich und halten Sie den Rumpf leicht angespannt.",
+     "Rollen Sie jeden Schritt von der Ferse bis zu den Zehen ab.",
+     "Gehen Sie die gewünschte Distanz oder Zeit."
+    ],
+    "es": [
+     "Párate erguido y camina a un ritmo cómodo y constante.",
+     "Balancea los brazos con naturalidad y mantén el core ligeramente activado.",
+     "Apoya cada paso del talón a la punta del pie.",
+     "Camina la distancia o el tiempo deseado."
+    ],
+    "fr": [
+     "Tenez-vous droit et marchez à un rythme confortable et régulier.",
+     "Balancez vos bras naturellement et gardez le tronc légèrement engagé.",
+     "Déroulez chaque pas du talon aux orteils.",
+     "Marchez pendant la distance ou le temps souhaité."
+    ],
+    "it": [
+     "Stai in piedi eretto e cammina a un ritmo comodo e costante.",
+     "Fai oscillare le braccia in modo naturale e mantieni il core leggermente attivo.",
+     "Appoggia ogni passo dal tallone alla punta.",
+     "Cammina per la distanza o il tempo desiderato."
+    ],
+    "ja": [
+     "背筋を伸ばして立ち、快適で一定のペースで歩きます。",
+     "腕を自然に振り、体幹を軽く引き締めます。",
+     "かかとからつま先へと体重を移しながら歩きます。",
+     "希望の距離または時間だけ歩きます。"
+    ],
+    "ko": [
+     "똑바로 서서 편안하고 일정한 속도로 걷습니다.",
+     "팔을 자연스럽게 흔들고 코어를 가볍게 유지합니다.",
+     "발뒤꿈치에서 발끝으로 굴리듯 걷습니다.",
+     "원하는 거리 또는 시간만큼 걷습니다."
+    ],
+    "pt-BR": [
+     "Fique ereto e caminhe em um ritmo confortável e constante.",
+     "Balance os braços naturalmente e mantenha o núcleo levemente ativado.",
+     "Role cada passo do calcanhar aos dedos.",
+     "Caminhe pela distância ou tempo desejado."
+    ]
+   }
+  },
+  {
+   "id": "default_202",
+   "nameKey": "_default.exercise.inclineTreadmillWalk",
+   "muscleGroup": "cardio",
+   "measurementType": "distanceAndDuration",
+   "instructions": [
+    "Set the treadmill to the desired incline and a brisk walking speed.",
+    "Stand tall and avoid leaning on the handrails.",
+    "Take controlled steps, driving through your heels.",
+    "Walk for the desired distance or time."
+   ],
+   "localizedInstructions": {
+    "de": [
+     "Stellen Sie das Laufband auf die gewünschte Steigung und ein zügiges Gehtempo ein.",
+     "Stehen Sie aufrecht und stützen Sie sich nicht auf den Handläufen ab.",
+     "Machen Sie kontrollierte Schritte und drücken Sie über die Fersen ab.",
+     "Gehen Sie die gewünschte Distanz oder Zeit."
+    ],
+    "es": [
+     "Ajusta la cinta a la inclinación deseada y a una velocidad de caminata rápida.",
+     "Mantente erguido y evita apoyarte en los pasamanos.",
+     "Da pasos controlados, empujando con los talones.",
+     "Camina la distancia o el tiempo deseado."
+    ],
+    "fr": [
+     "Réglez le tapis sur l'inclinaison souhaitée et une vitesse de marche soutenue.",
+     "Tenez-vous droit et évitez de vous appuyer sur les rampes.",
+     "Faites des pas contrôlés en poussant sur les talons.",
+     "Marchez pendant la distance ou le temps souhaité."
+    ],
+    "it": [
+     "Imposta il tapis roulant sull'inclinazione desiderata e una velocità di camminata sostenuta.",
+     "Stai eretto ed evita di appoggiarti ai corrimano.",
+     "Fai passi controllati spingendo sui talloni.",
+     "Cammina per la distanza o il tempo desiderato."
+    ],
+    "ja": [
+     "トレッドミルを希望の傾斜と速歩のスピードに設定します。",
+     "背筋を伸ばし、手すりに寄りかからないようにします。",
+     "かかとで踏み込みながら、コントロールされた歩幅で歩きます。",
+     "希望の距離または時間だけ歩きます。"
+    ],
+    "ko": [
+     "트레드밀을 원하는 경사와 빠른 걷기 속도로 설정합니다.",
+     "똑바로 서서 손잡이에 기대지 않습니다.",
+     "발뒤꿈치로 밀어내며 통제된 걸음을 내딛습니다.",
+     "원하는 거리 또는 시간만큼 걷습니다."
+    ],
+    "pt-BR": [
+     "Ajuste a esteira na inclinação desejada e em uma velocidade de caminhada rápida.",
+     "Fique ereto e evite se apoiar nos corrimãos.",
+     "Dê passos controlados, empurrando com os calcanhares.",
+     "Caminhe pela distância ou tempo desejado."
+    ]
+   }
+  },
+  {
+   "id": "default_203",
+   "nameKey": "_default.exercise.rucking",
+   "muscleGroup": "cardio",
+   "measurementType": "weightAndDistance",
+   "instructions": [
+    "Load a backpack or rucksack with the desired weight.",
+    "Wear it high and tight against your upper back.",
+    "Walk at a brisk pace with an upright posture.",
+    "Cover the desired distance at a steady pace."
+   ],
+   "localizedInstructions": {
+    "de": [
+     "Beladen Sie einen Rucksack mit dem gewünschten Gewicht.",
+     "Tragen Sie ihn hoch und eng am oberen Rücken.",
+     "Gehen Sie zügig mit aufrechter Haltung.",
+     "Legen Sie die gewünschte Distanz in gleichmäßigem Tempo zurück."
+    ],
+    "es": [
+     "Carga una mochila con el peso deseado.",
+     "Llévala alta y ajustada contra la parte superior de la espalda.",
+     "Camina a paso ligero con una postura erguida.",
+     "Cubre la distancia deseada a un ritmo constante."
+    ],
+    "fr": [
+     "Chargez un sac à dos avec le poids souhaité.",
+     "Portez-le haut et serré contre le haut du dos.",
+     "Marchez d'un pas soutenu avec une posture droite.",
+     "Parcourez la distance souhaitée à un rythme régulier."
+    ],
+    "it": [
+     "Carica uno zaino con il peso desiderato.",
+     "Indossalo alto e aderente alla parte alta della schiena.",
+     "Cammina a passo sostenuto con una postura eretta.",
+     "Copri la distanza desiderata a un ritmo costante."
+    ],
+    "ja": [
+     "バックパックに希望の重量を積みます。",
+     "背中の上部に高く密着させて背負います。",
+     "姿勢を正して速いペースで歩きます。",
+     "一定のペースで希望の距離を歩きます。"
+    ],
+    "ko": [
+     "배낭에 원하는 무게를 넣습니다.",
+     "등 위쪽에 높고 밀착되게 멥니다.",
+     "곧은 자세로 빠르게 걷습니다.",
+     "일정한 속도로 원하는 거리를 이동합니다."
+    ],
+    "pt-BR": [
+     "Carregue uma mochila com o peso desejado.",
+     "Use-a alta e justa contra a parte superior das costas.",
+     "Caminhe em ritmo acelerado com postura ereta.",
+     "Percorra a distância desejada em ritmo constante."
+    ]
+   }
+  },
+  {
+   "id": "default_204",
+   "nameKey": "_default.exercise.suitcaseCarry",
+   "muscleGroup": "abdominals",
+   "measurementType": "weightAndDistance",
+   "instructions": [
+    "Pick up a heavy dumbbell or kettlebell in one hand.",
+    "Stand tall without leaning toward the weight.",
+    "Brace your core to keep your torso level.",
+    "Walk the desired distance, then switch sides."
+   ],
+   "localizedInstructions": {
+    "de": [
+     "Nehmen Sie eine schwere Kurzhantel oder Kettlebell in eine Hand.",
+     "Stehen Sie aufrecht, ohne sich zum Gewicht zu neigen.",
+     "Spannen Sie den Rumpf an, um den Oberkörper gerade zu halten.",
+     "Gehen Sie die gewünschte Distanz und wechseln Sie dann die Seite."
+    ],
+    "es": [
+     "Levanta una mancuerna o pesa rusa pesada con una mano.",
+     "Mantente erguido sin inclinarte hacia el peso.",
+     "Aprieta el core para mantener el torso nivelado.",
+     "Camina la distancia deseada y luego cambia de lado."
+    ],
+    "fr": [
+     "Prenez un haltère lourd ou une kettlebell dans une main.",
+     "Tenez-vous droit sans pencher vers le poids.",
+     "Gainez votre tronc pour garder le buste droit.",
+     "Marchez la distance souhaitée, puis changez de côté."
+    ],
+    "it": [
+     "Prendi un manubrio pesante o un kettlebell con una mano.",
+     "Stai eretto senza inclinarti verso il peso.",
+     "Contrai il core per mantenere il busto in asse.",
+     "Cammina per la distanza desiderata, poi cambia lato."
+    ],
+    "ja": [
+     "片手に重いダンベルまたはケトルベルを持ちます。",
+     "重りの方に傾かず、まっすぐ立ちます。",
+     "体幹を締めて上体を水平に保ちます。",
+     "希望の距離を歩いたら、反対側に持ち替えます。"
+    ],
+    "ko": [
+     "한 손에 무거운 덤벨이나 케틀벨을 듭니다.",
+     "무게 쪽으로 기울지 않고 똑바로 섭니다.",
+     "코어에 힘을 주어 상체를 수평으로 유지합니다.",
+     "원하는 거리를 걸은 후 반대쪽으로 바꿉니다."
+    ],
+    "pt-BR": [
+     "Pegue um halter pesado ou kettlebell em uma mão.",
+     "Fique ereto sem inclinar para o lado do peso.",
+     "Contraia o núcleo para manter o tronco nivelado.",
+     "Caminhe a distância desejada e depois troque de lado."
+    ]
+   }
+  },
+  {
+   "id": "default_205",
+   "nameKey": "_default.exercise.overheadCarry",
+   "muscleGroup": "shoulders",
+   "measurementType": "weightAndDistance",
+   "instructions": [
+    "Press a dumbbell, kettlebell, or barbell overhead.",
+    "Lock out your arms and keep your ribs down.",
+    "Brace your core and walk with short, controlled steps.",
+    "Carry for the desired distance, then lower with control."
+   ],
+   "localizedInstructions": {
+    "de": [
+     "Drücken Sie eine Kurzhantel, Kettlebell oder Langhantel über den Kopf.",
+     "Strecken Sie die Arme durch und halten Sie die Rippen unten.",
+     "Spannen Sie den Rumpf an und gehen Sie mit kurzen, kontrollierten Schritten.",
+     "Tragen Sie die gewünschte Distanz und senken Sie das Gewicht kontrolliert ab."
+    ],
+    "es": [
+     "Presiona una mancuerna, pesa rusa o barra por encima de la cabeza.",
+     "Bloquea los brazos y mantén las costillas abajo.",
+     "Aprieta el core y camina con pasos cortos y controlados.",
+     "Acarrea la distancia deseada y baja el peso con control."
+    ],
+    "fr": [
+     "Poussez un haltère, une kettlebell ou une barre au-dessus de la tête.",
+     "Verrouillez vos bras et gardez les côtes basses.",
+     "Gainez votre tronc et marchez à petits pas contrôlés.",
+     "Portez sur la distance souhaitée, puis redescendez avec contrôle."
+    ],
+    "it": [
+     "Spingi un manubrio, un kettlebell o un bilanciere sopra la testa.",
+     "Blocca le braccia e tieni le costole basse.",
+     "Contrai il core e cammina con passi corti e controllati.",
+     "Trasporta per la distanza desiderata, poi abbassa con controllo."
+    ],
+    "ja": [
+     "ダンベル、ケトルベル、またはバーベルを頭上に押し上げます。",
+     "腕をロックし、肋骨を下げたままにします。",
+     "体幹を締め、短くコントロールされた歩幅で歩きます。",
+     "希望の距離を運び、コントロールしながら下ろします。"
+    ],
+    "ko": [
+     "덤벨, 케틀벨 또는 바벨을 머리 위로 밀어 올립니다.",
+     "팔을 완전히 펴고 갈비뼈를 아래로 유지합니다.",
+     "코어에 힘을 주고 짧고 통제된 걸음으로 걷습니다.",
+     "원하는 거리를 이동한 후 천천히 내립니다."
+    ],
+    "pt-BR": [
+     "Empurre um halter, kettlebell ou barra acima da cabeça.",
+     "Trave os braços e mantenha as costelas para baixo.",
+     "Contraia o núcleo e caminhe com passos curtos e controlados.",
+     "Carregue pela distância desejada e abaixe com controle."
+    ]
+   }
+  },
+  {
+   "id": "default_206",
+   "nameKey": "_default.exercise.yokeCarry",
+   "muscleGroup": "back",
+   "measurementType": "weightAndDistance",
+   "instructions": [
+    "Set the yoke to shoulder height and load it.",
+    "Step under it and brace your upper back against the crossbar.",
+    "Stand up tall with a tight core.",
+    "Take short, quick steps for the desired distance."
+   ],
+   "localizedInstructions": {
+    "de": [
+     "Stellen Sie das Joch auf Schulterhöhe ein und beladen Sie es.",
+     "Treten Sie darunter und pressen Sie den oberen Rücken gegen die Querstange.",
+     "Richten Sie sich mit angespanntem Rumpf auf.",
+     "Machen Sie kurze, schnelle Schritte über die gewünschte Distanz."
+    ],
+    "es": [
+     "Ajusta el yugo a la altura de los hombros y cárgalo.",
+     "Colócate debajo y apoya la parte superior de la espalda contra la barra.",
+     "Ponte de pie con el core apretado.",
+     "Da pasos cortos y rápidos por la distancia deseada."
+    ],
+    "fr": [
+     "Réglez le joug à hauteur d'épaules et chargez-le.",
+     "Placez-vous dessous et calez le haut du dos contre la barre.",
+     "Redressez-vous avec le tronc gainé.",
+     "Faites des pas courts et rapides sur la distance souhaitée."
+    ],
+    "it": [
+     "Regola il giogo all'altezza delle spalle e caricalo.",
+     "Mettiti sotto e appoggia la parte alta della schiena contro la barra.",
+     "Alzati in piedi con il core contratto.",
+     "Fai passi corti e rapidi per la distanza desiderata."
+    ],
+    "ja": [
+     "ヨークを肩の高さに設定し、重量を積みます。",
+     "下に入り、背中上部をクロスバーに押し当てます。",
+     "体幹を締めてまっすぐ立ち上がります。",
+     "短く素早い歩幅で希望の距離を進みます。"
+    ],
+    "ko": [
+     "요크를 어깨 높이로 설정하고 무게를 싣습니다.",
+     "아래로 들어가 등 위쪽을 크로스바에 밀착시킵니다.",
+     "코어에 힘을 주고 똑바로 일어섭니다.",
+     "짧고 빠른 걸음으로 원하는 거리를 이동합니다."
+    ],
+    "pt-BR": [
+     "Ajuste o yoke na altura dos ombros e carregue-o.",
+     "Posicione-se embaixo e apoie a parte superior das costas na barra.",
+     "Levante-se ereto com o núcleo contraído.",
+     "Dê passos curtos e rápidos pela distância desejada."
+    ]
+   }
+  },
+  {
+   "id": "default_207",
+   "nameKey": "_default.exercise.sandbagCarry",
+   "muscleGroup": "back",
+   "measurementType": "weightAndDistance",
+   "instructions": [
+    "Deadlift the sandbag and hug it to your chest.",
+    "Stand tall with your hips under your shoulders.",
+    "Grip tightly and keep your core braced.",
+    "Carry for the desired distance and set it down with control."
+   ],
+   "localizedInstructions": {
+    "de": [
+     "Heben Sie den Sandsack an und drücken Sie ihn an die Brust.",
+     "Stehen Sie aufrecht mit den Hüften unter den Schultern.",
+     "Greifen Sie fest zu und halten Sie den Rumpf angespannt.",
+     "Tragen Sie ihn die gewünschte Distanz und setzen Sie ihn kontrolliert ab."
+    ],
+    "es": [
+     "Levanta el saco de arena y abrázalo contra el pecho.",
+     "Mantente erguido con las caderas bajo los hombros.",
+     "Agarra con fuerza y mantén el core apretado.",
+     "Acarrea la distancia deseada y bájalo con control."
+    ],
+    "fr": [
+     "Soulevez le sac de sable et serrez-le contre votre poitrine.",
+     "Tenez-vous droit, les hanches sous les épaules.",
+     "Serrez fort et gardez le tronc gainé.",
+     "Portez sur la distance souhaitée et posez-le avec contrôle."
+    ],
+    "it": [
+     "Solleva il sacco di sabbia e stringilo al petto.",
+     "Stai eretto con i fianchi sotto le spalle.",
+     "Afferra saldamente e mantieni il core contratto.",
+     "Trasporta per la distanza desiderata e appoggialo con controllo."
+    ],
+    "ja": [
+     "サンドバッグを持ち上げ、胸に抱えます。",
+     "腰を肩の真下に置き、まっすぐ立ちます。",
+     "しっかりと握り、体幹を締めたままにします。",
+     "希望の距離を運び、コントロールしながら下ろします。"
+    ],
+    "ko": [
+     "샌드백을 들어 올려 가슴에 안습니다.",
+     "엉덩이를 어깨 아래에 두고 똑바로 섭니다.",
+     "단단히 잡고 코어에 힘을 유지합니다.",
+     "원하는 거리를 이동한 후 천천히 내려놓습니다."
+    ],
+    "pt-BR": [
+     "Levante o saco de areia e abrace-o contra o peito.",
+     "Fique ereto com os quadris sob os ombros.",
+     "Segure firme e mantenha o núcleo contraído.",
+     "Carregue pela distância desejada e abaixe com controle."
+    ]
+   }
+  },
+  {
+   "id": "default_208",
+   "nameKey": "_default.exercise.shuttleRun",
+   "muscleGroup": "cardio",
+   "measurementType": "distance",
+   "instructions": [
+    "Set two markers 10–20 meters apart.",
+    "Sprint from one marker to the other.",
+    "Touch the line, turn quickly, and sprint back.",
+    "Repeat for the desired total distance."
+   ],
+   "localizedInstructions": {
+    "de": [
+     "Stellen Sie zwei Markierungen im Abstand von 10–20 Metern auf.",
+     "Sprinten Sie von einer Markierung zur anderen.",
+     "Berühren Sie die Linie, drehen Sie schnell um und sprinten Sie zurück.",
+     "Wiederholen Sie dies für die gewünschte Gesamtdistanz."
+    ],
+    "es": [
+     "Coloca dos marcas separadas de 10 a 20 metros.",
+     "Esprinta de una marca a la otra.",
+     "Toca la línea, gira rápido y esprinta de vuelta.",
+     "Repite hasta la distancia total deseada."
+    ],
+    "fr": [
+     "Placez deux repères espacés de 10 à 20 mètres.",
+     "Sprintez d'un repère à l'autre.",
+     "Touchez la ligne, tournez vite et sprintez au retour.",
+     "Répétez jusqu'à la distance totale souhaitée."
+    ],
+    "it": [
+     "Posiziona due riferimenti a 10–20 metri di distanza.",
+     "Scatta da un riferimento all'altro.",
+     "Tocca la linea, girati rapidamente e scatta indietro.",
+     "Ripeti fino alla distanza totale desiderata."
+    ],
+    "ja": [
+     "10〜20メートル離して2つのマーカーを設置します。",
+     "一方のマーカーからもう一方へ全力疾走します。",
+     "ラインにタッチし、素早く方向転換して走り戻ります。",
+     "希望の合計距離になるまで繰り返します。"
+    ],
+    "ko": [
+     "10~20미터 간격으로 두 개의 마커를 설치합니다.",
+     "한 마커에서 다른 마커까지 전력 질주합니다.",
+     "라인을 터치하고 빠르게 돌아 다시 질주합니다.",
+     "원하는 총거리에 도달할 때까지 반복합니다."
+    ],
+    "pt-BR": [
+     "Coloque dois marcadores separados por 10 a 20 metros.",
+     "Corra em velocidade máxima de um marcador ao outro.",
+     "Toque a linha, gire rapidamente e corra de volta.",
+     "Repita até a distância total desejada."
     ]
    }
   }

--- a/LOGIT/Services/DefaultExerciseService.swift
+++ b/LOGIT/Services/DefaultExerciseService.swift
@@ -49,6 +49,29 @@ class DefaultExerciseService: ObservableObject {
     private let lastLoadedVersionKey = "lastLoadedDefaultExercisesVersion"
     private let lastLoadedLocaleKey = "lastLoadedDefaultExercisesLocale"
 
+    /// Measurement types that *older library versions* shipped for these exercises. Loading a
+    /// library update stores an explicit type, which makes the nil-check below blind to later
+    /// library re-types — so an unused exercise still carrying one of these provably (or as good
+    /// as: the user never recorded with it) got its type from the library, and a newer library
+    /// may re-type it. Library v7 moved the cardio machines from duration to distance+duration
+    /// and the carries from weight+duration to weight+distance.
+    private static let supersededLibraryTypes: [String: [SetMeasurementType]] = [
+        // v6 duration -> v7 distanceAndDuration
+        "default_076": [.duration],  // running
+        "default_077": [.duration],  // cycling
+        "default_078": [.duration],  // rowing
+        "default_080": [.duration],  // elliptical
+        "default_082": [.duration],  // swimming
+        "default_165": [.duration],  // sprints
+        "default_167": [.duration],  // assault bike
+        "default_168": [.duration],  // rowing machine
+        "default_169": [.duration],  // ski erg
+        // v6 weightAndDuration -> v7 weightAndDistance
+        "default_170": [.weightAndDuration],  // farmers walk
+        "default_192": [.weightAndDuration],  // sled push
+        "default_193": [.weightAndDuration],  // sled pull
+    ]
+
     init(database: Database, defaults: UserDefaults = .standard) {
         self.database = database
         self.defaults = defaults
@@ -87,10 +110,18 @@ class DefaultExerciseService: ObservableObject {
                     existingExercise.muscleGroup = muscleGroup
                 }
                 existingExercise.instructions = instructions
-                // Adopt the library's measurement type only while the user has neither chosen
-                // one (the editor always stores an explicit value) nor recorded anything with
-                // the exercise — an established logging habit is never changed underneath them.
-                if existingExercise.measurementTypeString == nil,
+                // Adopt the library's measurement type only while the user has never recorded
+                // anything with the exercise — an established logging habit is never changed
+                // underneath them — and the stored type is either absent or one an older
+                // library version shipped itself (a differing value means the user chose it in
+                // the editor, which always stores explicitly).
+                let storedType = SetMeasurementType(
+                    rawValue: existingExercise.measurementTypeString ?? ""
+                )
+                let libraryShippedStored = storedType.map {
+                    Self.supersededLibraryTypes[exerciseData.id]?.contains($0) ?? false
+                } ?? false
+                if existingExercise.measurementTypeString == nil || libraryShippedStored,
                    existingExercise.setGroups.isEmpty,
                    existingExercise.templateSetGroups.isEmpty {
                     existingExercise.measurementType = libraryMeasurementType

--- a/LOGIT/Services/WorkoutSharingService.swift
+++ b/LOGIT/Services/WorkoutSharingService.swift
@@ -300,6 +300,7 @@ final class WorkoutSharingService {
                     repetitions: Int64(entryDTO.repetitions ?? 0),
                     weight: Int64(entryDTO.weight ?? 0),
                     duration: Int64(entryDTO.duration ?? 0),
+                    distance: Int64(entryDTO.distance ?? 0),
                     exercise: workoutSet.positionalExercise(
                         forOrder: Int64(entryDTO.exerciseIndex ?? index)
                     )
@@ -319,6 +320,7 @@ final class WorkoutSharingService {
                     repetitions: Int64(entryDTO.repetitions ?? 0),
                     weight: Int64(entryDTO.weight ?? 0),
                     duration: Int64(entryDTO.duration ?? 0),
+                    distance: Int64(entryDTO.distance ?? 0),
                     exercise: templateSet.positionalExercise(
                         forOrder: Int64(entryDTO.exerciseIndex ?? index)
                     )

--- a/LOGIT/SharedUI/Views/PersonalBestRow.swift
+++ b/LOGIT/SharedUI/Views/PersonalBestRow.swift
@@ -61,7 +61,7 @@ func personalRecordDisplay(
     case .repetitions: return (String(base), NSLocalizedString("reps", comment: ""))
     case .duration: return (String(base), NSLocalizedString("sec", comment: ""))
     case .distance:
-        let style = exercise?.measurementType.distanceStyle ?? .long
+        let style = exercise?.distanceStyle ?? .long
         return (formatDistanceForDisplay(Int64(base), style: style), distanceUnitTitle(for: style))
     }
 }

--- a/LOGIT/SharedUI/Views/PersonalBestRow.swift
+++ b/LOGIT/SharedUI/Views/PersonalBestRow.swift
@@ -51,12 +51,18 @@ struct PersonalBestRow: View {
 
 /// A record's base value as a display string and its unit, in the metric's units. The tile and the
 /// card both render it through `UnitView`, which uppercases the unit, so the casing can't drift.
-func personalRecordDisplay(_ base: Int, metric: ExercisePrimaryMetric) -> (value: String, unit: String) {
+/// `exercise` decides the distance scale (km vs m) for distance records; other metrics ignore it.
+func personalRecordDisplay(
+    _ base: Int, metric: ExercisePrimaryMetric, exercise: Exercise? = nil
+) -> (value: String, unit: String) {
     switch metric {
     case .estimatedOneRepMax: return (formatEstimatedOneRepMax(base), WeightUnit.used.rawValue)
     case .weight: return (formatWeightForDisplay(base), WeightUnit.used.rawValue)
     case .repetitions: return (String(base), NSLocalizedString("reps", comment: ""))
     case .duration: return (String(base), NSLocalizedString("sec", comment: ""))
+    case .distance:
+        let style = exercise?.measurementType.distanceStyle ?? .long
+        return (formatDistanceForDisplay(Int64(base), style: style), distanceUnitTitle(for: style))
     }
 }
 
@@ -65,6 +71,6 @@ private func personalRecordValueView(
     for record: WorkoutProgressReport.PRRecord,
     configuration: UnitViewConfiguration = .normal
 ) -> some View {
-    let display = personalRecordDisplay(record.value, metric: record.metric)
+    let display = personalRecordDisplay(record.value, metric: record.metric, exercise: record.exercise)
     return UnitView(value: display.value, unit: display.unit, configuration: configuration)
 }

--- a/LOGIT/SharedUI/Views/SetEntryFieldsRow.swift
+++ b/LOGIT/SharedUI/Views/SetEntryFieldsRow.swift
@@ -16,6 +16,9 @@ protocol SetEntryFieldsEditable: NSManagedObject, ObservableObject {
     var duration: Int64 { get set }
     var distance: Int64 { get set }
     var type: SetMeasurementType { get }
+    /// The exercise the entry trains — decides the distance scale (km vs m) via the user's
+    /// per-exercise choice.
+    var exercise: Exercise? { get }
 }
 
 extension SetEntry: SetEntryFieldsEditable {}
@@ -46,28 +49,40 @@ struct SetEntryFieldsRow<Entry: SetEntryFieldsEditable>: View {
     var body: some View {
         HStack {
             Spacer()
-            switch entry.type {
-            case .repsAndWeight:
-                repetitionsField(tertiary: 0)
-                weightField(tertiary: 1)
-            case .repsOnly:
-                repetitionsField(tertiary: 0)
-            case .duration:
-                durationField(tertiary: 0)
-            case .weightAndDuration:
-                weightField(tertiary: 0)
-                durationField(tertiary: 1)
-            case .distance:
-                distanceField(tertiary: 0, style: .long)
-            case .distanceAndDuration:
-                distanceField(tertiary: 0, style: .long)
-                // No trend on the duration beside a distance: a longer time for the same run
-                // is worse, not better — only the distance carries the comparison.
-                durationField(tertiary: 1, showsTrend: false)
-            case .weightAndDistance:
-                weightField(tertiary: 0)
-                distanceField(tertiary: 1, style: .short)
+            // The distance scale (km vs m) is a property of the entry's *exercise*, so the
+            // fields must re-render when the exercise changes — flipping the unit in a
+            // Measurement menu mutates the exercise, never the entry itself.
+            if let exercise = entry.exercise {
+                ExerciseObservingFields(row: self, exercise: exercise)
+            } else {
+                fields
             }
+        }
+    }
+
+    @ViewBuilder
+    fileprivate var fields: some View {
+        switch entry.type {
+        case .repsAndWeight:
+            repetitionsField(tertiary: 0)
+            weightField(tertiary: 1)
+        case .repsOnly:
+            repetitionsField(tertiary: 0)
+        case .duration:
+            durationField(tertiary: 0)
+        case .weightAndDuration:
+            weightField(tertiary: 0)
+            durationField(tertiary: 1)
+        case .distance:
+            distanceField(tertiary: 0)
+        case .distanceAndDuration:
+            distanceField(tertiary: 0)
+            // No trend on the duration beside a distance: a longer time for the same run
+            // is worse, not better — only the distance carries the comparison.
+            durationField(tertiary: 1, showsTrend: false)
+        case .weightAndDistance:
+            weightField(tertiary: 0)
+            distanceField(tertiary: 1)
         }
     }
 
@@ -137,10 +152,12 @@ struct SetEntryFieldsRow<Entry: SetEntryFieldsEditable>: View {
         )
     }
 
-    /// The distance field in the scale the measurement type calls for: long distances as a
-    /// decimal in km/mi (cardio), short ones as whole m/yd (carries). Stored in meters either way.
+    /// The distance field in the entry's resolved scale — the exercise's own km/m choice when
+    /// the user made one, else the measurement type's default. Long distances enter as a
+    /// decimal in km/mi, short ones as whole m/yd. Stored in meters either way.
     @ViewBuilder
-    private func distanceField(tertiary: Int, style: SetMeasurementType.DistanceStyle) -> some View {
+    private func distanceField(tertiary: Int) -> some View {
+        let style = entry.type.distanceStyle(for: entry.exercise) ?? .short
         let delta = distanceDelta(
             currentMeters: entry.distance, previousMeters: reference?.distance, style: style
         )
@@ -172,7 +189,8 @@ struct SetEntryFieldsRow<Entry: SetEntryFieldsEditable>: View {
                     get: { convertShortDistanceForDisplaying(entry.distance) },
                     set: { entry.distance = convertShortDistanceForStoring($0) }
                 ),
-                maxDigits: 4,
+                // 5 digits, not 4: a 10 km run in the meter scale is a five-digit entry.
+                maxDigits: 5,
                 index: fieldIndex(tertiary),
                 focusedIntegerFieldIndex: $focusedIntegerFieldIndex,
                 unit: DistanceUnit.used.shortUnit,
@@ -183,6 +201,18 @@ struct SetEntryFieldsRow<Entry: SetEntryFieldsEditable>: View {
                 onTapPreviousValue: onTapPreviousValue
             )
         }
+    }
+}
+
+/// Re-renders an entry row's fields when its exercise changes. The row itself observes only
+/// the entry; the exercise carries the user's distance scale, and without this hop a unit
+/// switch would leave already-rendered rows in the stale unit until an unrelated re-render.
+private struct ExerciseObservingFields<Entry: SetEntryFieldsEditable>: View {
+    let row: SetEntryFieldsRow<Entry>
+    @ObservedObject var exercise: Exercise
+
+    var body: some View {
+        row.fields
     }
 }
 

--- a/LOGIT/SharedUI/Views/SetEntryFieldsRow.swift
+++ b/LOGIT/SharedUI/Views/SetEntryFieldsRow.swift
@@ -14,6 +14,7 @@ protocol SetEntryFieldsEditable: NSManagedObject, ObservableObject {
     var repetitions: Int64 { get set }
     var weight: Int64 { get set }
     var duration: Int64 { get set }
+    var distance: Int64 { get set }
     var type: SetMeasurementType { get }
 }
 
@@ -21,8 +22,9 @@ extension SetEntry: SetEntryFieldsEditable {}
 extension TemplateSetEntry: SetEntryFieldsEditable {}
 
 /// One set entry's input fields, laid out by the entry's measurement type:
-/// reps+weight, reps only, duration (min:sec), or weight+duration. This is the single row
-/// every set cell — standard, drop, super, workout or template — renders per entry.
+/// reps+weight, reps only, duration, weight+duration, distance, distance+duration, or
+/// weight+distance. This is the single row every set cell — standard, drop, super, workout
+/// or template — renders per entry.
 ///
 /// The focus index is (set position, entry position, field position); field positions must
 /// stay consistent with `SetMeasurementType.inputFieldCount`, which the recorder's keyboard
@@ -55,6 +57,16 @@ struct SetEntryFieldsRow<Entry: SetEntryFieldsEditable>: View {
             case .weightAndDuration:
                 weightField(tertiary: 0)
                 durationField(tertiary: 1)
+            case .distance:
+                distanceField(tertiary: 0, style: .long)
+            case .distanceAndDuration:
+                distanceField(tertiary: 0, style: .long)
+                // No trend on the duration beside a distance: a longer time for the same run
+                // is worse, not better — only the distance carries the comparison.
+                durationField(tertiary: 1, showsTrend: false)
+            case .weightAndDistance:
+                weightField(tertiary: 0)
+                distanceField(tertiary: 1, style: .short)
             }
         }
     }
@@ -105,8 +117,10 @@ struct SetEntryFieldsRow<Entry: SetEntryFieldsEditable>: View {
         )
     }
 
-    private func durationField(tertiary: Int) -> some View {
-        let delta = durationDelta(current: entry.duration, previous: reference?.duration)
+    private func durationField(tertiary: Int, showsTrend: Bool = true) -> some View {
+        let delta = showsTrend
+            ? durationDelta(current: entry.duration, previous: reference?.duration)
+            : (comparison: nil, text: "")
         return IntegerField(
             placeholder: placeholder?.duration ?? 0,
             value: $entry.duration,
@@ -122,6 +136,54 @@ struct SetEntryFieldsRow<Entry: SetEntryFieldsEditable>: View {
             onTapPreviousValue: onTapPreviousValue
         )
     }
+
+    /// The distance field in the scale the measurement type calls for: long distances as a
+    /// decimal in km/mi (cardio), short ones as whole m/yd (carries). Stored in meters either way.
+    @ViewBuilder
+    private func distanceField(tertiary: Int, style: SetMeasurementType.DistanceStyle) -> some View {
+        let delta = distanceDelta(
+            currentMeters: entry.distance, previousMeters: reference?.distance, style: style
+        )
+        let previousText = (reference?.distance ?? 0) > 0
+            ? formatDistanceForDisplay(reference!.distance, style: style) : nil
+        switch style {
+        case .long:
+            DecimalField(
+                placeholder: placeholder.map { convertDistanceForDisplayingDecimal($0.distance) } ?? 0,
+                value: Binding(
+                    get: { convertDistanceForDisplayingDecimal(entry.distance) },
+                    set: { entry.distance = convertDistanceForStoring($0) }
+                ),
+                maxDigits: 4,
+                decimalPlaces: 2,
+                index: fieldIndex(tertiary),
+                focusedIntegerFieldIndex: $focusedIntegerFieldIndex,
+                unit: DistanceUnit.used.rawValue,
+                trend: delta.comparison,
+                trendText: delta.text,
+                trendColor: trendColor,
+                previousValueText: previousText,
+                onTapPreviousValue: onTapPreviousValue
+            )
+        case .short:
+            IntegerField(
+                placeholder: placeholder.map { convertShortDistanceForDisplaying($0.distance) } ?? 0,
+                value: Binding(
+                    get: { convertShortDistanceForDisplaying(entry.distance) },
+                    set: { entry.distance = convertShortDistanceForStoring($0) }
+                ),
+                maxDigits: 4,
+                index: fieldIndex(tertiary),
+                focusedIntegerFieldIndex: $focusedIntegerFieldIndex,
+                unit: DistanceUnit.used.shortUnit,
+                trend: delta.comparison,
+                trendText: delta.text,
+                trendColor: trendColor,
+                previousValueText: previousText,
+                onTapPreviousValue: onTapPreviousValue
+            )
+        }
+    }
 }
 
 // MARK: - Duration Helpers
@@ -131,4 +193,28 @@ struct SetEntryFieldsRow<Entry: SetEntryFieldsEditable>: View {
 func durationDelta(current: Int64, previous: Int64?) -> (comparison: SetValueComparison?, text: String) {
     guard let previous, previous > 0, current > 0, current != previous else { return (nil, "") }
     return (current > previous ? .improved : .declined, String(abs(current - previous)))
+}
+
+/// Compares an entered distance (meters) against the previous workout's value — farther is
+/// improved. Direction and text are computed in display units, like `weightDelta`, so they
+/// match what the user sees.
+func distanceDelta(
+    currentMeters: Int64, previousMeters: Int64?, style: SetMeasurementType.DistanceStyle
+) -> (comparison: SetValueComparison?, text: String) {
+    guard let previousMeters, previousMeters > 0, currentMeters > 0 else { return (nil, "") }
+    switch style {
+    case .long:
+        let current = convertDistanceForDisplayingDecimal(currentMeters)
+        let previous = convertDistanceForDisplayingDecimal(previousMeters)
+        guard current != previous else { return (nil, "") }
+        return (
+            current > previous ? .improved : .declined,
+            formatDistanceForDisplay(convertDistanceForStoring(abs(current - previous)))
+        )
+    case .short:
+        let current = convertShortDistanceForDisplaying(currentMeters)
+        let previous = convertShortDistanceForDisplaying(previousMeters)
+        guard current != previous else { return (nil, "") }
+        return (current > previous ? .improved : .declined, String(abs(current - previous)))
+    }
 }

--- a/LOGITTests/EntityExtensionTests.swift
+++ b/LOGITTests/EntityExtensionTests.swift
@@ -277,11 +277,86 @@ final class EntityExtensionTests: XCTestCase {
     func testMaximumForWrongExercise() {
         let exercise1 = builder.createExercise(name: "Bench")
         let exercise2 = builder.createExercise(name: "Squat")
-        
+
         let set = builder.createStandardSet(repetitions: 10, weight: 50000, exercise: exercise1)
-        
+
         let maxReps = set.maximum(.repetitions, for: exercise2)
         XCTAssertEqual(maxReps, 0, "Should return 0 for wrong exercise")
+    }
+
+    // MARK: - Distance Entry Tests
+
+    func testDistanceCountsAsEntryAndPerformance() {
+        let set = database.newStandardSet(repetitions: 0, weight: 0)
+        set.overrideMeasurementType(.distanceAndDuration)
+        set.entries.first?.distance = 5000
+
+        XCTAssertTrue(set.hasEntry, "A recorded distance is a value")
+        XCTAssertTrue(
+            set.hasRepetitionEntry,
+            "Distance alone marks a distance entry as performed (rest timer / Live Activity signal)"
+        )
+    }
+
+    func testDurationAloneMarksDistanceAndDurationEntryPerformed() {
+        let set = database.newStandardSet(repetitions: 0, weight: 0)
+        set.overrideMeasurementType(.distanceAndDuration)
+        set.entries.first?.duration = 90
+
+        XCTAssertTrue(set.hasRepetitionEntry, "Either field of distance+duration counts as performed")
+    }
+
+    func testWeightAloneDoesNotMarkWeightAndDistanceEntryPerformed() {
+        let set = database.newStandardSet(repetitions: 0, weight: 0)
+        set.overrideMeasurementType(.weightAndDistance)
+        set.entries.first?.weight = 60000
+
+        XCTAssertTrue(set.hasEntry, "Weight is still a value")
+        XCTAssertFalse(set.hasRepetitionEntry, "Weight alone is not a performance value")
+    }
+
+    func testClearEntriesZeroesDistance() {
+        let set = database.newStandardSet(repetitions: 0, weight: 0)
+        set.overrideMeasurementType(.distanceAndDuration)
+        set.entries.first?.distance = 5000
+        set.clearEntries()
+
+        XCTAssertEqual(set.entries.first?.distance, 0, "Distance should be cleared")
+        XCTAssertFalse(set.hasEntry)
+    }
+
+    func testMaximumDistance() {
+        let exercise = builder.createExercise(name: "Running")
+        let set = builder.createStandardSet(repetitions: 0, weight: 0, exercise: exercise)
+        set.overrideMeasurementType(.distanceAndDuration)
+        set.entries.first?.distance = 5000
+
+        XCTAssertEqual(set.maximum(.distance, for: exercise), 5000)
+    }
+
+    func testRetypeKeepsStoredDistance() {
+        let set = database.newStandardSet(repetitions: 0, weight: 0)
+        set.overrideMeasurementType(.distanceAndDuration)
+        set.entries.first?.distance = 5000
+
+        // Re-typing never clears values: the distance is invisible under reps-only and
+        // intact when switching back.
+        set.overrideMeasurementType(.repsOnly)
+        XCTAssertFalse(set.hasEntry, "Reps-only tracks no distance, so the set reads empty")
+        set.overrideMeasurementType(.distanceAndDuration)
+        XCTAssertEqual(set.entries.first?.distance, 5000)
+        XCTAssertTrue(set.hasEntry)
+    }
+
+    func testMatchStructureCarriesDistanceType() {
+        let templateSet = database.newTemplateStandardSet()
+        templateSet.overrideMeasurementType(.weightAndDistance)
+
+        let set = database.newStandardSet(repetitions: 0, weight: 0)
+        set.matchStructure(toEntryValues: templateSet.entryValues)
+
+        XCTAssertEqual(set.entries.first?.type, .weightAndDistance)
+        XCTAssertEqual(set.entries.first?.distance, 0, "Structure matching starts values empty")
     }
 
     // MARK: - WorkoutSet Max Entry Tests

--- a/LOGITTests/EntityExtensionTests.swift
+++ b/LOGITTests/EntityExtensionTests.swift
@@ -348,6 +348,42 @@ final class EntityExtensionTests: XCTestCase {
         XCTAssertTrue(set.hasEntry)
     }
 
+    func testDistanceStyleDefaultsFromMeasurementType() {
+        let cardio = database.newExercise(name: "Run", measurementType: .distanceAndDuration)
+        let carry = database.newExercise(name: "Carry", measurementType: .weightAndDistance)
+
+        XCTAssertEqual(cardio.distanceStyle, .long, "Cardio defaults to the km scale")
+        XCTAssertEqual(carry.distanceStyle, .short, "Carries default to the meter scale")
+        XCTAssertNil(cardio.distanceStyleOverride, "Defaults are not stored as a choice")
+    }
+
+    func testDistanceStyleUserOverrideWinsEverywhere() {
+        let cardio = database.newExercise(name: "Run", measurementType: .distanceAndDuration)
+        cardio.distanceStyle = .short
+
+        XCTAssertEqual(cardio.distanceStyle, .short, "The user's choice replaces the type default")
+        XCTAssertEqual(
+            SetMeasurementType.distanceAndDuration.distanceStyle(for: cardio), .short,
+            "Entry-level resolution honors the exercise's choice"
+        )
+        XCTAssertEqual(
+            SetMeasurementType.weightAndDistance.distanceStyle(for: cardio), .short,
+            "The choice also applies to per-set type overrides"
+        )
+    }
+
+    func testDistanceStyleResolutionWithoutOverrideFollowsEntryType() {
+        let exercise = database.newExercise(name: "Run", measurementType: .distanceAndDuration)
+
+        // A one-off weight+distance set on a cardio exercise enters meters, not km.
+        XCTAssertEqual(SetMeasurementType.weightAndDistance.distanceStyle(for: exercise), .short)
+        XCTAssertEqual(SetMeasurementType.distanceAndDuration.distanceStyle(for: exercise), .long)
+        XCTAssertNil(
+            SetMeasurementType.repsAndWeight.distanceStyle(for: exercise),
+            "Non-distance types have no distance scale"
+        )
+    }
+
     func testMatchStructureCarriesDistanceType() {
         let templateSet = database.newTemplateStandardSet()
         templateSet.overrideMeasurementType(.weightAndDistance)

--- a/LOGITTests/SetEntryMigrationTests.swift
+++ b/LOGITTests/SetEntryMigrationTests.swift
@@ -214,7 +214,7 @@ final class SetEntryMigrationTests: XCTestCase {
 
     // MARK: - Migration
 
-    func testLegacyStoreOpensUnderV8ViaLightweightMigration() throws {
+    func testLegacyStoreOpensUnderCurrentModelViaLightweightMigration() throws {
         let container = try openMigratedStore()
         let context = container.viewContext
 

--- a/LOGITTests/WeightConvertingTests.swift
+++ b/LOGITTests/WeightConvertingTests.swift
@@ -248,3 +248,105 @@ final class WeightConvertingTests: XCTestCase {
         XCTAssertEqual(displayed2, 50.001, accuracy: 0.0001)
     }
 }
+
+// MARK: - Distance Conversion Tests
+
+final class DistanceConvertingTests: XCTestCase {
+
+    private var userDefaultsHelper: UserDefaultsTestHelper!
+
+    override func setUp() {
+        super.setUp()
+        userDefaultsHelper = UserDefaultsTestHelper()
+    }
+
+    override func tearDown() {
+        userDefaultsHelper.restoreAll()
+        super.tearDown()
+    }
+
+    // MARK: - Long Distances (km/mi)
+
+    func testConvertDistanceForStoringKm() {
+        userDefaultsHelper.setTestValue("km", forKey: "distanceUnit")
+
+        XCTAssertEqual(convertDistanceForStoring(5.5), 5500, "5.5 km should store as 5500 meters")
+    }
+
+    func testConvertDistanceForStoringMi() {
+        userDefaultsHelper.setTestValue("mi", forKey: "distanceUnit")
+
+        XCTAssertEqual(convertDistanceForStoring(1.0), 1609, "1 mi should store as 1609 meters")
+    }
+
+    func testConvertDistanceForDisplayingDecimalKm() {
+        userDefaultsHelper.setTestValue("km", forKey: "distanceUnit")
+
+        XCTAssertEqual(convertDistanceForDisplayingDecimal(5500), 5.5, accuracy: 0.001)
+    }
+
+    func testConvertDistanceForDisplayingDecimalMi() {
+        userDefaultsHelper.setTestValue("mi", forKey: "distanceUnit")
+
+        XCTAssertEqual(convertDistanceForDisplayingDecimal(1609), 1.0, accuracy: 0.01)
+    }
+
+    func testFormatDistanceDropsTrailingZeros() {
+        userDefaultsHelper.setTestValue("km", forKey: "distanceUnit")
+
+        XCTAssertEqual(formatDistanceForDisplay(Int64(5000)), "5")
+        XCTAssertEqual(formatDistanceForDisplay(Int64(5500)), "5.5")
+        XCTAssertEqual(formatDistanceForDisplay(Int64(5550)), "5.55")
+        XCTAssertEqual(formatDistanceForDisplay(Int64(0)), "0")
+    }
+
+    // MARK: - Short Distances (m/yd)
+
+    func testShortDistanceMetersPassThrough() {
+        userDefaultsHelper.setTestValue("km", forKey: "distanceUnit")
+
+        XCTAssertEqual(convertShortDistanceForStoring(40), 40, "Meters store as meters")
+        XCTAssertEqual(convertShortDistanceForDisplaying(40), 40)
+    }
+
+    func testShortDistanceYardsConversion() {
+        userDefaultsHelper.setTestValue("mi", forKey: "distanceUnit")
+
+        XCTAssertEqual(convertShortDistanceForStoring(50), 46, "50 yd should store as 46 meters")
+        XCTAssertEqual(convertShortDistanceForDisplaying(46), 50, "46 meters should display as 50 yd")
+    }
+
+    // MARK: - Style Dispatch
+
+    func testFormatDistanceForDisplayByStyle() {
+        userDefaultsHelper.setTestValue("km", forKey: "distanceUnit")
+
+        XCTAssertEqual(formatDistanceForDisplay(Int64(5500), style: .long), "5.5")
+        XCTAssertEqual(formatDistanceForDisplay(Int64(40), style: .short), "40")
+        XCTAssertEqual(distanceUnitTitle(for: .long), "km")
+        XCTAssertEqual(distanceUnitTitle(for: .short), "m")
+    }
+
+    // MARK: - Measurement Type Field Consistency
+
+    func testInputFieldCountMatchesTrackedFields() {
+        for type in SetMeasurementType.allCases {
+            let tracked = [
+                type.usesRepetitions, type.usesWeight, type.usesDuration, type.usesDistance,
+            ].filter { $0 }.count
+            XCTAssertEqual(
+                type.inputFieldCount, tracked,
+                "\(type.rawValue) must show one input field per tracked value"
+            )
+        }
+    }
+
+    func testDistanceStyleExistsExactlyForDistanceTypes() {
+        for type in SetMeasurementType.allCases {
+            XCTAssertEqual(
+                type.distanceStyle != nil, type.usesDistance,
+                "\(type.rawValue) distance style must accompany a distance field"
+            )
+        }
+    }
+}

--- a/LOGITTests/WorkoutSharingTests.swift
+++ b/LOGITTests/WorkoutSharingTests.swift
@@ -304,6 +304,30 @@ final class WorkoutDTOTests: XCTestCase {
         }
     }
     
+    func testWorkoutDTORoundTripDistanceEntries() throws {
+        let workout = database.newWorkout(name: "Cardio RT", date: Date())
+        let exercise = builder.createExercise(name: "Treadmill", muscleGroup: .legs)
+        let sg = database.newWorkoutSetGroup(exercise: exercise, workout: workout)
+        let set = sg.sets[0]
+        set.overrideMeasurementType(.distanceAndDuration)
+        set.entries.first?.distance = 5500
+        set.entries.first?.duration = 1500
+
+        let dto = WorkoutDTO(from: workout)
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(dto)
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(WorkoutDTO.self, from: data)
+
+        let entry = try XCTUnwrap(decoded.setGroups[0].sets[0].entries?.first)
+        XCTAssertEqual(entry.type, SetMeasurementType.distanceAndDuration.rawValue)
+        XCTAssertEqual(entry.distance, 5500, "Distance (meters) must survive the share round-trip")
+        XCTAssertEqual(entry.duration, 1500)
+    }
+
     func testWorkoutDTORoundTripSuperSets() throws {
         let workout = database.newWorkout(name: "Superset RT", date: Date())
         let exA = builder.createExercise(name: "Press", muscleGroup: .chest)

--- a/LOGITUITests/ScenarioScreenshots.swift
+++ b/LOGITUITests/ScenarioScreenshots.swift
@@ -86,6 +86,76 @@ final class ScenarioScreenshots: XCTestCase {
         attach(app, "plank_detail_duration_tiles")
     }
 
+    /// The distance measurement types in the recorder: the stress scenario's current
+    /// workout ends with a distance+duration Running group (km + sec fields) and a
+    /// weight+distance Sled Push group (kg + m fields). Scroll to them, capture, then
+    /// open the running detail: a distance exercise must show its distance tile (fed by
+    /// the seeded treadmill history) instead of weight/e1RM tiles.
+    func testRecorderDistanceTypes() {
+        let app = launchApp(
+            scenario: "stress",
+            extraArguments: ["-UITEST_SHOW_RECORDER", "-UITEST_NO_SHEET"]
+        )
+
+        let nameField = app.textFields.matching(NSPredicate(format: "value == 'Push Day'")).firstMatch
+        XCTAssertTrue(nameField.waitForExistence(timeout: 15), "Recorder never presented")
+        waitABit(2)
+
+        let sledHeader = app.staticTexts["Sled Push"]
+        for _ in 0 ..< 14 where !sledHeader.isHittable {
+            app.swipeUp()
+        }
+        XCTAssertTrue(sledHeader.waitForExistence(timeout: 5), "Sled Push group not reachable")
+        waitABit(1)
+        attach(app, "recorder_distance_types")
+
+        app.staticTexts["Running"].firstMatch.tap()
+        waitABit(3)
+        attach(app, "running_detail_distance_tiles")
+    }
+
+    /// The exercise detail's distance adaptation, reached through the Exercises tab (the
+    /// recorder's name-tap detail sheet is suppressed under -UITEST_NO_SHEET, so this is the
+    /// reliable element-driven route): Running must show the distance + duration tiles fed by
+    /// the seeded treadmill history, and the distance tile must open its chart screen.
+    func testDistanceExerciseDetailFromList() {
+        let app = launchApp(scenario: "stress")
+
+        let tabBar = app.tabBars.firstMatch
+        XCTAssertTrue(tabBar.waitForExistence(timeout: 30), "Tab bar never appeared")
+        tapTab(app, at: 3)
+        waitABit(1)
+
+        // The Search tab is a hub; go through its Exercises list. Prefer the list's search
+        // field when one is exposed; otherwise swipe down the alphabetical list to R.
+        let exercisesRow = app.staticTexts["Exercises"].firstMatch
+        XCTAssertTrue(exercisesRow.waitForExistence(timeout: 5), "Exercises row missing on the Search tab")
+        exercisesRow.tap()
+        waitABit(2)
+
+        let runningRow = app.staticTexts["Running"].firstMatch
+        let listSearchField = app.textFields.firstMatch
+        if listSearchField.waitForExistence(timeout: 2) {
+            listSearchField.tap()
+            app.typeText("Running")
+            waitABit(2)
+        } else {
+            for _ in 0 ..< 30 where !runningRow.isHittable {
+                app.swipeUp()
+            }
+        }
+        XCTAssertTrue(runningRow.waitForExistence(timeout: 5), "Running not reachable in the exercise list")
+        runningRow.tap()
+        waitABit(3)
+        attach(app, "running_detail_from_list")
+
+        let distanceTile = app.staticTexts["Distance"].firstMatch
+        XCTAssertTrue(distanceTile.waitForExistence(timeout: 5), "Distance tile missing on a distance exercise")
+        distanceTile.tap()
+        waitABit(2)
+        attach(app, "running_distance_chart_screen")
+    }
+
     // MARK: - Workout recorder (Transmission presentation)
     //
     // Note on element queries: while the persistent exercise tray sheet is

--- a/LOGITUITests/ScenarioScreenshots.swift
+++ b/LOGITUITests/ScenarioScreenshots.swift
@@ -114,6 +114,72 @@ final class ScenarioScreenshots: XCTestCase {
         attach(app, "running_detail_distance_tiles")
     }
 
+    /// The per-exercise distance unit choice, end to end: long-press a Sled Push set →
+    /// Measurement submenu → the Distance Unit section appears → switch to kilometers → the
+    /// row re-renders its 20 m as 0.02 km. Values are stored in meters, so this is purely a
+    /// display flip.
+    func testDistanceUnitChoiceMenu() {
+        let app = launchApp(
+            scenario: "stress",
+            extraArguments: ["-UITEST_SHOW_RECORDER", "-UITEST_NO_SHEET"]
+        )
+
+        let nameField = app.textFields.matching(NSPredicate(format: "value == 'Push Day'")).firstMatch
+        XCTAssertTrue(nameField.waitForExistence(timeout: 15), "Recorder never presented")
+        waitABit(2)
+
+        // Scroll to the bottom group with a settle after each swipe — hammering isHittable
+        // between rapid swipes races the accessibility snapshot under simulator load.
+        let sledHeader = app.staticTexts["Sled Push"]
+        var sledReachable = sledHeader.exists && sledHeader.isHittable
+        for _ in 0 ..< 14 where !sledReachable {
+            app.swipeUp()
+            sledReachable = sledHeader.waitForExistence(timeout: 1) && sledHeader.isHittable
+        }
+        XCTAssertTrue(sledReachable, "Sled Push group not reachable")
+        waitABit(1)
+
+        // Long-press the sled's first set row to open its context menu. The row's exact
+        // offset below the header varies slightly, so try a few plausible spots.
+        let measurementItem = app.buttons["Measurement"].firstMatch
+        for dy in [4.5, 3.5, 5.5] where !measurementItem.exists {
+            sledHeader.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: dy))
+                .press(forDuration: 0.9)
+            _ = measurementItem.waitForExistence(timeout: 3)
+        }
+        XCTAssertTrue(measurementItem.exists, "Set context menu did not open on the sled set")
+        measurementItem.tap()
+
+        let kilometersOption = app.buttons["Kilometers (km)"].firstMatch
+        XCTAssertTrue(
+            kilometersOption.waitForExistence(timeout: 4),
+            "Distance Unit options missing from the Measurement menu"
+        )
+        attach(app, "measurement_menu_distance_unit")
+
+        // The submenu holds all seven types plus the unit section, so the unit options can sit
+        // below its fold — scroll the open menu until the option is genuinely tappable.
+        var tappedKilometers = false
+        for _ in 0 ..< 4 where !tappedKilometers {
+            if kilometersOption.exists, kilometersOption.isHittable {
+                kilometersOption.tap()
+                tappedKilometers = true
+            } else {
+                app.swipeUp()
+                waitABit(1)
+            }
+        }
+        XCTAssertTrue(tappedKilometers, "Kilometers option never became tappable in the menu")
+        waitABit(1)
+        // The distance value lives in the entry's text field (20 m = 0.02 km).
+        let kmField = app.textFields.matching(NSPredicate(format: "value == '0.02'")).firstMatch
+        XCTAssertTrue(
+            kmField.waitForExistence(timeout: 4),
+            "Sled distance did not re-render as kilometers after the unit switch"
+        )
+        attach(app, "sled_row_in_kilometers")
+    }
+
     /// The exercise detail's distance adaptation, reached through the Exercises tab (the
     /// recorder's name-tap detail sheet is suppressed under -UITEST_NO_SHEET, so this is the
     /// reliable element-driven route): Running must show the distance + duration tiles fed by


### PR DESCRIPTION
Adds distance as a first-class metric so you can log the run at the start of a workout, the loaded carry at the end, and everything in between.

## What's new
- **Three measurement types** on the per-entry system: `distanceAndDuration` (treadmill, rower, cycling), `weightAndDistance` (farmer's walk, sled, carries), and bare `distance` (shuttle runs). Max two input fields per entry stays the invariant.
- **Distance stored in meters, always** — km/mi/m/yd are pure display conversions.
- **The unit is the user's per-exercise choice.** Each `Exercise` carries a distance scale (v9 `distanceStyleString`, defaulting from the type: cardio → km, carries → m). Switch it from any Measurement menu (group + set, workout + template) or the exercise editor. Settings picks the *system* (km/m vs mi/yd) beside the weight unit. Every display/entry site resolves through one `distanceStyle(for:)` helper.
- **Distance as a progress metric** — `ExercisePrimaryMetric.distance` drives the badge, PR trophies, records, VoiceOver; the metric info panel now offers only metrics that fit the exercise. Exercise detail gains distance/duration, weight/distance, and distance-only tile layouts plus a distance chart screen. The odd third tile of a 3-tile layout stays half-width.
- **Live Activity & sharing** carry distance (additive; old receivers ignore it).

## Default library v7
Cardio machines → distance+duration, carries → weight+distance (unused exercises upgrade on existing installs via `supersededLibraryTypes`; recorded/user-chosen types untouched). 8 new localized exercises: Walking, Incline Treadmill Walk, Rucking, Suitcase/Overhead/Yoke/Sandbag Carry, Shuttle Run.

## Model
v9, additive & CloudKit-safe: `distance` on SetEntry/TemplateSetEntry + `distanceStyleString` on Exercise. Lightweight migration; the v8 backfill is untouched.

## Verification
- 387 unit tests green (new conversion, entry-semantics, distance-style resolution, and share round-trip coverage)
- Full empty/one/many/free screenshot matrix
- New `ScenarioScreenshots` tests: distance recorder layouts, exercise-detail adaptation + chart, and the end-to-end unit-choice flow (long-press → Distance Unit → switch → live re-render)

⚠️ Before an App Store release: deploy the v9 CloudKit schema to Production (new `distance` field on both entry record types), same step as v8's record types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)