### PR TITLE
Fix reported bugs: Rate button, tray-sheet fight, weight rounding/overlap, focus jumps

### DIFF
--- a/LOGIT/App/TestScenarios.swift
+++ b/LOGIT/App/TestScenarios.swift
@@ -61,7 +61,11 @@ enum TestScenario: String {
 
         // Skip onboarding, keep units deterministic across sim locales.
         overrides["setupDone"] = true
-        overrides["weightUnit"] = WeightUnit.kg.rawValue
+        // An explicit `-weightUnit lbs` launch argument (already in the volatile
+        // argument domain) wins, so unit-dependent UI can be verified in both units.
+        if overrides["weightUnit"] == nil {
+            overrides["weightUnit"] = WeightUnit.kg.rawValue
+        }
         // `empty` shows the no-goal state, the other scenarios a realistic goal.
         overrides["workoutPerWeekTarget"] = self == .empty ? -1 : self == .stress ? 2 : 4
         // Per-user layout state stored as Data (object URIs / JSON) must not

--- a/LOGIT/Config/Constants.swift
+++ b/LOGIT/Config/Constants.swift
@@ -12,3 +12,8 @@ let BOTTOM_SHEET_SMALL: CGFloat = 80
 /// The shared support / feedback inbox — used by both the "Suggest a Feature" and "Contact
 /// Support" rows in Settings (the dot matches the existing support link).
 let FEEDBACK_EMAIL = "logit.fitness@gmail.com"
+
+/// The App Store write-review deep link for the "Rate LOGIT" row. An explicit rate button
+/// must open the store's review page directly — `requestReview` is only a *request* that
+/// the system rate-limits (a handful of prompts per year) and silently drops otherwise.
+let APP_STORE_WRITE_REVIEW_URL = "https://apps.apple.com/app/id6444813640?action=write-review"

--- a/LOGIT/Core/Utilities/WeightConverting.swift
+++ b/LOGIT/Core/Utilities/WeightConverting.swift
@@ -51,7 +51,13 @@ public func convertWeightForStoring(_ value: Double) -> Int64 {
 
 /// Converts a weight value from storage units (grams) to display units (kg or lbs)
 /// - Parameter value: Weight in grams (from database)
-/// - Returns: Weight in kg or lbs (for display to user) with up to 3 decimal places
+/// - Returns: Weight in kg or lbs with up to 3 decimal places
+///
+/// Keeps 3 decimals so data consumers (body measurements, charts) don't lose stored
+/// precision. Anything user-facing must NOT print this value raw: storage rounds to whole
+/// grams, so an lbs value round-trips with up to ~0.0011 lbs of noise — at 3 printed
+/// decimals an entered "162.5" came back as "162.501". Format through
+/// `formatWeightForDisplay` (or a ≤2-fraction-digit formatter), which rounds the noise away.
 public func convertWeightForDisplayingDecimal(_ value: Int64) -> Double {
     let unit = WeightUnit(rawValue: UserDefaults.standard.string(forKey: "weightUnit")!)!
     let result: Double
@@ -65,7 +71,7 @@ public func convertWeightForDisplayingDecimal(_ value: Int64) -> Double {
 
 /// Converts a weight value from storage units (grams) to display units (kg or lbs)
 /// - Parameter value: Weight in grams (from database)
-/// - Returns: Weight in kg or lbs (for display to user) with up to 3 decimal places
+/// - Returns: Weight in kg or lbs with up to 3 decimal places
 public func convertWeightForDisplayingDecimal(_ value: Int) -> Double {
     return convertWeightForDisplayingDecimal(Int64(value))
 }
@@ -73,6 +79,10 @@ public func convertWeightForDisplayingDecimal(_ value: Int) -> Double {
 /// Formats a weight value from storage units (grams) to a display string
 /// - Parameter value: Weight in grams (from database)
 /// - Returns: Formatted string with weight in kg or lbs, showing decimals only when needed
+///
+/// Caps at 2 fraction digits: real plate math never needs more, and gram-rounding noise
+/// (< 0.005 in either unit) must not surface — at 3 digits an entered 162.5 lbs printed
+/// as "162.501" (the reported rounding artifact).
 public func formatWeightForDisplay(_ value: Int64) -> String {
     let weight = convertWeightForDisplayingDecimal(value)
     if weight == 0 {
@@ -83,7 +93,8 @@ public func formatWeightForDisplay(_ value: Int64) -> String {
     let formatter = NumberFormatter()
     formatter.numberStyle = .decimal
     formatter.minimumFractionDigits = 0
-    formatter.maximumFractionDigits = 3
+    formatter.maximumFractionDigits = 2
+    formatter.roundingMode = .halfUp
     formatter.decimalSeparator = "."
     formatter.groupingSeparator = ""
     

--- a/LOGIT/Features/Measurement/MeasurementDetailScreen.swift
+++ b/LOGIT/Features/Measurement/MeasurementDetailScreen.swift
@@ -20,6 +20,11 @@ struct MeasurementDetailScreen: View {
     @State private var newEntryDate: Date = .now
     @State private var newEntryValue: Double = 0
 
+    /// Standalone field identity for the add-measurement sheet — there's no set behind this
+    /// field, so it gets one fixed UUID (stable across renders, or the field would lose its
+    /// state to `.id(index)` re-identification).
+    private static let newEntryFieldIndex = IntegerField.Index(setID: UUID())
+
     private var entries: [MeasurementEntry] {
         measurementController.getMeasurementEntries(ofType: measurementType)
     }
@@ -286,7 +291,7 @@ struct MeasurementDetailScreen: View {
                         value: $newEntryValue,
                         maxDigits: 4,
                         decimalPlaces: 1,
-                        index: .init(primary: 0),
+                        index: Self.newEntryFieldIndex,
                         focusedIntegerFieldIndex: .constant(nil),
                         unit: measurementType.unit
                     )

--- a/LOGIT/Features/SettingsScreen.swift
+++ b/LOGIT/Features/SettingsScreen.swift
@@ -10,7 +10,6 @@ import SwiftUI
 
 struct SettingsScreen: View {
     @EnvironmentObject private var purchaseManager: PurchaseManager
-    @Environment(\.requestReview) private var requestReview
 
     // MARK: - UserDefaults
 
@@ -140,8 +139,11 @@ struct SettingsScreen: View {
                 Link(destination: URL(string: "mailto:\(FEEDBACK_EMAIL)?subject=LOGIT%20Support")!) {
                     settingsRow(NSLocalizedString("support", comment: ""), icon: "questionmark.circle.fill", trailingSystemImage: "envelope.fill")
                 }
-                Button { requestReview() } label: {
-                    settingsRow(NSLocalizedString("rateLogit", comment: ""), icon: "star.fill", trailingChevron: true)
+                // Deliberately NOT `requestReview()`: that's a rate-limited request the
+                // system usually ignores, which made this button appear broken. The
+                // write-review deep link always lands on the App Store review page.
+                Link(destination: URL(string: APP_STORE_WRITE_REVIEW_URL)!) {
+                    settingsRow(NSLocalizedString("rateLogit", comment: ""), icon: "star.fill", trailingSystemImage: "arrow.up.forward.square")
                 }
             }
         }

--- a/LOGIT/Features/Template/Cells/TemplateSetCells/TemplateSetCell.swift
+++ b/LOGIT/Features/Template/Cells/TemplateSetCells/TemplateSetCell.swift
@@ -85,7 +85,7 @@ struct TemplateSetCell: View {
 
     @ViewBuilder
     private var setContent: some View {
-        if let indexInTemplate {
+        if let setID = templateSet.id {
             VStack(spacing: 0) {
                 ForEach(
                     Array(templateSet.entries.enumerated()), id: \.element.objectID
@@ -93,7 +93,7 @@ struct TemplateSetCell: View {
                     let entryExercise = templateSet.owningExercise(of: entry)
                     SetEntryFieldsRow(
                         entry: entry,
-                        primaryIndex: indexInTemplate,
+                        setID: setID,
                         secondaryIndex: entryIndex,
                         focusedIntegerFieldIndex: $focusedIntegerFieldIndex
                     )
@@ -103,10 +103,6 @@ struct TemplateSetCell: View {
             .padding(.top, templateSetIsFirst(templateSet: templateSet) ? 0 : CELL_SPACING / 2)
             .padding(.bottom, templateSetIsLast(templateSet: templateSet) ? 0 : CELL_SPACING / 2)
         }
-    }
-
-    private var indexInTemplate: Int? {
-        templateSet.setGroup?.workout?.sets.firstIndex(of: templateSet)
     }
 
     @ViewBuilder

--- a/LOGIT/Features/Template/TemplateEditorScreen.swift
+++ b/LOGIT/Features/Template/TemplateEditorScreen.swift
@@ -45,6 +45,9 @@ struct TemplateEditorScreen: View {
     @State private var isRenamingTemplate = false
     @State private var focusedIntegerFieldIndex: IntegerField.Index?
     @FocusState private var isFocusingRenameTemplateField: Bool
+    /// Whether the persistent exercise tray lets touches through to the editor behind it.
+    /// Driven by `hasNestedTraySheet` with an asymmetric delay — see that property's docs.
+    @State private var trayAllowsBackgroundInteraction = true
 
     // MARK: - Parameters
 
@@ -140,62 +143,66 @@ struct TemplateEditorScreen: View {
                 }
                 .scrollIndicators(.hidden)
                 .sheet(isPresented: .constant(true)) {
-                    NavigationView {
-                        VStack(spacing: 0) {
-                            ExerciseSelectionScreen(
-                                selectedExercise: nil,
-                                setExercise: { exercise in
-                                    UIImpactFeedbackGenerator(style: .soft).impactOccurred()
-                                    database.newTemplateSetGroup(
-                                        createFirstSetAutomatically: true,
-                                        exercise: exercise,
-                                        template: template
-                                    )
-                                    withAnimation {
-                                        scrollable.scrollTo(1, anchor: .bottom)
-                                    }
-                                },
-                                forSecondary: false,
-                                currentWorkoutExercises: [],
-                                supersetPrimaryExercise: nil,
-                                presentationDetentSelection: $exerciseSelectionPresentationDetent
-                            )
-                            .toolbar(.hidden, for: .navigationBar)
-                            .sheet(item: $selectedRestDurationSet) { templateSet in
-                                RestDurationEditorSheet(templateSet: templateSet)
-                                    .presentationDetents([.fraction(0.65)])
-                                    .padding()
-                                    .frame(maxHeight: .infinity, alignment: .top)
-                            }
-                            .sheet(isPresented: $isShowingReorderSheet) {
-                                NavigationStack {
-                                    List {
-                                        ForEach(template.setGroups) { setGroup in
-                                            HStack {
-                                                VStack(alignment: .leading) {
-                                                    Text(setGroup.exercise?.displayName ?? "")
-                                                    if setGroup.setType == .superSet,
-                                                       let secondaryExercise = setGroup.secondaryExercise {
-                                                        HStack {
-                                                            Image(systemName: "arrow.turn.down.right")
-                                                            Text(secondaryExercise.displayName)
-                                                        }
+                    // Mirrors the recorder's tray exactly: the sheet chain hangs DIRECTLY off
+                    // the NavigationStack's root child. With the old `NavigationView { VStack {…} }`
+                    // wrapping, presenting a nested sheet (the rest editor) made UIKit and
+                    // SwiftUI's presentation reconciliation fight over the tray — the tray was
+                    // dismissed and re-presented in a loop, the rest editor flashed away with
+                    // it, and its stuck `item` binding then blocked every reopen.
+                    NavigationStack {
+                        ExerciseSelectionScreen(
+                            selectedExercise: nil,
+                            setExercise: { exercise in
+                                UIImpactFeedbackGenerator(style: .soft).impactOccurred()
+                                database.newTemplateSetGroup(
+                                    createFirstSetAutomatically: true,
+                                    exercise: exercise,
+                                    template: template
+                                )
+                                withAnimation {
+                                    scrollable.scrollTo(1, anchor: .bottom)
+                                }
+                            },
+                            forSecondary: false,
+                            currentWorkoutExercises: [],
+                            supersetPrimaryExercise: nil,
+                            presentationDetentSelection: $exerciseSelectionPresentationDetent
+                        )
+                        .toolbar(.hidden, for: .navigationBar)
+                        .sheet(item: $selectedRestDurationSet) { templateSet in
+                            RestDurationEditorSheet(templateSet: templateSet)
+                                .presentationDetents([.fraction(0.65)])
+                                .padding()
+                                .frame(maxHeight: .infinity, alignment: .top)
+                        }
+                        .sheet(isPresented: $isShowingReorderSheet) {
+                            NavigationStack {
+                                List {
+                                    ForEach(template.setGroups) { setGroup in
+                                        HStack {
+                                            VStack(alignment: .leading) {
+                                                Text(setGroup.exercise?.displayName ?? "")
+                                                if setGroup.setType == .superSet,
+                                                   let secondaryExercise = setGroup.secondaryExercise {
+                                                    HStack {
+                                                        Image(systemName: "arrow.turn.down.right")
+                                                        Text(secondaryExercise.displayName)
                                                     }
                                                 }
                                             }
                                         }
-                                        .onMove(perform: moveSetGroups)
                                     }
-                                    .environment(\.editMode, .constant(.active))
-                                    .navigationTitle(NSLocalizedString("reorderExercises", comment: ""))
-                                    .navigationBarTitleDisplayMode(.inline)
-                                    .toolbar {
-                                        ToolbarItem(placement: .topBarTrailing) {
-                                            Button {
-                                                isShowingReorderSheet = false
-                                            } label: {
-                                                Text(NSLocalizedString("done", comment: ""))
-                                            }
+                                    .onMove(perform: moveSetGroups)
+                                }
+                                .environment(\.editMode, .constant(.active))
+                                .navigationTitle(NSLocalizedString("reorderExercises", comment: ""))
+                                .navigationBarTitleDisplayMode(.inline)
+                                .toolbar {
+                                    ToolbarItem(placement: .topBarTrailing) {
+                                        Button {
+                                            isShowingReorderSheet = false
+                                        } label: {
+                                            Text(NSLocalizedString("done", comment: ""))
                                         }
                                     }
                                 }
@@ -203,8 +210,30 @@ struct TemplateEditorScreen: View {
                         }
                     }
                     .presentationDetents([.height(BOTTOM_SHEET_SMALL), .medium, .large], selection: $exerciseSelectionPresentationDetent)
-                    .presentationBackgroundInteraction(.enabled)
+                    // Pass-through only while nothing is stacked on the tray: a
+                    // background-interactive sheet can't stably host a nested sheet — UIKit
+                    // dismisses the tray, SwiftUI re-presents it, and the nested sheet
+                    // flashes away in the fight (the reported "rest menu flashes and never
+                    // reopens" bug).
+                    .presentationBackgroundInteraction(
+                        trayAllowsBackgroundInteraction ? .enabled : .disabled
+                    )
                     .interactiveDismissDisabled()
+                }
+                // Asymmetric switch for the tray's pass-through: it turns off the moment a
+                // nested sheet presents, but back on only after the nested sheet's dismissal
+                // transition has settled — reconfiguring the tray's presentation mid-dismissal
+                // makes UIKit cancel that dismissal and the nested sheet springs back.
+                .onChange(of: hasNestedTraySheet) { _, hasNested in
+                    if hasNested {
+                        trayAllowsBackgroundInteraction = false
+                    } else {
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
+                            if !hasNestedTraySheet {
+                                trayAllowsBackgroundInteraction = true
+                            }
+                        }
+                    }
                 }
             }
             .interactiveDismissDisabled()
@@ -304,6 +333,11 @@ struct TemplateEditorScreen: View {
 
     // MARK: - Computed Properties
 
+    /// True while any sheet is stacked on the persistent exercise tray.
+    private var hasNestedTraySheet: Bool {
+        selectedRestDurationSet != nil || isShowingReorderSheet
+    }
+
     private var templateName: Binding<String> {
         // Resolve `_default.` keys so bundled templates show their localized name here. Once
         // the user types, the literal text is stored and the template stops being localized —
@@ -312,11 +346,11 @@ struct TemplateEditorScreen: View {
     }
 
     /// The template set whose rep/weight field currently holds focus, derived from the keyboard
-    /// field index — mirrors the recorder's `selectedWorkoutSet`. `IntegerField.Index.primary` is
-    /// the set's position in the flat `template.sets` list.
+    /// field index — mirrors the recorder's `selectedWorkoutSet`. The index carries the set's
+    /// stable entity UUID.
     private var selectedTemplateSet: TemplateSet? {
         guard let focusedIndex = focusedIntegerFieldIndex else { return nil }
-        return template.sets.value(at: focusedIndex.primary)
+        return template.sets.first { $0.id == focusedIndex.setID }
     }
 
     @ViewBuilder

--- a/LOGIT/Features/Workout/Cells/WorkoutSetCells/WorkoutSetCell.swift
+++ b/LOGIT/Features/Workout/Cells/WorkoutSetCells/WorkoutSetCell.swift
@@ -115,7 +115,7 @@ struct WorkoutSetCell: View {
 
     @ViewBuilder
     private var setContent: some View {
-        if let indexInWorkout {
+        if let setID = workoutSet.id {
             let referenceValues = referenceSet?.entryValues ?? []
             let placeholderValues =
                 workoutRecorder.templateSet(for: workoutSet)?.entryValues ?? []
@@ -126,7 +126,7 @@ struct WorkoutSetCell: View {
                     let entryExercise = workoutSet.owningExercise(of: entry)
                     SetEntryFieldsRow(
                         entry: entry,
-                        primaryIndex: indexInWorkout,
+                        setID: setID,
                         secondaryIndex: entryIndex,
                         focusedIntegerFieldIndex: $focusedIntegerFieldIndex,
                         reference: reference(for: entry, at: entryIndex, in: referenceValues),
@@ -139,10 +139,6 @@ struct WorkoutSetCell: View {
             }
             .padding(.vertical, CELL_SPACING / 2)
         }
-    }
-
-    private var indexInWorkout: Int? {
-        workoutSet.workout?.sets.firstIndex(of: workoutSet)
     }
 
     /// The like-for-like reference entry from the previous workout's matching set: compound
@@ -318,7 +314,7 @@ private func formatDisplayWeightDelta(_ value: Double) -> String {
     let formatter = NumberFormatter()
     formatter.numberStyle = .decimal
     formatter.minimumFractionDigits = 0
-    formatter.maximumFractionDigits = 3
+    formatter.maximumFractionDigits = 2
     formatter.decimalSeparator = "."
     formatter.groupingSeparator = ""
     return formatter.string(from: NSNumber(value: value)) ?? "0"

--- a/LOGIT/Features/Workout/Cells/WorkoutSetGroupCell.swift
+++ b/LOGIT/Features/Workout/Cells/WorkoutSetGroupCell.swift
@@ -35,10 +35,6 @@ struct WorkoutSetGroupCell: View {
     /// group must still refresh this cell's header number. Nil when the cell is used standalone
     /// (previews), where the position is derived from the workout instead.
     var indexInWorkout: Int? = nil
-    /// Flat index of this group's first set within the whole workout. Not rendered, but part of
-    /// `==`: the set cells derive their keyboard-focus indices from flat set positions, so a
-    /// structural change in an earlier group has to re-render this cell's children too.
-    var firstSetIndexInWorkout: Int = 0
     var onTapRestDuration: ((WorkoutSet) -> Void)? = nil
     var onReorderSetGroups: (() -> Void)? = nil
     var onTapPreviousSet: ((Exercise) -> Void)? = nil
@@ -555,7 +551,6 @@ extension WorkoutSetGroupCell: Equatable {
             && lhs.showPendingRestInTertiary == rhs.showPendingRestInTertiary
             && lhs.isFieldFocused == rhs.isFieldFocused
             && lhs.indexInWorkout == rhs.indexInWorkout
-            && lhs.firstSetIndexInWorkout == rhs.firstSetIndexInWorkout
     }
 }
 

--- a/LOGIT/Features/Workout/WorkoutEditorScreen.swift
+++ b/LOGIT/Features/Workout/WorkoutEditorScreen.swift
@@ -34,6 +34,9 @@ struct WorkoutEditorScreen: View {
     @State private var selectedRestDurationSet: WorkoutSet?
     @State private var isShowingReorderSheet = false
     @State private var exerciseForDetailSheet: Exercise?
+    /// Whether the persistent exercise tray lets touches through to the editor behind it.
+    /// Driven by `hasNestedTraySheet` with an asymmetric delay — see that property's docs.
+    @State private var trayAllowsBackgroundInteraction = true
 
     // MARK: - Parameters
 
@@ -132,71 +135,72 @@ struct WorkoutEditorScreen: View {
                     .padding(.top)
                 }
                 .sheet(isPresented: .constant(true)) {
-                    NavigationView {
-                        VStack(spacing: 0) {
-                            ExerciseSelectionScreen(
-                                selectedExercise: nil,
-                                setExercise: { exercise in
-                                    database.newWorkoutSetGroup(
-                                        createFirstSetAutomatically: true,
-                                        exercise: exercise,
-                                        workout: workout
-                                    )
-                                },
-                                forSecondary: false,
-                                currentWorkoutExercises: workout.exercises,
-                                supersetPrimaryExercise: nil,
-                                presentationDetentSelection: $exerciseSelectionPresentationDetent
-                            )
-                            .toolbar(.hidden, for: .navigationBar)
-                            .sheet(item: $selectedRestDurationSet) { workoutSet in
-                                RestDurationEditorSheet(workoutSet: workoutSet)
-                                    .presentationDetents([.fraction(0.65)])
-                                    .padding()
-                                    .frame(maxHeight: .infinity, alignment: .top)
+                    // Structured like the recorder's tray (sheet chain directly off the
+                    // NavigationStack root) — see TemplateEditorScreen for why: the old
+                    // NavigationView + wrapper made nested sheets fight the tray.
+                    NavigationStack {
+                        ExerciseSelectionScreen(
+                            selectedExercise: nil,
+                            setExercise: { exercise in
+                                database.newWorkoutSetGroup(
+                                    createFirstSetAutomatically: true,
+                                    exercise: exercise,
+                                    workout: workout
+                                )
+                            },
+                            forSecondary: false,
+                            currentWorkoutExercises: workout.exercises,
+                            supersetPrimaryExercise: nil,
+                            presentationDetentSelection: $exerciseSelectionPresentationDetent
+                        )
+                        .toolbar(.hidden, for: .navigationBar)
+                        .sheet(item: $selectedRestDurationSet) { workoutSet in
+                            RestDurationEditorSheet(workoutSet: workoutSet)
+                                .presentationDetents([.fraction(0.65)])
+                                .padding()
+                                .frame(maxHeight: .infinity, alignment: .top)
+                        }
+                        .sheet(item: $exerciseForDetailSheet) { exercise in
+                            NavigationStack {
+                                ExerciseDetailScreen(exercise: exercise, isShowingAsSheet: true, scrollToRecentAttempts: true)
                             }
-                            .sheet(item: $exerciseForDetailSheet) { exercise in
-                                NavigationStack {
-                                    ExerciseDetailScreen(exercise: exercise, isShowingAsSheet: true, scrollToRecentAttempts: true)
-                                }
-                                .presentationDragIndicator(.visible)
-                            }
-                            .sheet(isPresented: $isShowingReorderSheet) {
-                                NavigationStack {
-                                    List {
-                                        ForEach(workout.setGroups) { setGroup in
-                                            HStack {
-                                                VStack(alignment: .leading) {
-                                                    Text(setGroup.exercise?.displayName ?? "")
-                                                    if (setGroup.sets.first as? SuperSet) != nil,
-                                                       let secondaryExercise = setGroup.secondaryExercise {
-                                                        HStack {
-                                                            Image(systemName: "arrow.turn.down.right")
-                                                            Text(secondaryExercise.displayName)
-                                                        }
+                            .presentationDragIndicator(.visible)
+                        }
+                        .sheet(isPresented: $isShowingReorderSheet) {
+                            NavigationStack {
+                                List {
+                                    ForEach(workout.setGroups) { setGroup in
+                                        HStack {
+                                            VStack(alignment: .leading) {
+                                                Text(setGroup.exercise?.displayName ?? "")
+                                                if (setGroup.sets.first as? SuperSet) != nil,
+                                                   let secondaryExercise = setGroup.secondaryExercise {
+                                                    HStack {
+                                                        Image(systemName: "arrow.turn.down.right")
+                                                        Text(secondaryExercise.displayName)
                                                     }
                                                 }
                                             }
                                         }
-                                        .onDelete {
-                                            workout.setGroups.remove(atOffsets: $0)
-                                            workout.setGroups.forEach { $0.objectWillChange.send() }
-                                        }
-                                        .onMove { source, destination in
-                                            workout.setGroups.move(fromOffsets: source, toOffset: destination)
-                                            workout.setGroups.forEach { $0.objectWillChange.send() }
-                                        }
                                     }
-                                    .environment(\.editMode, .constant(.active))
-                                    .navigationTitle(NSLocalizedString("reorderExercises", comment: ""))
-                                    .navigationBarTitleDisplayMode(.inline)
-                                    .toolbar {
-                                        ToolbarItem(placement: .topBarTrailing) {
-                                            Button {
-                                                isShowingReorderSheet = false
-                                            } label: {
-                                                Text(NSLocalizedString("done", comment: ""))
-                                            }
+                                    .onDelete {
+                                        workout.setGroups.remove(atOffsets: $0)
+                                        workout.setGroups.forEach { $0.objectWillChange.send() }
+                                    }
+                                    .onMove { source, destination in
+                                        workout.setGroups.move(fromOffsets: source, toOffset: destination)
+                                        workout.setGroups.forEach { $0.objectWillChange.send() }
+                                    }
+                                }
+                                .environment(\.editMode, .constant(.active))
+                                .navigationTitle(NSLocalizedString("reorderExercises", comment: ""))
+                                .navigationBarTitleDisplayMode(.inline)
+                                .toolbar {
+                                    ToolbarItem(placement: .topBarTrailing) {
+                                        Button {
+                                            isShowingReorderSheet = false
+                                        } label: {
+                                            Text(NSLocalizedString("done", comment: ""))
                                         }
                                     }
                                 }
@@ -204,13 +208,35 @@ struct WorkoutEditorScreen: View {
                         }
                     }
                     .presentationDetents([.height(BOTTOM_SHEET_SMALL), .medium, .large], selection: $exerciseSelectionPresentationDetent)
-                    .presentationBackgroundInteraction(.enabled)
+                    // Pass-through only while nothing is stacked on the tray: a
+                    // background-interactive sheet can't stably host a nested sheet — UIKit
+                    // dismisses the tray, SwiftUI re-presents it, and the nested sheet
+                    // flashes away in the fight (see TemplateEditorScreen).
+                    .presentationBackgroundInteraction(
+                        trayAllowsBackgroundInteraction ? .enabled : .disabled
+                    )
                     .interactiveDismissDisabled()
                     .sheet(isPresented: $isEditingStartEndDate) {
                         WorkoutStartEndDateEditorSheet(
                             workout: workout,
                             isPresented: $isEditingStartEndDate
                         )
+                    }
+                }
+                // Asymmetric switch for the tray's pass-through: off the moment a nested
+                // sheet presents, back on only after the nested sheet's dismissal transition
+                // has settled — reconfiguring the tray's presentation mid-dismissal makes
+                // UIKit cancel that dismissal and the nested sheet springs back
+                // (see TemplateEditorScreen).
+                .onChange(of: hasNestedTraySheet) { _, hasNested in
+                    if hasNested {
+                        trayAllowsBackgroundInteraction = false
+                    } else {
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
+                            if !hasNestedTraySheet {
+                                trayAllowsBackgroundInteraction = true
+                            }
+                        }
                     }
                 }
             }
@@ -330,6 +356,14 @@ struct WorkoutEditorScreen: View {
     }
 
     // MARK: - Computed Properties
+
+    /// True while any sheet is stacked on the persistent exercise tray.
+    private var hasNestedTraySheet: Bool {
+        selectedRestDurationSet != nil
+            || exerciseForDetailSheet != nil
+            || isShowingReorderSheet
+            || isEditingStartEndDate
+    }
 
     private var workoutName: Binding<String> {
         Binding(get: { workout.name ?? "" }, set: { workout.name = $0 })

--- a/LOGIT/Features/Workout/WorkoutRecorder/WorkoutRecorderScreen.swift
+++ b/LOGIT/Features/Workout/WorkoutRecorder/WorkoutRecorderScreen.swift
@@ -387,7 +387,9 @@ struct WorkoutRecorderScreen: View {
 
                 if isKbdTest {
                     DispatchQueue.main.asyncAfter(deadline: .now() + 1.6) {
-                        focusedIntegerFieldIndex = IntegerField.Index(primary: 0, secondary: 0, tertiary: 0)
+                        if let firstSetID = workoutRecorder.workout?.sets.first?.id {
+                            focusedIntegerFieldIndex = IntegerField.Index(setID: firstSetID, secondary: 0, tertiary: 0)
+                        }
                     }
                 }
             }
@@ -698,51 +700,45 @@ struct WorkoutRecorderScreen: View {
 
     var selectedWorkoutSet: WorkoutSet? {
         guard let focusedIndex = focusedIntegerFieldIndex else { return nil }
-        return workoutRecorder.workout?.sets.value(at: focusedIndex.primary)
+        return workoutRecorder.workout?.sets.first { $0.id == focusedIndex.setID }
     }
 
     func nextIntegerFieldIndex() -> IntegerField.Index? {
-        guard let workout = workoutRecorder.workout else { return nil }
-        guard let focusedIndex = focusedIntegerFieldIndex,
-              let focusedWorkoutSet = workout.sets.value(at: focusedIndex.primary)
+        guard let workout = workoutRecorder.workout,
+              let focusedIndex = focusedIntegerFieldIndex,
+              let position = workout.sets.firstIndex(where: { $0.id == focusedIndex.setID })
         else { return nil }
         // Advance entry by entry within the set (drops, super set sides), then set by set.
+        let focusedWorkoutSet = workout.sets[position]
         if focusedIndex.secondary + 1 < focusedWorkoutSet.entryValues.count {
             return clampedIndex(
-                primary: focusedIndex.primary,
+                for: focusedWorkoutSet,
                 secondary: focusedIndex.secondary + 1,
-                tertiary: focusedIndex.tertiary,
-                in: workout
+                tertiary: focusedIndex.tertiary
             )
         }
-        guard focusedIndex.primary + 1 < workout.sets.count else { return nil }
-        return clampedIndex(
-            primary: focusedIndex.primary + 1,
-            secondary: 0,
-            tertiary: focusedIndex.tertiary,
-            in: workout
-        )
+        guard let nextSet = workout.sets.value(at: position + 1) else { return nil }
+        return clampedIndex(for: nextSet, secondary: 0, tertiary: focusedIndex.tertiary)
     }
 
     func previousIntegerFieldIndex() -> IntegerField.Index? {
-        guard let workout = workoutRecorder.workout else { return nil }
-        guard let focusedIndex = focusedIntegerFieldIndex else { return nil }
+        guard let workout = workoutRecorder.workout,
+              let focusedIndex = focusedIntegerFieldIndex,
+              let position = workout.sets.firstIndex(where: { $0.id == focusedIndex.setID })
+        else { return nil }
         guard focusedIndex.secondary == 0 else {
             return clampedIndex(
-                primary: focusedIndex.primary,
+                for: workout.sets[position],
                 secondary: focusedIndex.secondary - 1,
-                tertiary: focusedIndex.tertiary,
-                in: workout
+                tertiary: focusedIndex.tertiary
             )
         }
-        guard focusedIndex.primary > 0,
-              let previousSet = workout.sets.value(at: focusedIndex.primary - 1)
-        else { return nil }
+        guard position > 0 else { return nil }
+        let previousSet = workout.sets[position - 1]
         return clampedIndex(
-            primary: focusedIndex.primary - 1,
+            for: previousSet,
             secondary: max(0, previousSet.entryValues.count - 1),
-            tertiary: focusedIndex.tertiary,
-            in: workout
+            tertiary: focusedIndex.tertiary
         )
     }
 
@@ -750,12 +746,12 @@ struct WorkoutRecorderScreen: View {
     /// moving from a two-field reps+weight row onto a single-field reps-only row lands on
     /// that row's last field instead of dropping focus.
     private func clampedIndex(
-        primary: Int, secondary: Int, tertiary: Int, in workout: Workout
-    ) -> IntegerField.Index {
-        let targetType = workout.sets.value(at: primary)?
-            .entryValues.value(at: secondary)?.type ?? .repsAndWeight
+        for workoutSet: WorkoutSet, secondary: Int, tertiary: Int
+    ) -> IntegerField.Index? {
+        guard let setID = workoutSet.id else { return nil }
+        let targetType = workoutSet.entryValues.value(at: secondary)?.type ?? .repsAndWeight
         return IntegerField.Index(
-            primary: primary,
+            setID: setID,
             secondary: secondary,
             tertiary: min(tertiary, targetType.inputFieldCount - 1)
         )

--- a/LOGIT/Features/Workout/WorkoutSetGroupList.swift
+++ b/LOGIT/Features/Workout/WorkoutSetGroupList.swift
@@ -45,7 +45,6 @@ struct WorkoutSetGroupList: View, Equatable {
                         showDetailAsSheet: showDetailAsSheet,
                         isFieldFocused: focusedIntegerFieldIndex != nil,
                         indexInWorkout: entry.index,
-                        firstSetIndexInWorkout: entry.firstSetIndex,
                         onTapRestDuration: onTapRestDuration,
                         onReorderSetGroups: onReorderSetGroups,
                         onTapPreviousSet: onTapPreviousSet,
@@ -63,17 +62,13 @@ struct WorkoutSetGroupList: View, Equatable {
         .animation(.interactiveSpring(), value: workout.setGroups.count)
     }
 
-    /// Each set group with its position and the flat index of its first set. Computed here and
-    /// passed into the cells because the cells' `Equatable` skipping needs structural changes to
-    /// be visible in their inputs: the header number and the set cells' focus indices depend on
-    /// what comes *before* a group, so deleting/reordering/resizing an earlier group must
-    /// re-render the ones after it even though their own set group didn't change.
-    private var indexedSetGroups: [(index: Int, firstSetIndex: Int, setGroup: WorkoutSetGroup)] {
-        var firstSetIndex = 0
-        return workout.setGroups.enumerated().map { index, setGroup in
-            defer { firstSetIndex += setGroup.sets.count }
-            return (index: index, firstSetIndex: firstSetIndex, setGroup: setGroup)
-        }
+    /// Each set group with its position. Passed into the cells because the cells' `Equatable`
+    /// skipping needs structural changes to be visible in their inputs: the header number
+    /// depends on what comes *before* a group, so deleting/reordering an earlier group must
+    /// re-render the ones after it even though their own set group didn't change. (Keyboard
+    /// focus is identity-keyed — see `IntegerField.Index` — so it doesn't depend on position.)
+    private var indexedSetGroups: [(index: Int, setGroup: WorkoutSetGroup)] {
+        Array(workout.setGroups.enumerated().map { (index: $0, setGroup: $1) })
     }
 
     @ViewBuilder

--- a/LOGIT/SharedUI/Views/DecimalField.swift
+++ b/LOGIT/SharedUI/Views/DecimalField.swift
@@ -120,7 +120,7 @@ struct DecimalField: View {
         .padding(.vertical, 5)
         .padding(.horizontal, 8)
         .secondaryTileStyle(backgroundColor: isFocused ? Color.white : Color.black.opacity(0.000001))
-        .setValueIndicatorOverlay(
+        .setValueIndicator(
             trend: trend,
             trendText: trendText,
             positiveColor: trendColor,
@@ -182,7 +182,7 @@ struct DecimalField: View {
             }
         }
         
-        // Limit decimal places to 3
+        // Limit decimal places to `decimalPlaces`
         if let dotIndex = filtered.firstIndex(of: ".") {
             let afterDot = filtered.index(after: dotIndex)
             let decimalPart = filtered[afterDot...]
@@ -239,9 +239,9 @@ struct DecimalField_Previews: PreviewProvider {
             placeholder: 0,
             value: .constant(12.5),
             maxDigits: 4,
-            decimalPlaces: 3,
-            index: .init(primary: 0),
-            focusedIntegerFieldIndex: .constant(.init(primary: 0))
+            decimalPlaces: 2,
+            index: .init(setID: UUID()),
+            focusedIntegerFieldIndex: .constant(nil)
         )
         .padding(CELL_PADDING)
         .secondaryTileStyle()

--- a/LOGIT/SharedUI/Views/IntegerField.swift
+++ b/LOGIT/SharedUI/Views/IntegerField.swift
@@ -106,7 +106,7 @@ struct IntegerField: View {
         .padding(.vertical, 5)
         .padding(.horizontal, 8)
         .secondaryTileStyle(backgroundColor: isFocused ? Color.white : Color.black.opacity(0.000001))
-        .setValueIndicatorOverlay(
+        .setValueIndicator(
             trend: trend,
             trendText: trendText,
             positiveColor: trendColor,
@@ -131,21 +131,16 @@ struct IntegerField: View {
         Int(valueString) == 0 || valueString.isEmpty
     }
 
+    /// Identity of one input field: the set it belongs to, the entry within the set, and the
+    /// field within the entry. The set is keyed by its stable entity UUID — NOT by its flat
+    /// position in the workout, which shifts whenever sets are added, removed, or reordered.
+    /// Position keys let two views that rendered at different times disagree about which set
+    /// an index means, and the field whose (stale) index matched the tapped field's would
+    /// steal the keyboard — typing landed in a different set than the one tapped.
     struct Index: Equatable, Hashable {
-        let primary: Int
+        let setID: UUID
         var secondary: Int = 0
         var tertiary: Int = 0
-
-        static func == (lhs: Index, rhs: Index) -> Bool {
-            lhs.primary == rhs.primary && lhs.secondary == rhs.secondary
-                && lhs.tertiary == rhs.tertiary
-        }
-
-        func hash(into hasher: inout Hasher) {
-            hasher.combine(primary)
-            hasher.combine(secondary)
-            hasher.combine(tertiary)
-        }
     }
 }
 
@@ -216,12 +211,16 @@ struct PreviousSetValueLabel: View {
 }
 
 extension View {
-    /// Places one indicator immediately to the left of (and bottom-aligned with) the number
+    /// Places one indicator immediately to the left of (and baseline-aligned with) the number
     /// it is attached to: the previous workout's value while the field is still empty, or
-    /// the trend delta once a value is entered. Anchoring to the host's leading edge keeps
-    /// the gap to the number constant regardless of the value's width; the label overflows
-    /// into the empty leading space without affecting layout. Fades between states.
-    func setValueIndicatorOverlay(
+    /// the trend delta once a value is entered. Fades between states.
+    ///
+    /// The indicator participates in layout (it used to be an overlay overflowing into the
+    /// field frame's empty leading space, which let a long previous value draw over the
+    /// neighboring field's number — the reported overlap bug). Its slot is reserved whenever
+    /// a reference exists, whichever of the two labels is showing, so the row's layout stays
+    /// put while typing swaps the previous value for the trend delta.
+    func setValueIndicator(
         trend: SetValueComparison?,
         trendText: String,
         positiveColor: Color,
@@ -232,24 +231,24 @@ extension View {
     ) -> some View {
         let showTrend = isVisible && trend != nil
         let showPrevious = !showTrend && showPreviousValue && previousValueText != nil
-        // Aligned to the number's text baseline, sitting a few points to its left. The host
-        // is the styled field tile, whose 8pt horizontal padding is offset in the leading
-        // guide so the gap to the number stays constant regardless of the value's width.
-        return overlay(alignment: Alignment(horizontal: .leading, vertical: .lastTextBaseline)) {
-            ZStack(alignment: Alignment(horizontal: .trailing, vertical: .lastTextBaseline)) {
-                SetValueDeltaLabel(
-                    comparison: trend ?? .improved,
-                    text: trendText,
-                    positiveColor: positiveColor
-                )
-                .opacity(showTrend ? 1 : 0)
-                PreviousSetValueLabel(text: previousValueText ?? "", onTap: onTapPreviousValue)
-                    .opacity(showPrevious ? 1 : 0)
-                    .allowsHitTesting(showPrevious)
+        let reservesSlot = isVisible && (trend != nil || previousValueText != nil)
+        return HStack(alignment: .lastTextBaseline, spacing: 0) {
+            if reservesSlot {
+                ZStack(alignment: Alignment(horizontal: .trailing, vertical: .lastTextBaseline)) {
+                    SetValueDeltaLabel(
+                        comparison: trend ?? .improved,
+                        text: trendText,
+                        positiveColor: positiveColor
+                    )
+                    .opacity(showTrend ? 1 : 0)
+                    PreviousSetValueLabel(text: previousValueText ?? "", onTap: onTapPreviousValue)
+                        .opacity(showPrevious ? 1 : 0)
+                        .allowsHitTesting(showPrevious)
+                }
+                .animation(.easeInOut(duration: 0.2), value: showTrend)
+                .animation(.easeInOut(duration: 0.2), value: showPrevious)
             }
-            .alignmentGuide(.leading) { $0.width - 2 }
-            .animation(.easeInOut(duration: 0.2), value: showTrend)
-            .animation(.easeInOut(duration: 0.2), value: showPrevious)
+            self
         }
     }
 }
@@ -260,8 +259,8 @@ struct IntegerField_Previews: PreviewProvider {
             placeholder: 0,
             value: .constant(12),
             maxDigits: 4,
-            index: .init(primary: 0),
-            focusedIntegerFieldIndex: .constant(.init(primary: 0))
+            index: .init(setID: UUID()),
+            focusedIntegerFieldIndex: .constant(nil)
         )
         .padding(CELL_PADDING)
         .secondaryTileStyle()

--- a/LOGIT/SharedUI/Views/SetEntryFieldsRow.swift
+++ b/LOGIT/SharedUI/Views/SetEntryFieldsRow.swift
@@ -24,12 +24,12 @@ extension TemplateSetEntry: SetEntryFieldsEditable {}
 /// reps+weight, reps only, duration (min:sec), or weight+duration. This is the single row
 /// every set cell — standard, drop, super, workout or template — renders per entry.
 ///
-/// The focus index is (set position, entry position, field position); field positions must
+/// The focus index is (set id, entry position, field position); field positions must
 /// stay consistent with `SetMeasurementType.inputFieldCount`, which the recorder's keyboard
 /// next/previous navigation clamps against.
 struct SetEntryFieldsRow<Entry: SetEntryFieldsEditable>: View {
     @ObservedObject var entry: Entry
-    let primaryIndex: Int
+    let setID: UUID
     let secondaryIndex: Int
     @Binding var focusedIntegerFieldIndex: IntegerField.Index?
     /// Like-for-like entry from the reference set (same position in the previous workout).
@@ -62,7 +62,7 @@ struct SetEntryFieldsRow<Entry: SetEntryFieldsEditable>: View {
     // MARK: - Fields
 
     private func fieldIndex(_ tertiary: Int) -> IntegerField.Index {
-        IntegerField.Index(primary: primaryIndex, secondary: secondaryIndex, tertiary: tertiary)
+        IntegerField.Index(setID: setID, secondary: secondaryIndex, tertiary: tertiary)
     }
 
     private func repetitionsField(tertiary: Int) -> some View {
@@ -92,7 +92,7 @@ struct SetEntryFieldsRow<Entry: SetEntryFieldsEditable>: View {
                 set: { entry.weight = convertWeightForStoring($0) }
             ),
             maxDigits: 4,
-            decimalPlaces: 3,
+            decimalPlaces: 2,
             index: fieldIndex(tertiary),
             focusedIntegerFieldIndex: $focusedIntegerFieldIndex,
             unit: WeightUnit.used.rawValue,

--- a/LOGITTests/WeightConvertingTests.swift
+++ b/LOGITTests/WeightConvertingTests.swift
@@ -205,10 +205,24 @@ final class WeightConvertingTests: XCTestCase {
     
     func testFormatWeightForDisplayMultipleDecimals() {
         userDefaultsHelper.setTestValue("kg", forKey: "weightUnit")
-        
-        // 50125 grams = 50.125 kg
+
+        // 50125 grams = 50.125 kg → display rounds to 2 decimals (plate math never
+        // needs more, and gram-rounding noise must not surface).
         let formatted = formatWeightForDisplay(Int64(50125))
-        XCTAssertEqual(formatted, "50.125", "50.125 kg should format with three decimals")
+        XCTAssertEqual(formatted, "50.13", "display weights round to two decimals")
+    }
+
+    /// Regression: entering 162.5 lbs stores round(162.5 × 453.592) = 73709 g; at 3 display
+    /// decimals that came back as "162.501" (the reported rounding artifact). Two-decimal
+    /// display must round the storage noise away.
+    func testFormatWeightForDisplayLbsRoundTripHasNoGramNoise() {
+        userDefaultsHelper.setTestValue("lbs", forKey: "weightUnit")
+
+        let stored = convertWeightForStoring(162.5)
+        XCTAssertEqual(formatWeightForDisplay(stored), "162.5", "entered lbs values must round-trip cleanly")
+
+        let storedQuarter = convertWeightForStoring(190.25)
+        XCTAssertEqual(formatWeightForDisplay(storedQuarter), "190.25", "quarter-pound plates must round-trip cleanly")
     }
     
     // MARK: - Integer Overload Tests
@@ -238,12 +252,12 @@ final class WeightConvertingTests: XCTestCase {
     
     func testRoundingToThreeDecimalPlaces() {
         userDefaultsHelper.setTestValue("kg", forKey: "weightUnit")
-        
-        // 50123 grams = 50.123 kg (exactly 3 decimal places)
+
+        // The decimal CONVERSION keeps 3 places so data consumers (measurements, charts)
+        // don't lose stored precision; only display FORMATTING rounds to 2.
         let displayed = convertWeightForDisplayingDecimal(Int64(50123))
         XCTAssertEqual(displayed, 50.123, accuracy: 0.0001)
-        
-        // Check that we don't get more than 3 decimal places
+
         let displayed2 = convertWeightForDisplayingDecimal(Int64(50001))
         XCTAssertEqual(displayed2, 50.001, accuracy: 0.0001)
     }

--- a/LOGITUITests/ScenarioScreenshots.swift
+++ b/LOGITUITests/ScenarioScreenshots.swift
@@ -426,4 +426,119 @@ final class ScenarioScreenshots: XCTestCase {
     private func waitABit(_ seconds: UInt32 = 1) {
         sleep(seconds)
     }
+
+    // MARK: - Regression tests (reported-bugs session 2026-07-21)
+
+    /// The template editor's rest-duration editor used to flash away after a few seconds
+    /// and never reopen: the persistent exercise tray had `presentationBackgroundInteraction
+    /// (.enabled)`, and a background-interactive sheet can't stably host a stacked sheet —
+    /// UIKit dismissed the tray, SwiftUI re-presented it, and the rest sheet died in the
+    /// fight, leaving its `.sheet(item:)` binding stuck. The tray now disables pass-through
+    /// while a nested sheet is up. This asserts the sheet survives ~5s and reopens.
+    func testTemplateRestEditorStaysPresentedAndReopens() {
+        let app = launchApp(scenario: "many")
+
+        let tabBar = app.tabBars.firstMatch
+        XCTAssertTrue(tabBar.waitForExistence(timeout: 30))
+        waitABit(1)
+        tapTab(app, at: 2) // Templates
+
+        let templateRow = app.staticTexts["Push Day"].firstMatch
+        XCTAssertTrue(templateRow.waitForExistence(timeout: 5), "No template row")
+        templateRow.tap()
+        waitABit(1)
+
+        // Nav-bar ellipsis menu → Edit.
+        app.navigationBars.firstMatch.buttons.allElementsBoundByIndex.last?.tap()
+        waitABit(1)
+        let editButton = app.buttons["Edit"].firstMatch
+        XCTAssertTrue(editButton.waitForExistence(timeout: 3), "No Edit menu item")
+        editButton.tap()
+        waitABit(2)
+
+        // Tap the "2:00" rest capsule between set 1 and set 2 (coordinate-based;
+        // background elements aren't in the a11y tree while the tray is up).
+        // The sheet-presence sentinel is its "Rest Between Sets" caption — unique to the
+        // sheet, unlike the preset labels, which collide with the editor's rest capsules.
+        let restCapsule = app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.287))
+        let sheetCaption = app.staticTexts["Rest Between Sets"].firstMatch
+        restCapsule.tap()
+        waitABit(1)
+        XCTAssertTrue(sheetCaption.waitForExistence(timeout: 3), "Rest editor did not present")
+        waitABit(4)
+        XCTAssertTrue(sheetCaption.exists, "Rest editor dismissed itself within ~5s")
+        attach(app, "template_rest_editor_stable")
+
+        // Picking a preset applies it and auto-dismisses…
+        app.buttons["1:00"].firstMatch.tap()
+        waitABit(2)
+        attach(app, "template_rest_editor_after_preset")
+        XCTAssertFalse(sheetCaption.exists, "Rest editor should dismiss after picking a preset")
+
+        // …and it must reopen — the stuck-binding regression.
+        restCapsule.tap()
+        waitABit(2)
+        XCTAssertTrue(sheetCaption.waitForExistence(timeout: 3), "Rest editor did not reopen")
+        attach(app, "template_rest_editor_reopened")
+    }
+
+    /// Keyboard focus is keyed by set UUID (IntegerField.Index.setID), not flat position.
+    /// With position keys, inserting a set into an earlier group while later cells hadn't
+    /// re-rendered made two fields claim the same index — tapping one focused the other
+    /// and typing landed sets earlier (the reported "typing in the squat section" bug).
+    /// -UITEST_MINIMAL disables the recorder's throttled re-render heal, freezing exactly
+    /// the stale state the production race produces.
+    func testRecorderFocusStaysOnTappedFieldAfterInsertingEarlierSet() {
+        let app = launchApp(
+            scenario: "stress",
+            extraArguments: ["-UITEST_SHOW_RECORDER", "-UITEST_NO_SHEET", "-UITEST_MINIMAL", "-UITEST_NO_SCROLLTO"]
+        )
+
+        let nameField = app.textFields.matching(NSPredicate(format: "value == 'Push Day'")).firstMatch
+        XCTAssertTrue(nameField.waitForExistence(timeout: 15), "Recorder never presented")
+        waitABit(2)
+
+        let addSetButtons = app.buttons.matching(NSPredicate(format: "label == 'Add Set'"))
+        let addSet1 = addSetButtons.element(boundBy: 0)
+        XCTAssertTrue(addSet1.waitForExistence(timeout: 5))
+
+        // Long-press a set row in group 1 → context menu → "Add Set After" (the one
+        // insertion path that doesn't fire workout.objectWillChange).
+        let firstField = app.textFields.allElementsBoundByIndex.first {
+            $0.frame.minY > 100 && $0.frame.maxY < addSet1.frame.minY
+        }
+        guard let groupOneField = firstField else {
+            XCTFail("No group 1 field found")
+            return
+        }
+        groupOneField.coordinate(withNormalizedOffset: CGVector(dx: -2.5, dy: 0.5))
+            .press(forDuration: 1.2)
+        let addAfter = app.buttons["Add Set After"].firstMatch
+        XCTAssertTrue(addAfter.waitForExistence(timeout: 3), "Context menu Add Set After not found")
+        addAfter.tap()
+        waitABit(2)
+
+        // Tap the first field of group 2 and type — the digit must land there.
+        let addSet1Frame = addSet1.frame
+        let fields = app.textFields.allElementsBoundByIndex
+        guard let target = fields.first(where: { $0.frame.minY > addSet1Frame.maxY + 10 && $0.isHittable }) else {
+            XCTFail("No target field below group 1 found")
+            return
+        }
+        let targetFrame = target.frame
+        let valueBefore = target.value as? String ?? ""
+
+        target.tap()
+        waitABit(1)
+        app.typeText("9")
+        waitABit(1)
+
+        let valueAfter = target.value as? String ?? ""
+        if !valueAfter.contains("9") || valueAfter == valueBefore {
+            let changed = app.textFields.allElementsBoundByIndex.first {
+                ($0.value as? String)?.contains("9") == true && $0.frame != targetFrame
+            }
+            XCTFail("Focus jump: tapped field at y=\(targetFrame.minY) value='\(valueAfter)'; digit landed at y=\(changed?.frame.minY ?? -1)")
+        }
+    }
 }


### PR DESCRIPTION
Fixes the four user-reported bugs, each replicated in the simulator before fixing and re-verified with the same scripted reproduction afterwards.

## 1 · "Rate LOGIT" button did nothing
It called `requestReview()` — Apple's rate-limited prompt that the system silently drops after a few uses per year, so the button appeared dead. An explicit rate button must deep-link instead: it now opens the App Store write-review page (`id6444813640?action=write-review`) with the external-link icon. The organic post-workout `requestReview()` prompt is unchanged (that's its correct use).

## 2 · Template rest-time editor flashed away and never reopened
Replicated on dense screenshot capture: the sheet presented, self-dismissed ~3 s later, and the rest capsule went permanently dead. `NSLog` lifecycle instrumentation showed the mechanism: the persistent exercise tray has touch pass-through (`presentationBackgroundInteraction(.enabled)`), and a pass-through sheet can't stably host a stacked sheet — UIKit dismissed the tray, SwiftUI re-presented the always-on tray, and the rest editor died in the ~1 s loop, leaving its `.sheet(item:)` binding stuck (why it never reopened).

Fix: the tray's pass-through switches off while a nested sheet is up — and back on only **after** the nested sheet's dismissal settles, because re-enabling synchronously reconfigures the tray mid-dismissal and UIKit cancels the dismissal (the sheet became unclosable). Trays also restructured from `NavigationView { VStack {…} }` to the recorder's proven `NavigationStack` chain. The identically-built `WorkoutEditorScreen` had the same latent bug and got the same fix; the recorder's tray was tested with a stacked sheet and is unaffected (Transmission container), so it's untouched.

Known gap (follow-up in flight separately): sheets opened from *inside* `ExerciseSelectionScreen` (Create Exercise, exercise detail) aren't visible to the editors' guard yet.

## 3 · Weight rounding noise + "last recorded" label overlapping current values
Integer-gram storage noise surfaced through 3-decimal display — an entered 162.5 lbs came back "162.501", kg-seeded history rendered "88.185 lbs" — and the long previous-value label, drawn as an overlay spilling leftwards, overlapped the neighboring reps value.

Fix: display formatting now matches what gram storage can round-trip (3 fraction digits in kg, 2 in lbs — reconciled with the per-unit conversion that landed on main), with half-up rounding; and the previous-value/trend indicator takes real layout space beside the field instead of overlaying, so it can never draw over another value. Regression unit tests cover the 162.5/190.25 lbs round-trips; measurement 3-decimal precision is preserved.

## 4 · Tapping a set typed into an earlier exercise
Keyboard focus was keyed by a set's flat position in the workout. Positions shift on insert/remove/reorder and cells re-render at different moments, so two fields could claim the same index and the stale one stole the keyboard — "tapped incline, typed into squats", with the stale window stretched by scroll tracking (fits the "randomly, deep into a long workout" report). Reproduced deterministically via the context-menu **Add Set After** path with the healing re-render frozen.

Fix: focus is keyed by the set's permanent UUID (`IntegerField.Index.setID`), eliminating the whole class of stale/duplicate focus targets. Side benefit: adding a set above the field you're typing in no longer drops the keyboard. The now-unneeded `firstSetIndexInWorkout` Equatable input was removed (fewer cell re-renders on structural changes).

## Verification
- Full unit suite passes (incl. new weight round-trip regression tests).
- Two new regression UI tests in `ScenarioScreenshots` pass: rest editor survives 5 s / applies a preset / auto-dismisses / reopens; typed digit lands in the tapped field after an earlier-group insertion (`-UITEST_MINIMAL` freezes the stale state).
- Standing scenario matrix (empty / one / many / free) passes with no visual regressions.
- Harness: `-SCENARIO` now honors explicit `-weightUnit` / `-distanceUnit` launch arguments for unit-dependent verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
