### PR TITLE
Fix ScenarioScreenshots tapTab: select tabs by label, not index

### DIFF
--- a/LOGITUITests/ScenarioScreenshots.swift
+++ b/LOGITUITests/ScenarioScreenshots.swift
@@ -708,21 +708,37 @@ final class ScenarioScreenshots: XCTestCase {
         return app
     }
 
+    /// Tab titles as they appear in English (the tests launch with -AppleLanguages (en)).
+    private static let tabLabels = ["Summary", "History", "Templates", "Search"]
+
     private func tapTab(_ app: XCUIApplication, at index: Int) {
+        let label = Self.tabLabels[index]
         let tabBar = app.tabBars.firstMatch
         guard tabBar.waitForExistence(timeout: 5) else { return }
-        var buttons = tabBar.buttons.allElementsBoundByIndex
-        if index >= buttons.count {
-            // Tab bar is minimized after a scroll — swipe down to restore it.
+
+        // Look up by label, never by index: on iOS 26 the bar collapses both
+        // after a scroll (tabBarMinimizeBehavior) and while the Search tab is
+        // active (the regular tabs fold into a single leading button next to
+        // the search pill), and in those states positional indices lie.
+        var button = tabBar.buttons[label]
+        if !button.exists {
+            // Scroll-minimized bar: swiping down restores it.
             app.swipeDown()
             sleep(1)
-            buttons = tabBar.buttons.allElementsBoundByIndex
+            button = tabBar.buttons[label]
         }
-        guard index < buttons.count else {
-            XCTFail("Tab index \(index) not reachable (\(buttons.count) tab buttons visible)")
+        if !button.exists, tabBar.buttons.count > 0 {
+            // Search-active bar: tapping the collapsed leading button leaves
+            // search and re-expands the full tab row.
+            tabBar.buttons.firstMatch.tap()
+            sleep(1)
+            button = tabBar.buttons[label]
+        }
+        guard button.waitForExistence(timeout: 2) else {
+            XCTFail("Tab '\(label)' not reachable in the tab bar")
             return
         }
-        buttons[index].tap()
+        button.tap()
     }
 
     private func attach(_ app: XCUIApplication, _ name: String) {


### PR DESCRIPTION
## Problem

On the iOS 26.4 iPhone 17 Pro simulator, `ScenarioScreenshots.captureMainScreens`' final `02_summary_scrolled` capture showed the scrolled **Templates** list in all four scenarios instead of the scrolled **Summary** screen.

## Root cause

`captureMainScreens` visits the Search tab (`role: .search`) before returning to Summary. While the Search tab is active, the iOS 26 tab bar collapses into two buttons — a collapsed-tabs leading button and the search pill — so index-based `tabBar.buttons[index]` lookups no longer map index 0 to Summary. Tapping index 0 hit the collapsed group and merely returned to the previously selected tab (Templates); the subsequent `swipeUp` then scrolled that list.

## Fix

`tapTab` now resolves buttons by their English accessibility label (`Summary` / `History` / `Templates` / `Search` — deterministic because the suite launches with `-AppleLanguages (en)`) instead of positional index. If the label isn't present it first swipes down (restores the scroll-minimized bar), then taps the collapsed leading button (exits the search-active state and re-expands the bar) before retrying, and fails loudly if the tab still can't be found. `tapTab` was the only index-based tab lookup in the test targets.

## Verification

`testEmptyScenario` passes on iPhone 17 Pro / iOS 26.4 (35s), and the exported `02_summary_scrolled` attachment now shows the empty-scenario Summary screen ("Log your first workout" hero + "What you'll track" tiles), not the Templates list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)