### PR TITLE
Tray sheets: delegate ExerciseSelectionScreen presentations to tray hosts

### DIFF
--- a/LOGIT/Features/Exercise/ExerciseSelectionScreen.swift
+++ b/LOGIT/Features/Exercise/ExerciseSelectionScreen.swift
@@ -20,6 +20,14 @@ struct ExerciseSelectionScreen: View {
         }
     }
 
+    /// A Create Exercise presentation delegated to the host: the prefilled name
+    /// (current search text) and the muscle-group filter at the moment of the request.
+    struct AddExerciseRequest: Identifiable {
+        let id = UUID()
+        let name: String
+        let muscleGroup: MuscleGroup?
+    }
+
     // MARK: - Environment
 
     @EnvironmentObject private var exerciseSuggestionService: ExerciseSuggestionService
@@ -41,6 +49,15 @@ struct ExerciseSelectionScreen: View {
     let currentWorkoutExercises: [Exercise]
     let supersetPrimaryExercise: Exercise?
     @Binding var presentationDetentSelection: PresentationDetent
+    /// When set, Create Exercise is delegated to the host instead of being presented
+    /// from this screen's own hierarchy. Hosts that show this screen inside a
+    /// persistent background-interactive tray MUST delegate: stacking a sheet onto the
+    /// tray makes UIKit dismiss and re-present the tray, and a nested sheet whose
+    /// owning state lives inside the recycled tray content is torn down with it —
+    /// only host-owned state survives the cycle (see TemplateEditorScreen).
+    var onRequestAddExercise: ((AddExerciseRequest) -> Void)? = nil
+    /// Same delegation for the context menus' "Show Details" sheet.
+    var onRequestExerciseDetail: ((Exercise) -> Void)? = nil
 
     // MARK: - Body
 
@@ -140,6 +157,32 @@ struct ExerciseSelectionScreen: View {
         }
     }
 
+    // MARK: - Presentation
+
+    /// Create Exercise: delegated to the host when it asked for it (tray hosts —
+    /// see `onRequestAddExercise`), otherwise presented from this screen.
+    private func showAddExercise() {
+        if let onRequestAddExercise {
+            onRequestAddExercise(
+                AddExerciseRequest(
+                    name: searchedText.trimmingCharacters(in: .whitespacesAndNewlines).capitalized,
+                    muscleGroup: selectedMuscleGroup
+                )
+            )
+        } else {
+            sheetType = .addExercise
+        }
+    }
+
+    /// "Show Details": same host delegation as `showAddExercise`.
+    private func showExerciseDetail(_ exercise: Exercise) {
+        if let onRequestExerciseDetail {
+            onRequestExerciseDetail(exercise)
+        } else {
+            selectedExerciseForDetail = exercise
+        }
+    }
+
     // MARK: - Subviews
 
     @ViewBuilder
@@ -170,7 +213,7 @@ struct ExerciseSelectionScreen: View {
             .clipShape(.capsule)
             if !isSmallDetent {
                 Button {
-                    sheetType = .addExercise
+                    showAddExercise()
                 } label: {
                     Image(systemName: "plus")
                         .font(.title2)
@@ -197,7 +240,7 @@ struct ExerciseSelectionScreen: View {
                             description: NSLocalizedString("noExercisesTipDescription", comment: ""),
                             buttonAction: .init(
                                 title: NSLocalizedString("createExercise", comment: ""),
-                                action: { sheetType = .addExercise }
+                                action: { showAddExercise() }
                             ),
                             isShown: $isShowingNoExercisesTip
                         )
@@ -263,7 +306,7 @@ struct ExerciseSelectionScreen: View {
                     .buttonStyle(TileButtonStyle())
                     .contextMenu {
                         Button {
-                            selectedExerciseForDetail = exercise
+                            showExerciseDetail(exercise)
                         } label: {
                             Label(NSLocalizedString("showDetails", comment: ""), systemImage: "info.circle")
                         }
@@ -300,7 +343,7 @@ struct ExerciseSelectionScreen: View {
                 .buttonStyle(TileButtonStyle())
                 .contextMenu {
                     Button {
-                        selectedExerciseForDetail = exercise
+                        showExerciseDetail(exercise)
                     } label: {
                         Label(NSLocalizedString("showDetails", comment: ""), systemImage: "info.circle")
                     }
@@ -342,7 +385,7 @@ struct ExerciseSelectionScreen: View {
                         .buttonStyle(TileButtonStyle())
                         .contextMenu {
                             Button {
-                                selectedExerciseForDetail = exercise
+                                showExerciseDetail(exercise)
                             } label: {
                                 Label(NSLocalizedString("showDetails", comment: ""), systemImage: "info.circle")
                             }

--- a/LOGIT/Features/Template/TemplateEditorScreen.swift
+++ b/LOGIT/Features/Template/TemplateEditorScreen.swift
@@ -45,6 +45,15 @@ struct TemplateEditorScreen: View {
     @State private var isRenamingTemplate = false
     @State private var focusedIntegerFieldIndex: IntegerField.Index?
     @FocusState private var isFocusingRenameTemplateField: Bool
+    /// Whether the persistent exercise tray lets touches through to the editor behind it.
+    /// Driven by `hasNestedTraySheet` with an asymmetric delay — see that property's docs.
+    @State private var trayAllowsBackgroundInteraction = true
+    /// Create Exercise, delegated up from the tray's ExerciseSelectionScreen — owned
+    /// here because a nested sheet only survives the tray's dismiss/re-present cycle
+    /// when its owning state lives outside the recycled tray content.
+    @State private var createExerciseRequest: ExerciseSelectionScreen.AddExerciseRequest?
+    /// "Show Details" from the tray's context menus — host-owned for the same reason.
+    @State private var exerciseDetailFromTray: Exercise?
 
     // MARK: - Parameters
 
@@ -140,11 +149,43 @@ struct TemplateEditorScreen: View {
                 }
                 .scrollIndicators(.hidden)
                 .sheet(isPresented: .constant(true)) {
-                    NavigationView {
-                        VStack(spacing: 0) {
-                            ExerciseSelectionScreen(
-                                selectedExercise: nil,
-                                setExercise: { exercise in
+                    // Mirrors the recorder's tray exactly: the sheet chain hangs DIRECTLY off
+                    // the NavigationStack's root child. With the old `NavigationView { VStack {…} }`
+                    // wrapping, presenting a nested sheet (the rest editor) made UIKit and
+                    // SwiftUI's presentation reconciliation fight over the tray — the tray was
+                    // dismissed and re-presented in a loop, the nested sheet flashed away with
+                    // it, and its stuck `item` binding then blocked every reopen.
+                    NavigationStack {
+                        ExerciseSelectionScreen(
+                            selectedExercise: nil,
+                            setExercise: { exercise in
+                                UIImpactFeedbackGenerator(style: .soft).impactOccurred()
+                                database.newTemplateSetGroup(
+                                    createFirstSetAutomatically: true,
+                                    exercise: exercise,
+                                    template: template
+                                )
+                                withAnimation {
+                                    scrollable.scrollTo(1, anchor: .bottom)
+                                }
+                            },
+                            forSecondary: false,
+                            currentWorkoutExercises: [],
+                            supersetPrimaryExercise: nil,
+                            presentationDetentSelection: $exerciseSelectionPresentationDetent,
+                            onRequestAddExercise: { createExerciseRequest = $0 },
+                            onRequestExerciseDetail: { exerciseDetailFromTray = $0 }
+                        )
+                        .toolbar(.hidden, for: .navigationBar)
+                        .sheet(item: $selectedRestDurationSet) { templateSet in
+                            RestDurationEditorSheet(templateSet: templateSet)
+                                .presentationDetents([.fraction(0.65)])
+                                .padding()
+                                .frame(maxHeight: .infinity, alignment: .top)
+                        }
+                        .sheet(item: $createExerciseRequest) { request in
+                            ExerciseEditScreen(
+                                onEditFinished: { exercise in
                                     UIImpactFeedbackGenerator(style: .soft).impactOccurred()
                                     database.newTemplateSetGroup(
                                         createFirstSetAutomatically: true,
@@ -154,48 +195,46 @@ struct TemplateEditorScreen: View {
                                     withAnimation {
                                         scrollable.scrollTo(1, anchor: .bottom)
                                     }
+                                    exerciseSelectionPresentationDetent = .height(BOTTOM_SHEET_SMALL)
                                 },
-                                forSecondary: false,
-                                currentWorkoutExercises: [],
-                                supersetPrimaryExercise: nil,
-                                presentationDetentSelection: $exerciseSelectionPresentationDetent
+                                initialExerciseName: request.name,
+                                initialMuscleGroup: request.muscleGroup ?? .chest
                             )
-                            .toolbar(.hidden, for: .navigationBar)
-                            .sheet(item: $selectedRestDurationSet) { templateSet in
-                                RestDurationEditorSheet(templateSet: templateSet)
-                                    .presentationDetents([.fraction(0.65)])
-                                    .padding()
-                                    .frame(maxHeight: .infinity, alignment: .top)
+                        }
+                        .sheet(item: $exerciseDetailFromTray) { exercise in
+                            NavigationStack {
+                                ExerciseDetailScreen(exercise: exercise, isShowingAsSheet: true)
                             }
-                            .sheet(isPresented: $isShowingReorderSheet) {
-                                NavigationStack {
-                                    List {
-                                        ForEach(template.setGroups) { setGroup in
-                                            HStack {
-                                                VStack(alignment: .leading) {
-                                                    Text(setGroup.exercise?.displayName ?? "")
-                                                    if setGroup.setType == .superSet,
-                                                       let secondaryExercise = setGroup.secondaryExercise {
-                                                        HStack {
-                                                            Image(systemName: "arrow.turn.down.right")
-                                                            Text(secondaryExercise.displayName)
-                                                        }
+                            .presentationDragIndicator(.visible)
+                        }
+                        .sheet(isPresented: $isShowingReorderSheet) {
+                            NavigationStack {
+                                List {
+                                    ForEach(template.setGroups) { setGroup in
+                                        HStack {
+                                            VStack(alignment: .leading) {
+                                                Text(setGroup.exercise?.displayName ?? "")
+                                                if setGroup.setType == .superSet,
+                                                   let secondaryExercise = setGroup.secondaryExercise {
+                                                    HStack {
+                                                        Image(systemName: "arrow.turn.down.right")
+                                                        Text(secondaryExercise.displayName)
                                                     }
                                                 }
                                             }
                                         }
-                                        .onMove(perform: moveSetGroups)
                                     }
-                                    .environment(\.editMode, .constant(.active))
-                                    .navigationTitle(NSLocalizedString("reorderExercises", comment: ""))
-                                    .navigationBarTitleDisplayMode(.inline)
-                                    .toolbar {
-                                        ToolbarItem(placement: .topBarTrailing) {
-                                            Button {
-                                                isShowingReorderSheet = false
-                                            } label: {
-                                                Text(NSLocalizedString("done", comment: ""))
-                                            }
+                                    .onMove(perform: moveSetGroups)
+                                }
+                                .environment(\.editMode, .constant(.active))
+                                .navigationTitle(NSLocalizedString("reorderExercises", comment: ""))
+                                .navigationBarTitleDisplayMode(.inline)
+                                .toolbar {
+                                    ToolbarItem(placement: .topBarTrailing) {
+                                        Button {
+                                            isShowingReorderSheet = false
+                                        } label: {
+                                            Text(NSLocalizedString("done", comment: ""))
                                         }
                                     }
                                 }
@@ -203,8 +242,30 @@ struct TemplateEditorScreen: View {
                         }
                     }
                     .presentationDetents([.height(BOTTOM_SHEET_SMALL), .medium, .large], selection: $exerciseSelectionPresentationDetent)
-                    .presentationBackgroundInteraction(.enabled)
+                    // Pass-through only while nothing is stacked on the tray: a
+                    // background-interactive sheet can't stably host a nested sheet — UIKit
+                    // dismisses the tray, SwiftUI re-presents it, and the nested sheet
+                    // flashes away in the fight (the reported "rest menu flashes and never
+                    // reopens" bug).
+                    .presentationBackgroundInteraction(
+                        trayAllowsBackgroundInteraction ? .enabled : .disabled
+                    )
                     .interactiveDismissDisabled()
+                }
+                // Asymmetric switch for the tray's pass-through: it turns off the moment a
+                // nested sheet presents, but back on only after the nested sheet's dismissal
+                // transition has settled — reconfiguring the tray's presentation mid-dismissal
+                // makes UIKit cancel that dismissal and the nested sheet springs back.
+                .onChange(of: hasNestedTraySheet) { _, hasNested in
+                    if hasNested {
+                        trayAllowsBackgroundInteraction = false
+                    } else {
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
+                            if !hasNestedTraySheet {
+                                trayAllowsBackgroundInteraction = true
+                            }
+                        }
+                    }
                 }
             }
             .interactiveDismissDisabled()
@@ -303,6 +364,15 @@ struct TemplateEditorScreen: View {
     }
 
     // MARK: - Computed Properties
+
+    /// True while any sheet is stacked on the persistent exercise tray — rest editor,
+    /// reorder, or one of the tray-delegated presentations (create exercise, detail).
+    private var hasNestedTraySheet: Bool {
+        selectedRestDurationSet != nil
+            || isShowingReorderSheet
+            || createExerciseRequest != nil
+            || exerciseDetailFromTray != nil
+    }
 
     private var templateName: Binding<String> {
         // Resolve `_default.` keys so bundled templates show their localized name here. Once

--- a/LOGIT/Features/Workout/WorkoutEditorScreen.swift
+++ b/LOGIT/Features/Workout/WorkoutEditorScreen.swift
@@ -35,6 +35,14 @@ struct WorkoutEditorScreen: View {
     @State private var selectedRestDurationSet: WorkoutSet?
     @State private var isShowingReorderSheet = false
     @State private var exerciseForDetailSheet: Exercise?
+    /// Whether the persistent exercise tray lets touches through to the editor behind it.
+    /// Driven by `hasNestedTraySheet` with an asymmetric delay — see that property's docs.
+    @State private var trayAllowsBackgroundInteraction = true
+    /// Create Exercise, delegated up from the tray's ExerciseSelectionScreen — owned
+    /// here because a nested sheet only survives the tray's dismiss/re-present cycle
+    /// when its owning state lives outside the recycled tray content
+    /// (see TemplateEditorScreen).
+    @State private var createExerciseRequest: ExerciseSelectionScreen.AddExerciseRequest?
 
     // MARK: - Parameters
 
@@ -133,71 +141,88 @@ struct WorkoutEditorScreen: View {
                     .padding(.top)
                 }
                 .sheet(isPresented: .constant(true)) {
-                    NavigationView {
-                        VStack(spacing: 0) {
-                            ExerciseSelectionScreen(
-                                selectedExercise: nil,
-                                setExercise: { exercise in
+                    // Structured like the recorder's tray (sheet chain directly off the
+                    // NavigationStack root) — see TemplateEditorScreen for why: the old
+                    // NavigationView + wrapper made nested sheets fight the tray.
+                    NavigationStack {
+                        ExerciseSelectionScreen(
+                            selectedExercise: nil,
+                            setExercise: { exercise in
+                                database.newWorkoutSetGroup(
+                                    createFirstSetAutomatically: true,
+                                    exercise: exercise,
+                                    workout: workout
+                                )
+                            },
+                            forSecondary: false,
+                            currentWorkoutExercises: workout.exercises,
+                            supersetPrimaryExercise: nil,
+                            presentationDetentSelection: $exerciseSelectionPresentationDetent,
+                            onRequestAddExercise: { createExerciseRequest = $0 },
+                            onRequestExerciseDetail: { exerciseForDetailSheet = $0 }
+                        )
+                        .toolbar(.hidden, for: .navigationBar)
+                        .sheet(item: $selectedRestDurationSet) { workoutSet in
+                            RestDurationEditorSheet(workoutSet: workoutSet)
+                                .presentationDetents([.fraction(0.65)])
+                                .padding()
+                                .frame(maxHeight: .infinity, alignment: .top)
+                        }
+                        .sheet(item: $exerciseForDetailSheet) { exercise in
+                            NavigationStack {
+                                ExerciseDetailScreen(exercise: exercise, isShowingAsSheet: true, scrollToRecentAttempts: true)
+                            }
+                            .presentationDragIndicator(.visible)
+                        }
+                        .sheet(item: $createExerciseRequest) { request in
+                            ExerciseEditScreen(
+                                onEditFinished: { exercise in
                                     database.newWorkoutSetGroup(
                                         createFirstSetAutomatically: true,
                                         exercise: exercise,
                                         workout: workout
                                     )
+                                    exerciseSelectionPresentationDetent = .height(BOTTOM_SHEET_SMALL)
                                 },
-                                forSecondary: false,
-                                currentWorkoutExercises: workout.exercises,
-                                supersetPrimaryExercise: nil,
-                                presentationDetentSelection: $exerciseSelectionPresentationDetent
+                                initialExerciseName: request.name,
+                                initialMuscleGroup: request.muscleGroup ?? .chest
                             )
-                            .toolbar(.hidden, for: .navigationBar)
-                            .sheet(item: $selectedRestDurationSet) { workoutSet in
-                                RestDurationEditorSheet(workoutSet: workoutSet)
-                                    .presentationDetents([.fraction(0.65)])
-                                    .padding()
-                                    .frame(maxHeight: .infinity, alignment: .top)
-                            }
-                            .sheet(item: $exerciseForDetailSheet) { exercise in
-                                NavigationStack {
-                                    ExerciseDetailScreen(exercise: exercise, isShowingAsSheet: true, scrollToRecentAttempts: true)
-                                }
-                                .presentationDragIndicator(.visible)
-                            }
-                            .sheet(isPresented: $isShowingReorderSheet) {
-                                NavigationStack {
-                                    List {
-                                        ForEach(workout.setGroups) { setGroup in
-                                            HStack {
-                                                VStack(alignment: .leading) {
-                                                    Text(setGroup.exercise?.displayName ?? "")
-                                                    if (setGroup.sets.first as? SuperSet) != nil,
-                                                       let secondaryExercise = setGroup.secondaryExercise {
-                                                        HStack {
-                                                            Image(systemName: "arrow.turn.down.right")
-                                                            Text(secondaryExercise.displayName)
-                                                        }
+                        }
+                        .sheet(isPresented: $isShowingReorderSheet) {
+                            NavigationStack {
+                                List {
+                                    ForEach(workout.setGroups) { setGroup in
+                                        HStack {
+                                            VStack(alignment: .leading) {
+                                                Text(setGroup.exercise?.displayName ?? "")
+                                                if (setGroup.sets.first as? SuperSet) != nil,
+                                                   let secondaryExercise = setGroup.secondaryExercise {
+                                                    HStack {
+                                                        Image(systemName: "arrow.turn.down.right")
+                                                        Text(secondaryExercise.displayName)
                                                     }
                                                 }
                                             }
                                         }
-                                        .onDelete {
-                                            workout.setGroups.remove(atOffsets: $0)
-                                            workout.setGroups.forEach { $0.objectWillChange.send() }
-                                        }
-                                        .onMove { source, destination in
-                                            workout.setGroups.move(fromOffsets: source, toOffset: destination)
-                                            workout.setGroups.forEach { $0.objectWillChange.send() }
-                                        }
                                     }
-                                    .environment(\.editMode, .constant(.active))
-                                    .navigationTitle(NSLocalizedString("reorderExercises", comment: ""))
-                                    .navigationBarTitleDisplayMode(.inline)
-                                    .toolbar {
-                                        ToolbarItem(placement: .topBarTrailing) {
-                                            Button {
-                                                isShowingReorderSheet = false
-                                            } label: {
-                                                Text(NSLocalizedString("done", comment: ""))
-                                            }
+                                    .onDelete {
+                                        workout.setGroups.remove(atOffsets: $0)
+                                        workout.setGroups.forEach { $0.objectWillChange.send() }
+                                    }
+                                    .onMove { source, destination in
+                                        workout.setGroups.move(fromOffsets: source, toOffset: destination)
+                                        workout.setGroups.forEach { $0.objectWillChange.send() }
+                                    }
+                                }
+                                .environment(\.editMode, .constant(.active))
+                                .navigationTitle(NSLocalizedString("reorderExercises", comment: ""))
+                                .navigationBarTitleDisplayMode(.inline)
+                                .toolbar {
+                                    ToolbarItem(placement: .topBarTrailing) {
+                                        Button {
+                                            isShowingReorderSheet = false
+                                        } label: {
+                                            Text(NSLocalizedString("done", comment: ""))
                                         }
                                     }
                                 }
@@ -205,13 +230,35 @@ struct WorkoutEditorScreen: View {
                         }
                     }
                     .presentationDetents([.height(BOTTOM_SHEET_SMALL), .medium, .large], selection: $exerciseSelectionPresentationDetent)
-                    .presentationBackgroundInteraction(.enabled)
+                    // Pass-through only while nothing is stacked on the tray: a
+                    // background-interactive sheet can't stably host a nested sheet — UIKit
+                    // dismisses the tray, SwiftUI re-presents it, and the nested sheet
+                    // flashes away in the fight (see TemplateEditorScreen).
+                    .presentationBackgroundInteraction(
+                        trayAllowsBackgroundInteraction ? .enabled : .disabled
+                    )
                     .interactiveDismissDisabled()
                     .sheet(isPresented: $isEditingStartEndDate) {
                         WorkoutStartEndDateEditorSheet(
                             workout: workout,
                             isPresented: $isEditingStartEndDate
                         )
+                    }
+                }
+                // Asymmetric switch for the tray's pass-through: off the moment a nested
+                // sheet presents, back on only after the nested sheet's dismissal transition
+                // has settled — reconfiguring the tray's presentation mid-dismissal makes
+                // UIKit cancel that dismissal and the nested sheet springs back
+                // (see TemplateEditorScreen).
+                .onChange(of: hasNestedTraySheet) { _, hasNested in
+                    if hasNested {
+                        trayAllowsBackgroundInteraction = false
+                    } else {
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
+                            if !hasNestedTraySheet {
+                                trayAllowsBackgroundInteraction = true
+                            }
+                        }
                     }
                 }
             }
@@ -334,6 +381,16 @@ struct WorkoutEditorScreen: View {
     }
 
     // MARK: - Computed Properties
+
+    /// True while any sheet is stacked on the persistent exercise tray — rest editor,
+    /// exercise detail, reorder, date editor, or the tray-delegated create exercise.
+    private var hasNestedTraySheet: Bool {
+        selectedRestDurationSet != nil
+            || exerciseForDetailSheet != nil
+            || isShowingReorderSheet
+            || isEditingStartEndDate
+            || createExerciseRequest != nil
+    }
 
     private var workoutName: Binding<String> {
         Binding(get: { workout.name ?? "" }, set: { workout.name = $0 })

--- a/LOGITUITests/ScenarioScreenshots.swift
+++ b/LOGITUITests/ScenarioScreenshots.swift
@@ -652,6 +652,140 @@ final class ScenarioScreenshots: XCTestCase {
         attach(app, "recorder_17_opened_from_pill")
     }
 
+    // MARK: - Template editor tray: nested Create Exercise sheet
+
+    /// A sheet presented from INSIDE the editors' background-interactive exercise tray
+    /// must survive: while the tray passes touches through, UIKit and SwiftUI fight over
+    /// a stacked sheet (the tray is dismissed and re-presented, tearing the nested sheet
+    /// down within seconds). The rest/reorder sheets are guarded in the editors
+    /// themselves; this covers ExerciseSelectionScreen's own Create Exercise sheet,
+    /// whose state the editors can't see directly.
+    func testTemplateEditorCreateExerciseSheetStaysUp() {
+        let app = launchApp(scenario: "many")
+
+        let tabBar = app.tabBars.firstMatch
+        XCTAssertTrue(tabBar.waitForExistence(timeout: 30), "Tab bar never appeared")
+        tapTab(app, at: 2)
+        waitABit(1)
+
+        // "+" toolbar menu → New Template → the editor opens with its persistent tray.
+        let plusButton = app.navigationBars.buttons["Add"].firstMatch
+        XCTAssertTrue(plusButton.waitForExistence(timeout: 5), "Templates + button missing")
+        plusButton.tap()
+        let newTemplateItem = app.buttons["New Template"].firstMatch
+        XCTAssertTrue(newTemplateItem.waitForExistence(timeout: 5), "New Template menu item missing")
+        newTemplateItem.tap()
+
+        let traySearchField = app.textFields.matching(
+            NSPredicate(format: "placeholderValue == 'Search in Exercises'")
+        ).firstMatch
+        XCTAssertTrue(traySearchField.waitForExistence(timeout: 10), "Template editor tray missing")
+        waitABit(2)
+
+        // The + next to the search field — ExerciseSelectionScreen's own Create
+        // Exercise sheet. (No typing: focusing the tray search field is flaky with a
+        // connected hardware keyboard, and the + presents the same sheet either way.)
+        let addExercise = app.buttons["Add"].firstMatch
+        XCTAssertTrue(addExercise.waitForExistence(timeout: 5), "Tray + (create exercise) button missing")
+        addExercise.tap()
+
+        let newExerciseTitle = app.staticTexts["New Exercise"].firstMatch
+        XCTAssertTrue(newExerciseTitle.waitForExistence(timeout: 5), "Create Exercise sheet never presented")
+        attach(app, "tray_create_01_presented")
+
+        // The sheet must stay up — on the unguarded build the tray fight tears it
+        // down within a few seconds.
+        var vanishedAfter: Int?
+        for second in 1 ... 6 {
+            waitABit(1)
+            if !newExerciseTitle.exists {
+                vanishedAfter = second
+                break
+            }
+        }
+        attach(app, "tray_create_02_after_wait")
+        XCTAssertNil(
+            vanishedAfter,
+            "Create Exercise sheet vanished after ~\(vanishedAfter ?? 0)s — tray dismiss/re-present fight"
+        )
+        guard vanishedAfter == nil else { return }
+
+        // Cancel must dismiss it cleanly, the tray must come back, and the sheet must
+        // be reopenable (an abnormal teardown leaves the sheet binding stuck non-nil,
+        // blocking every later attempt). Scope the query to the create sheet's own
+        // navigation bar — a bare buttons["Cancel"].firstMatch can resolve to the
+        // editor's (occluded) Cancel and the tap then lands on the scrim.
+        let sheetCancel = app.navigationBars["New Exercise"].buttons["Cancel"].firstMatch
+        XCTAssertTrue(sheetCancel.waitForExistence(timeout: 3), "Create sheet's Cancel button not found")
+        sheetCancel.tap()
+        waitABit(2)
+        XCTAssertFalse(newExerciseTitle.exists, "Create Exercise sheet stuck after Cancel")
+        XCTAssertTrue(traySearchField.waitForExistence(timeout: 5), "Tray gone after closing the create sheet")
+        addExercise.tap()
+        XCTAssertTrue(
+            newExerciseTitle.waitForExistence(timeout: 5),
+            "Create Exercise sheet could not be reopened — stuck sheet binding"
+        )
+        attach(app, "tray_create_03_reopened")
+    }
+
+    /// Same guarantee for the workout editor's tray (History → + → editor): its
+    /// Create Exercise sheet is host-owned for the same reason as the template
+    /// editor's — see `testTemplateEditorCreateExerciseSheetStaysUp`.
+    func testWorkoutEditorCreateExerciseSheetStaysUp() {
+        let app = launchApp(scenario: "many")
+
+        let tabBar = app.tabBars.firstMatch
+        XCTAssertTrue(tabBar.waitForExistence(timeout: 30), "Tab bar never appeared")
+        tapTab(app, at: 1)
+        waitABit(1)
+
+        let plusButton = app.navigationBars.buttons["Add"].firstMatch
+        XCTAssertTrue(plusButton.waitForExistence(timeout: 5), "History + button missing")
+        plusButton.tap()
+
+        let traySearchField = app.textFields.matching(
+            NSPredicate(format: "placeholderValue == 'Search in Exercises'")
+        ).firstMatch
+        XCTAssertTrue(traySearchField.waitForExistence(timeout: 10), "Workout editor tray missing")
+        waitABit(2)
+
+        let addExercise = app.buttons["Add"].firstMatch
+        XCTAssertTrue(addExercise.waitForExistence(timeout: 5), "Tray + (create exercise) button missing")
+        addExercise.tap()
+
+        let newExerciseTitle = app.staticTexts["New Exercise"].firstMatch
+        XCTAssertTrue(newExerciseTitle.waitForExistence(timeout: 5), "Create Exercise sheet never presented")
+
+        var vanishedAfter: Int?
+        for second in 1 ... 6 {
+            waitABit(1)
+            if !newExerciseTitle.exists {
+                vanishedAfter = second
+                break
+            }
+        }
+        attach(app, "workout_tray_create_after_wait")
+        XCTAssertNil(
+            vanishedAfter,
+            "Create Exercise sheet vanished after ~\(vanishedAfter ?? 0)s — tray dismiss/re-present fight"
+        )
+        guard vanishedAfter == nil else { return }
+
+        let sheetCancel = app.navigationBars["New Exercise"].buttons["Cancel"].firstMatch
+        XCTAssertTrue(sheetCancel.waitForExistence(timeout: 3), "Create sheet's Cancel button not found")
+        sheetCancel.tap()
+        waitABit(2)
+        XCTAssertFalse(newExerciseTitle.exists, "Create Exercise sheet stuck after Cancel")
+        XCTAssertTrue(traySearchField.waitForExistence(timeout: 5), "Tray gone after closing the create sheet")
+        addExercise.tap()
+        XCTAssertTrue(
+            newExerciseTitle.waitForExistence(timeout: 5),
+            "Create Exercise sheet could not be reopened — stuck sheet binding"
+        )
+        attach(app, "workout_tray_create_reopened")
+    }
+
     // MARK: - Walkthrough
 
     private func captureMainScreens(


### PR DESCRIPTION
Follow-up to #97, which fixed the tray-stacked rest editor flashing away by conditionally disabling the persistent exercise tray's touch pass-through. This closes the remaining gap: sheets presented from **inside** `ExerciseSelectionScreen` (Create Exercise, and the context menus' Show Details) still died, because their owning `@State` lives inside the tray content.

## Refined root cause
Stacking any sheet onto the tray makes UIKit dismiss and re-present (recycle) the tray view controller — even when pass-through is already disabled. A nested sheet survives that recycle only if its owning state lives **outside** the tray content, in the host editor. The rest/reorder sheets already did (that's why #97's guard sufficed for them); the exercise-selection screen's internal sheets did not — disabling pass-through, even synchronously in the same transaction as the presentation, does not save them.

## Fix
`ExerciseSelectionScreen` gains optional `onRequestAddExercise(AddExerciseRequest)` / `onRequestExerciseDetail(Exercise)` callbacks. Tray hosts (`TemplateEditorScreen`, `WorkoutEditorScreen`) set them: the host owns the presentation state, shows the Create Exercise / exercise-detail sheets next to its rest and reorder sheets, and folds them into the tray's pass-through guard (`hasNestedTraySheet`). Non-tray hosts (set-group cells, the recorder) leave the callbacks nil and keep the internal presentation unchanged. The `AddExerciseRequest` carries the prefilled name (current search text) and muscle-group filter, so delegated creation behaves exactly like the internal path.

## Verification
- New regression UI tests `testTemplateEditorCreateExerciseSheetStaysUp` and `testWorkoutEditorCreateExerciseSheetStaysUp` (present → survive 6 s → Cancel → reopen), verified on the iOS 26.4 simulator.
- Re-ran after merging current main (#97): full unit suite plus all four tray/focus regression tests pass on the merged tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
