### PR TITLE
Calorie estimates: density-based active energy on workouts + Apple Health export

### DIFF
--- a/LOGIT.xcodeproj/project.pbxproj
+++ b/LOGIT.xcodeproj/project.pbxproj
@@ -86,8 +86,6 @@
 		801BBD892DF7338A00CDB1FB /* Exercise+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBCD12DF7338A00CDB1FB /* Exercise+.swift */; };
 		801BBD8C2DF7338A00CDB1FB /* ExerciseVolumeTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBCEB2DF7338A00CDB1FB /* ExerciseVolumeTile.swift */; };
 		801BBD8D2DF7338A00CDB1FB /* WeightUnit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBCA32DF7338A00CDB1FB /* WeightUnit.swift */; };
-		80DI00022F84DD0100DI0002 /* DistanceUnit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80DI00012F84DD0100DI0001 /* DistanceUnit.swift */; };
-		80DI00042F84DD0100DI0004 /* DistanceConverting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80DI00032F84DD0100DI0003 /* DistanceConverting.swift */; };
 		801BBD902DF7338A00CDB1FB /* CanEditModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBD3B2DF7338A00CDB1FB /* CanEditModifier.swift */; };
 		801BBD912DF7338A00CDB1FB /* GenerationScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBD2D2DF7338A00CDB1FB /* GenerationScreen.swift */; };
 		801BBD922DF7338A00CDB1FB /* SettingsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBD302DF7338A00CDB1FB /* SettingsScreen.swift */; };
@@ -163,8 +161,6 @@
 		801BBDE42DF7338A00CDB1FB /* NoDataPlaceholderModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBD3E2DF7338A00CDB1FB /* NoDataPlaceholderModifier.swift */; };
 		801BBDE52DF7338A00CDB1FB /* WeightConverting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBCBF2DF7338A00CDB1FB /* WeightConverting.swift */; };
 		801BBDE62DF7338A00CDB1FB /* ExerciseRepetitionsTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBCEA2DF7338A00CDB1FB /* ExerciseRepetitionsTile.swift */; };
-		80DI00062F84DD0100DI0006 /* ExerciseDistanceTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80DI00052F84DD0100DI0005 /* ExerciseDistanceTile.swift */; };
-		80DI00082F84DD0100DI0008 /* ExerciseDistanceScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80DI00072F84DD0100DI0007 /* ExerciseDistanceScreen.swift */; };
 		801BBDE72DF7338A00CDB1FB /* UIConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBCAB2DF7338A00CDB1FB /* UIConstants.swift */; };
 		801BBDE82DF7338A00CDB1FB /* ExerciseHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBD4F2DF7338A00CDB1FB /* ExerciseHeader.swift */; };
 		801BBDE92DF7338A00CDB1FB /* UIScreen+ScreenCorners.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBCB42DF7338A00CDB1FB /* UIScreen+ScreenCorners.swift */; };
@@ -216,6 +212,10 @@
 		80CBE1D52ED7AFD500DDE1C5 /* MeasurementsEditSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80CBE1D32ED7AFD500DDE1C5 /* MeasurementsEditSheet.swift */; };
 		80CBE1D62ED7AFD500DDE1C5 /* MeasurementDetailScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80CBE1D22ED7AFD500DDE1C5 /* MeasurementDetailScreen.swift */; };
 		80CBE1D72ED7AFD500DDE1C5 /* MeasurementTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80CBE1D42ED7AFD500DDE1C5 /* MeasurementTile.swift */; };
+		80DI00022F84DD0100DI0002 /* DistanceUnit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80DI00012F84DD0100DI0001 /* DistanceUnit.swift */; };
+		80DI00042F84DD0100DI0004 /* DistanceConverting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80DI00032F84DD0100DI0003 /* DistanceConverting.swift */; };
+		80DI00062F84DD0100DI0006 /* ExerciseDistanceTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80DI00052F84DD0100DI0005 /* ExerciseDistanceTile.swift */; };
+		80DI00082F84DD0100DI0008 /* ExerciseDistanceScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80DI00072F84DD0100DI0007 /* ExerciseDistanceScreen.swift */; };
 		80DU00022F70CC0100DU0002 /* ExerciseDurationTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80DU00012F70CC0100DU0001 /* ExerciseDurationTile.swift */; };
 		80DU00042F70CC0100DU0004 /* ExerciseDurationScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80DU00032F70CC0100DU0003 /* ExerciseDurationScreen.swift */; };
 		80NEWSHAR001 /* WorkoutActivityItemSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80NEWSHAR002 /* WorkoutActivityItemSource.swift */; };
@@ -234,12 +234,14 @@
 		80SE00112F70CC0100SE0011 /* SetEntryFieldsRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80SE00122F70CC0100SE0012 /* SetEntryFieldsRow.swift */; };
 		85709CDA5A20D6B7D9C23487 /* ExerciseMergeServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF956F5D14BBB78133BD528A /* ExerciseMergeServiceTests.swift */; };
 		85D5027D8B1FA8DB36998EBC /* SummaryStatScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE557E27ADC9A2C02BE79DBE /* SummaryStatScreen.swift */; };
+		8628A1F9D2552C1D90998743 /* WorkoutCalorieRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 073E8CD784A7ED9A595CA5E2 /* WorkoutCalorieRow.swift */; };
 		898FDFC3AC4FF171A0E6C549 /* WorkoutLiveActivityAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 829F12D41C231764936B6B83 /* WorkoutLiveActivityAttributes.swift */; };
 		8C2580F9D7A5C52A72312A9A /* StatPeriod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8571CBB4B50589F1F8F36F44 /* StatPeriod.swift */; };
 		8C6BE79BA086E3876A56C1D7 /* SharedWithYouBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3184F4CAAB24791B6F5AC79A /* SharedWithYouBanner.swift */; };
 		8E306606440725A568FE5F1A /* ExerciseMergeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF0CFD6EDA94DA1792A2CA82 /* ExerciseMergeService.swift */; };
 		8F4A3C022E5A9B0100D4E5F2 /* SetVolumeBarChart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F4A3C012E5A9B0100D4E5F1 /* SetVolumeBarChart.swift */; };
 		9392C43C9501E6676A02488A /* WorkoutLiveActivitySnapshotBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B6F634C95B552C305EA0055 /* WorkoutLiveActivitySnapshotBuilder.swift */; };
+		94B930251BE222630CF21349 /* CalorieEstimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6430636F05E66F518AE5872 /* CalorieEstimator.swift */; };
 		9870C5C11EC204B609726272 /* SwipeableMonthView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79EEE8722792E15D71C22DA3 /* SwipeableMonthView.swift */; };
 		99A5C6A814E6BD98F45BDFF1 /* CapabilityChartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BEA94B4E4E01D1D9185359 /* CapabilityChartView.swift */; };
 		9C03B11C8A034786C5544D2E /* ScreenshotFixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = C05F3FE01CADB8E0526C799F /* ScreenshotFixtures.swift */; };
@@ -354,6 +356,7 @@
 		0258213863A5C9812190A44D /* MuscleBalanceCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MuscleBalanceCalculator.swift; sourceTree = "<group>"; };
 		0400C2E827A4AEAF03BACDC6 /* SnapshotHelper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SnapshotHelper.swift; sourceTree = "<group>"; };
 		06A7CD832F8CF2FDAB33579C /* WorkoutLiveActivityManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkoutLiveActivityManager.swift; sourceTree = "<group>"; };
+		073E8CD784A7ED9A595CA5E2 /* WorkoutCalorieRow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkoutCalorieRow.swift; sourceTree = "<group>"; };
 		0D5D5995AEAE4AA8849AAF28 /* TrendIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrendIndicatorView.swift; sourceTree = "<group>"; };
 		0E384D0F4B54340F910F6813 /* ExerciseMergingSheet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ExerciseMergingSheet.swift; sourceTree = "<group>"; };
 		144AED8F76DE3EBB1A1752AD /* LOGITUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LOGITUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -403,8 +406,6 @@
 		801BBCA12DF7338A00CDB1FB /* MeasurementEntryType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeasurementEntryType.swift; sourceTree = "<group>"; };
 		801BBCA22DF7338A00CDB1FB /* MuscleGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MuscleGroup.swift; sourceTree = "<group>"; };
 		801BBCA32DF7338A00CDB1FB /* WeightUnit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeightUnit.swift; sourceTree = "<group>"; };
-		80DI00012F84DD0100DI0001 /* DistanceUnit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DistanceUnit.swift; sourceTree = "<group>"; };
-		80DI00032F84DD0100DI0003 /* DistanceConverting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DistanceConverting.swift; sourceTree = "<group>"; };
 		801BBCA72DF7338A00CDB1FB /* EnvironmentValues+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EnvironmentValues+.swift"; sourceTree = "<group>"; };
 		801BBCA82DF7338A00CDB1FB /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
 		801BBCA92DF7338A00CDB1FB /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -459,8 +460,6 @@
 		801BBCE52DF7338A00CDB1FB /* WorkoutSetGroupPredicateFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutSetGroupPredicateFactory.swift; sourceTree = "<group>"; };
 		801BBCE62DF7338A00CDB1FB /* WorkoutSetPredicateFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutSetPredicateFactory.swift; sourceTree = "<group>"; };
 		801BBCEA2DF7338A00CDB1FB /* ExerciseRepetitionsTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseRepetitionsTile.swift; sourceTree = "<group>"; };
-		80DI00052F84DD0100DI0005 /* ExerciseDistanceTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseDistanceTile.swift; sourceTree = "<group>"; };
-		80DI00072F84DD0100DI0007 /* ExerciseDistanceScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseDistanceScreen.swift; sourceTree = "<group>"; };
 		801BBCEB2DF7338A00CDB1FB /* ExerciseVolumeTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseVolumeTile.swift; sourceTree = "<group>"; };
 		801BBCEC2DF7338A00CDB1FB /* ExerciseWeightTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseWeightTile.swift; sourceTree = "<group>"; };
 		801BBCEE2DF7338A00CDB1FB /* ExerciseDetailScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseDetailScreen.swift; sourceTree = "<group>"; };
@@ -557,8 +556,8 @@
 		80AA00072F3A000100AA0001 /* RestDurationEditorSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestDurationEditorSheet.swift; sourceTree = "<group>"; };
 		80AA00072F5CAA0100AA0007 /* LOGIT 7.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "LOGIT 7.0.xcdatamodel"; sourceTree = "<group>"; };
 		80AA00082F70CC0100AA0008 /* LOGIT 8.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "LOGIT 8.0.xcdatamodel"; sourceTree = "<group>"; };
-		80AA00092F84DD0100AA0009 /* LOGIT 9.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "LOGIT 9.0.xcdatamodel"; sourceTree = "<group>"; };
 		80AA00092F3A000100AA0001 /* WorkoutRecorderFloatingTimerButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutRecorderFloatingTimerButton.swift; sourceTree = "<group>"; };
+		80AA00092F84DD0100AA0009 /* LOGIT 9.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "LOGIT 9.0.xcdatamodel"; sourceTree = "<group>"; };
 		80AA000B2F3A000100AA0001 /* WorkoutRecorderFloatingStopwatchStopButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutRecorderFloatingStopwatchStopButton.swift; sourceTree = "<group>"; };
 		80AA10022F5CAA0200AA1002 /* DeterministicUUID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeterministicUUID.swift; sourceTree = "<group>"; };
 		80AA10042F5CAA0200AA1004 /* DefaultTemplateService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultTemplateService.swift; sourceTree = "<group>"; };
@@ -570,6 +569,10 @@
 		80CBE1D22ED7AFD500DDE1C5 /* MeasurementDetailScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeasurementDetailScreen.swift; sourceTree = "<group>"; };
 		80CBE1D32ED7AFD500DDE1C5 /* MeasurementsEditSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeasurementsEditSheet.swift; sourceTree = "<group>"; };
 		80CBE1D42ED7AFD500DDE1C5 /* MeasurementTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeasurementTile.swift; sourceTree = "<group>"; };
+		80DI00012F84DD0100DI0001 /* DistanceUnit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DistanceUnit.swift; sourceTree = "<group>"; };
+		80DI00032F84DD0100DI0003 /* DistanceConverting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DistanceConverting.swift; sourceTree = "<group>"; };
+		80DI00052F84DD0100DI0005 /* ExerciseDistanceTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseDistanceTile.swift; sourceTree = "<group>"; };
+		80DI00072F84DD0100DI0007 /* ExerciseDistanceScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseDistanceScreen.swift; sourceTree = "<group>"; };
 		80DU00012F70CC0100DU0001 /* ExerciseDurationTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseDurationTile.swift; sourceTree = "<group>"; };
 		80DU00032F70CC0100DU0003 /* ExerciseDurationScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseDurationScreen.swift; sourceTree = "<group>"; };
 		80NEWSHAR002 /* WorkoutActivityItemSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutActivityItemSource.swift; sourceTree = "<group>"; };
@@ -631,6 +634,7 @@
 		C82BC4F48812B4D49D4E38E2 /* ChartRange.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ChartRange.swift; sourceTree = "<group>"; };
 		CF1126F67238BF3E85FCC8C8 /* WeeklyGoalHeroTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyGoalHeroTile.swift; sourceTree = "<group>"; };
 		D1D1D1000000000000000F01 /* MetricTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetricTile.swift; sourceTree = "<group>"; };
+		D6430636F05E66F518AE5872 /* CalorieEstimator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CalorieEstimator.swift; sourceTree = "<group>"; };
 		DC42311A655A248061E11238 /* SummaryEmptyStates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryEmptyStates.swift; sourceTree = "<group>"; };
 		DD50531C168D4EDFB527D76A /* SetEntityClasses.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetEntityClasses.swift; sourceTree = "<group>"; };
 		DD6EBE9FCA104B46ACA995DE /* ScenarioScreenshots.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ScenarioScreenshots.swift; sourceTree = "<group>"; };
@@ -895,6 +899,7 @@
 				801BBCBF2DF7338A00CDB1FB /* WeightConverting.swift */,
 				80DI00032F84DD0100DI0003 /* DistanceConverting.swift */,
 				8E740E99321E2590B08B80A0 /* HealthKitSyncManager.swift */,
+				D6430636F05E66F518AE5872 /* CalorieEstimator.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -1169,6 +1174,7 @@
 				801BBD2A2DF7338A00CDB1FB /* WorkoutSetGroupList.swift */,
 				8068AEBB2F1500380007FA8F /* WorkoutStartSheet.swift */,
 				6B0C5444A74B071859C40CB3 /* LiveActivity */,
+				073E8CD784A7ED9A595CA5E2 /* WorkoutCalorieRow.swift */,
 			);
 			path = Workout;
 			sourceTree = "<group>";
@@ -1858,6 +1864,8 @@
 				A10F7CBC23FBD8F36CC4A1D6 /* TestScenarios.swift in Sources */,
 				99A5C6A814E6BD98F45BDFF1 /* CapabilityChartView.swift in Sources */,
 				09A688DA944843286D5190DB /* HealthKitSyncManager.swift in Sources */,
+				94B930251BE222630CF21349 /* CalorieEstimator.swift in Sources */,
+				8628A1F9D2552C1D90998743 /* WorkoutCalorieRow.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/LOGIT/App/LOGITApp.swift
+++ b/LOGIT/App/LOGITApp.swift
@@ -122,6 +122,7 @@ struct LOGIT: App {
             "distanceUnit": DistanceUnit.defaultFromLocale.rawValue,
             "workoutPerWeekTarget": -1,
             "setupDone": false,
+            CalorieEstimator.enabledKey: true,
         ])
         // Fixes issue with wrong Accent Color in Alerts
         UIView.appearance().tintColor = UIColor(named: "AccentColor")

--- a/LOGIT/Core/Environment/de.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/de.lproj/Localizable.strings
@@ -1086,3 +1086,20 @@
 "syncToAppleHealth" = "Mit Apple Health synchronisieren";
 "workoutsExportedToHealth" = "%d Workouts exportiert.";
 "workoutsSkippedNoDuration" = "%d übersprungen (keine Dauer).";
+
+// MARK: - Calorie Estimates
+
+"calorieEstimateExplanation" = "LOGIT schätzt Aktivkalorien aus Trainingsdichte und Körpergewicht — immer auf dieselbe Weise, damit Vergleiche zwischen deinen Workouts aussagekräftig bleiben. Der individuelle Verbrauch variiert; betrachte den absoluten Wert als Näherung.";
+"calorieEstimateHealthNote" = "Wird als Aktivkalorien mit Apple Health synchronisiert. Du kannst die Schätzung in den Einstellungen deaktivieren.";
+"calorieEstimates" = "Kalorienschätzung";
+"calorieEstimatesDescription" = "Schätzt Aktivkalorien aus deinen geloggten Sätzen und deinem Körpergewicht. Erscheint bei Workouts und in der Apple-Health-Synchronisierung.";
+"estCalories" = "Gesch. Kalorien";
+"estimatedCalories" = "Geschätzte Kalorien";
+"fromYourLoggedSets" = "Aus deinen geloggten Sätzen";
+"loggedDateFormat" = "Geloggt am %@";
+"logBodyWeightToEstimate" = "Körpergewicht loggen für Kalorien";
+"publishedStrengthRange" = "Publizierter Bereich für Krafttraining";
+"restShareLabel" = "Pause & Aufbau";
+"sessionIntensity" = "Trainingsintensität";
+"workingShareLabel" = "Arbeit";
+"workingTime" = "Arbeitszeit";

--- a/LOGIT/Core/Environment/en.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/en.lproj/Localizable.strings
@@ -1090,3 +1090,20 @@
 "syncToAppleHealth" = "Sync to Apple Health";
 "workoutsExportedToHealth" = "%d workouts exported.";
 "workoutsSkippedNoDuration" = "%d skipped (no duration).";
+
+// MARK: - Calorie Estimates
+
+"calorieEstimateExplanation" = "LOGIT estimates active calories from your training density and body weight — the same way every time, so comparing your workouts stays meaningful. Individual burn varies; treat the absolute number as approximate.";
+"calorieEstimateHealthNote" = "Included in Apple Health sync as active calories. You can turn estimates off in Settings.";
+"calorieEstimates" = "Calorie Estimates";
+"calorieEstimatesDescription" = "Estimates active calories from your logged sets and body weight. Shown on workout details and included in Apple Health sync.";
+"estCalories" = "Est. Calories";
+"estimatedCalories" = "Estimated Calories";
+"fromYourLoggedSets" = "From your logged sets";
+"loggedDateFormat" = "Logged %@";
+"logBodyWeightToEstimate" = "Log body weight to estimate calories";
+"publishedStrengthRange" = "Published range for strength training";
+"restShareLabel" = "rest & setup";
+"sessionIntensity" = "Session Intensity";
+"workingShareLabel" = "working";
+"workingTime" = "Working Time";

--- a/LOGIT/Core/Environment/es.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/es.lproj/Localizable.strings
@@ -1090,3 +1090,20 @@
 "syncToAppleHealth" = "Sincronizar con Apple Salud";
 "workoutsExportedToHealth" = "%d entrenamientos exportados.";
 "workoutsSkippedNoDuration" = "%d omitidos (sin duración).";
+
+// MARK: - Calorie Estimates
+
+"calorieEstimateExplanation" = "LOGIT estima las calorías activas a partir de la densidad del entrenamiento y tu peso corporal — siempre de la misma manera, para que comparar tus entrenamientos siga siendo útil. El gasto individual varía; toma el número absoluto como aproximado.";
+"calorieEstimateHealthNote" = "Se sincroniza con Apple Salud como calorías activas. Puedes desactivar la estimación en Ajustes.";
+"calorieEstimates" = "Estimación de calorías";
+"calorieEstimatesDescription" = "Estima calorías activas a partir de tus series y tu peso corporal. Se muestra en los entrenamientos y se incluye en la sincronización con Apple Salud.";
+"estCalories" = "Calorías est.";
+"estimatedCalories" = "Calorías estimadas";
+"fromYourLoggedSets" = "De tus series registradas";
+"loggedDateFormat" = "Registrado el %@";
+"logBodyWeightToEstimate" = "Registra tu peso para estimar calorías";
+"publishedStrengthRange" = "Rango publicado para entrenamiento de fuerza";
+"restShareLabel" = "descanso y preparación";
+"sessionIntensity" = "Intensidad de la sesión";
+"workingShareLabel" = "trabajo";
+"workingTime" = "Tiempo de trabajo";

--- a/LOGIT/Core/Environment/fr.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/fr.lproj/Localizable.strings
@@ -1090,3 +1090,20 @@
 "syncToAppleHealth" = "Synchroniser avec Apple Santé";
 "workoutsExportedToHealth" = "%d entraînements exportés.";
 "workoutsSkippedNoDuration" = "%d ignorés (aucune durée).";
+
+// MARK: - Calorie Estimates
+
+"calorieEstimateExplanation" = "LOGIT estime les calories actives à partir de la densité d'entraînement et du poids de corps — toujours de la même façon, pour que les comparaisons entre tes séances restent pertinentes. La dépense individuelle varie ; considère la valeur absolue comme approximative.";
+"calorieEstimateHealthNote" = "Synchronisé avec Apple Santé comme calories actives. Tu peux désactiver l'estimation dans les Réglages.";
+"calorieEstimates" = "Estimation des calories";
+"calorieEstimatesDescription" = "Estime les calories actives à partir de tes séries et de ton poids de corps. Affiché sur les entraînements et inclus dans la synchronisation Apple Santé.";
+"estCalories" = "Calories est.";
+"estimatedCalories" = "Calories estimées";
+"fromYourLoggedSets" = "D'après tes séries enregistrées";
+"loggedDateFormat" = "Enregistré le %@";
+"logBodyWeightToEstimate" = "Enregistre ton poids pour les calories";
+"publishedStrengthRange" = "Plage publiée pour la musculation";
+"restShareLabel" = "repos & préparation";
+"sessionIntensity" = "Intensité de la séance";
+"workingShareLabel" = "travail";
+"workingTime" = "Temps de travail";

--- a/LOGIT/Core/Environment/it.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/it.lproj/Localizable.strings
@@ -1090,3 +1090,20 @@
 "syncToAppleHealth" = "Sincronizza con Apple Salute";
 "workoutsExportedToHealth" = "%d allenamenti esportati.";
 "workoutsSkippedNoDuration" = "%d saltati (nessuna durata).";
+
+// MARK: - Calorie Estimates
+
+"calorieEstimateExplanation" = "LOGIT stima le calorie attive dalla densità dell'allenamento e dal peso corporeo — sempre allo stesso modo, così i confronti tra i tuoi allenamenti restano significativi. Il consumo individuale varia; considera il valore assoluto come approssimativo.";
+"calorieEstimateHealthNote" = "Sincronizzato con Apple Salute come calorie attive. Puoi disattivare la stima nelle Impostazioni.";
+"calorieEstimates" = "Stima delle calorie";
+"calorieEstimatesDescription" = "Stima le calorie attive dalle tue serie e dal tuo peso corporeo. Mostrata negli allenamenti e inclusa nella sincronizzazione con Apple Salute.";
+"estCalories" = "Calorie stim.";
+"estimatedCalories" = "Calorie stimate";
+"fromYourLoggedSets" = "Dalle tue serie registrate";
+"loggedDateFormat" = "Registrato il %@";
+"logBodyWeightToEstimate" = "Registra il peso per stimare le calorie";
+"publishedStrengthRange" = "Intervallo pubblicato per l'allenamento di forza";
+"restShareLabel" = "riposo e preparazione";
+"sessionIntensity" = "Intensità della sessione";
+"workingShareLabel" = "lavoro";
+"workingTime" = "Tempo di lavoro";

--- a/LOGIT/Core/Environment/ja.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/ja.lproj/Localizable.strings
@@ -1090,3 +1090,20 @@
 "syncToAppleHealth" = "ヘルスケアと同期";
 "workoutsExportedToHealth" = "%d件のワークアウトを書き出しました。";
 "workoutsSkippedNoDuration" = "%d件をスキップしました（時間なし）。";
+
+// MARK: - Calorie Estimates
+
+"calorieEstimateExplanation" = "LOGITはトレーニング密度と体重からアクティブカロリーを推定します。毎回同じ方法で計算するため、ワークアウト同士の比較に意味があります。消費量には個人差があるため、絶対値は目安としてください。";
+"calorieEstimateHealthNote" = "アクティブカロリーとしてヘルスケアに同期されます。推定は設定でオフにできます。";
+"calorieEstimates" = "カロリー推定";
+"calorieEstimatesDescription" = "記録したセットと体重からアクティブカロリーを推定します。ワークアウト詳細に表示され、ヘルスケア同期に含まれます。";
+"estCalories" = "推定カロリー";
+"estimatedCalories" = "推定カロリー";
+"fromYourLoggedSets" = "記録したセットから";
+"loggedDateFormat" = "%@に記録";
+"logBodyWeightToEstimate" = "体重を記録するとカロリーを推定できます";
+"publishedStrengthRange" = "筋力トレーニングの公表範囲";
+"restShareLabel" = "休憩・準備";
+"sessionIntensity" = "セッション強度";
+"workingShareLabel" = "運動";
+"workingTime" = "運動時間";

--- a/LOGIT/Core/Environment/ko.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/ko.lproj/Localizable.strings
@@ -1090,3 +1090,20 @@
 "syncToAppleHealth" = "Apple 건강과 동기화";
 "workoutsExportedToHealth" = "운동 %d개를 내보냈습니다.";
 "workoutsSkippedNoDuration" = "%d개 건너뜀(운동 시간 없음).";
+
+// MARK: - Calorie Estimates
+
+"calorieEstimateExplanation" = "LOGIT은 운동 밀도와 체중으로 활동 칼로리를 추정합니다. 항상 같은 방식으로 계산하므로 운동 간 비교가 의미 있게 유지됩니다. 소모량은 개인차가 있으니 절대값은 참고용으로 보세요.";
+"calorieEstimateHealthNote" = "활동 칼로리로 건강 앱에 동기화됩니다. 추정은 설정에서 끌 수 있습니다.";
+"calorieEstimates" = "칼로리 추정";
+"calorieEstimatesDescription" = "기록한 세트와 체중으로 활동 칼로리를 추정합니다. 운동 상세에 표시되고 건강 앱 동기화에 포함됩니다.";
+"estCalories" = "추정 칼로리";
+"estimatedCalories" = "추정 칼로리";
+"fromYourLoggedSets" = "기록한 세트 기준";
+"loggedDateFormat" = "%@ 기록";
+"logBodyWeightToEstimate" = "체중을 기록하면 칼로리를 추정할 수 있어요";
+"publishedStrengthRange" = "근력 운동의 공인 범위";
+"restShareLabel" = "휴식·준비";
+"sessionIntensity" = "세션 강도";
+"workingShareLabel" = "운동";
+"workingTime" = "운동 시간";

--- a/LOGIT/Core/Environment/pt-BR.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/pt-BR.lproj/Localizable.strings
@@ -1090,3 +1090,20 @@
 "syncToAppleHealth" = "Sincronizar com o Apple Saúde";
 "workoutsExportedToHealth" = "%d treinos exportados.";
 "workoutsSkippedNoDuration" = "%d ignorados (sem duração).";
+
+// MARK: - Calorie Estimates
+
+"calorieEstimateExplanation" = "O LOGIT estima calorias ativas a partir da densidade do treino e do seu peso corporal — sempre da mesma forma, para que comparar seus treinos continue fazendo sentido. O gasto individual varia; trate o número absoluto como aproximado.";
+"calorieEstimateHealthNote" = "Sincronizado com o Apple Saúde como calorias ativas. Você pode desativar a estimativa em Ajustes.";
+"calorieEstimates" = "Estimativa de calorias";
+"calorieEstimatesDescription" = "Estima calorias ativas a partir das suas séries e do seu peso corporal. Aparece nos detalhes do treino e é incluída na sincronização com o Apple Saúde.";
+"estCalories" = "Calorias est.";
+"estimatedCalories" = "Calorias estimadas";
+"fromYourLoggedSets" = "Das suas séries registradas";
+"loggedDateFormat" = "Registrado em %@";
+"logBodyWeightToEstimate" = "Registre o peso para estimar calorias";
+"publishedStrengthRange" = "Faixa publicada para treino de força";
+"restShareLabel" = "descanso e preparação";
+"sessionIntensity" = "Intensidade da sessão";
+"workingShareLabel" = "trabalho";
+"workingTime" = "Tempo de trabalho";

--- a/LOGIT/Core/Utilities/CalorieEstimator.swift
+++ b/LOGIT/Core/Utilities/CalorieEstimator.swift
@@ -1,0 +1,164 @@
+//
+//  CalorieEstimator.swift
+//  LOGIT
+//
+//  Created by Lukas Kaibel on 22.07.26.
+//
+
+import CoreData
+import Foundation
+
+/// Estimates a workout's active energy from data the user actually logged.
+///
+/// Two steps:
+/// 1. **Working time** — every set entry contributes seconds from the best field it has:
+///    logged durations directly, repetitions at a controlled-rep pace, distances at a
+///    conservative carry pace. Nothing requires fields a set's measurement type doesn't track.
+/// 2. **Density → intensity** — the share of the workout spent working interpolates the
+///    session MET across the published range for resistance training (3.0–6.0 METs,
+///    anchored so a typical gym session lands on the Compendium of Physical Activities'
+///    3.5). Active energy is net of resting burn — the same definition as Apple Health's
+///    Active Calories, so the in-app number and the synced number are the same number.
+///
+/// Guardrails, because a number that feels random is worse than no number:
+/// - billable duration is capped (per-set rest allowance + session overhead), so a recorder
+///   left running for hours bills like the workout it plausibly was;
+/// - the MET is clamped to the published strength-training range;
+/// - without a logged body weight there is no estimate at all — never a population default;
+/// - results round to 5 kcal and the estimator is fully deterministic.
+enum CalorieEstimator {
+    /// UserDefaults key for the user-facing opt-out (Settings › Workout). Governs both the
+    /// detail-screen row and whether synced Health workouts carry an energy sample.
+    static let enabledKey = "calorieEstimatesEnabled"
+
+    // MARK: - Tuning Constants
+
+    /// Seconds of work one controlled repetition takes.
+    static let secondsPerRepetition: Double = 3.5
+    /// Pace assumed for distance entries without a logged duration (carries), plus a cap so a
+    /// long run logged as distance-only can't dominate the working time.
+    static let distanceMetersPerSecond: Double = 1.0
+    static let maxSecondsPerDistanceEntry: Double = 180
+    /// Billable rest allowance: per performed set, plus fixed session overhead (warmup, setup).
+    static let maxRestSecondsPerSet: Double = 240
+    static let sessionOverheadSeconds: Double = 600
+    /// Session MET = 2.4 + 6.3 × working share, clamped to the published range for
+    /// resistance training. A typical session (~17% working time) lands on 3.5.
+    static let sessionMETRange: ClosedRange<Double> = 3.0...6.0
+    /// Estimates below this aren't worth showing.
+    static let minimumKilocalories = 5
+
+    /// A computed estimate plus the inputs it was computed from — the explainer sheet shows
+    /// exactly these, so what the user sees is what the math used.
+    struct Estimate: Equatable {
+        let activeKilocalories: Int
+        let workingSeconds: Int
+        let billableSeconds: Int
+        let sessionMET: Double
+        let bodyWeightKilograms: Double
+        let bodyWeightDate: Date?
+    }
+
+    // MARK: - Workout-Level Estimate
+
+    /// The estimate for a workout, or `nil` when it can't be honest: no duration, nothing
+    /// performed, or no logged body weight. Must run on the workout's context queue.
+    static func estimate(for workout: Workout) -> Estimate? {
+        guard let start = workout.date, let end = workout.endDate, end > start,
+              let context = workout.managedObjectContext,
+              let bodyWeight = bodyWeight(nearestTo: start, in: context)
+        else { return nil }
+
+        let performedSets = workout.sets.map { workingSeconds(for: $0.entryValues) }
+            .filter { $0 > 0 }
+        return estimate(
+            workingSeconds: performedSets.reduce(0, +),
+            performedSetCount: performedSets.count,
+            wallClockSeconds: end.timeIntervalSince(start),
+            bodyWeightKilograms: bodyWeight.kilograms,
+            bodyWeightDate: bodyWeight.date
+        )
+    }
+
+    // MARK: - Pure Math
+
+    /// One set's working seconds, summed over its entries (drop sets and supersets have one
+    /// entry per drop/exercise, so they fall out naturally). A logged duration is the truth;
+    /// repetitions and distances are converted at conservative paces.
+    static func workingSeconds(for entryValues: [SetEntryValues]) -> Double {
+        entryValues.reduce(0) { total, values in
+            guard values.hasPerformanceValue else { return total }
+            if values.type.usesDuration && values.duration > 0 {
+                return total + Double(values.duration)
+            }
+            if values.type.usesRepetitions && values.repetitions > 0 {
+                return total + Double(values.repetitions) * secondsPerRepetition
+            }
+            if values.type.usesDistance && values.distance > 0 {
+                return total + min(
+                    Double(values.distance) / distanceMetersPerSecond,
+                    maxSecondsPerDistanceEntry
+                )
+            }
+            return total
+        }
+    }
+
+    static func estimate(
+        workingSeconds: Double,
+        performedSetCount: Int,
+        wallClockSeconds: Double,
+        bodyWeightKilograms: Double,
+        bodyWeightDate: Date? = nil
+    ) -> Estimate? {
+        guard workingSeconds > 0, wallClockSeconds > 0, bodyWeightKilograms > 0 else { return nil }
+
+        // A forgotten recorder can't inflate the bill: rest beyond the per-set allowance
+        // (plus overhead) isn't billable. Working time itself is always billable.
+        let billableCap = workingSeconds
+            + Double(performedSetCount) * maxRestSecondsPerSet
+            + sessionOverheadSeconds
+        let billableSeconds = min(wallClockSeconds, billableCap)
+
+        let workingShare = min(workingSeconds / billableSeconds, 1)
+        let sessionMET = min(
+            max(2.4 + 6.3 * workingShare, sessionMETRange.lowerBound),
+            sessionMETRange.upperBound
+        )
+
+        // (MET − 1) × kg × h — net of resting burn, matching Apple's Active Calories.
+        let kilocalories = (sessionMET - 1) * bodyWeightKilograms * (billableSeconds / 3600)
+        let rounded = Int((kilocalories / 5).rounded()) * 5
+        guard rounded >= minimumKilocalories else { return nil }
+
+        return Estimate(
+            activeKilocalories: rounded,
+            workingSeconds: Int(workingSeconds.rounded()),
+            billableSeconds: Int(billableSeconds.rounded()),
+            sessionMET: sessionMET,
+            bodyWeightKilograms: bodyWeightKilograms,
+            bodyWeightDate: bodyWeightDate
+        )
+    }
+
+    // MARK: - Body Weight Lookup
+
+    /// The logged body weight nearest to the given date (so backfilled history uses the weight
+    /// the user had *then*), or `nil` when none was ever logged.
+    static func bodyWeight(
+        nearestTo date: Date, in context: NSManagedObjectContext
+    ) -> (kilograms: Double, date: Date)? {
+        let request: NSFetchRequest<MeasurementEntry> = MeasurementEntry.fetchRequest()
+        let entries = (try? context.fetch(request)) ?? []
+        return entries
+            .compactMap { entry -> (kilograms: Double, date: Date)? in
+                guard entry.type == .bodyweight, entry.value_ > 0, let entryDate = entry.date
+                else { return nil }
+                // Body weight is stored in grams regardless of the display unit.
+                return (Double(entry.value_) / 1000, entryDate)
+            }
+            .min {
+                abs($0.date.timeIntervalSince(date)) < abs($1.date.timeIntervalSince(date))
+            }
+    }
+}

--- a/LOGIT/Core/Utilities/HealthKitSyncManager.swift
+++ b/LOGIT/Core/Utilities/HealthKitSyncManager.swift
@@ -27,6 +27,9 @@ final class HealthKitSyncManager: ObservableObject {
         let name: String?
         let start: Date
         let end: Date
+        /// The workout's estimated active energy (see `CalorieEstimator`), or `nil` when
+        /// estimates are disabled or impossible — the Health entry then has no energy sample.
+        var activeKilocalories: Int? = nil
     }
 
     enum BackfillState: Equatable {
@@ -68,12 +71,21 @@ final class HealthKitSyncManager: ObservableObject {
         healthStore.authorizationStatus(for: .workoutType()) == .sharingAuthorized
     }
 
-    /// Presents the system Health access sheet (only the first time; later calls are no-ops)
-    /// and reports whether write access ended up granted.
+    /// Whether energy samples may be written. Requested together with workout access; users
+    /// who granted workouts before calorie estimates existed simply sync without energy until
+    /// they re-run the authorization (any toggle-on in settings does).
+    var isAuthorizedForActiveEnergy: Bool {
+        healthStore.authorizationStatus(for: HKQuantityType(.activeEnergyBurned)) == .sharingAuthorized
+    }
+
+    /// Presents the system Health access sheet (only for so-far-undetermined types; later
+    /// calls are no-ops) and reports whether workout write access ended up granted.
     func requestAuthorization() async -> Bool {
         guard isHealthDataAvailable else { return false }
         do {
-            try await healthStore.requestAuthorization(toShare: [.workoutType()], read: [])
+            try await healthStore.requestAuthorization(
+                toShare: [.workoutType(), HKQuantityType(.activeEnergyBurned)], read: []
+            )
         } catch {
             Self.logger.error(
                 "Requesting Health authorization failed: \(String(describing: error), privacy: .public)"
@@ -162,11 +174,12 @@ final class HealthKitSyncManager: ObservableObject {
         configuration.activityType = .traditionalStrengthTraining
         configuration.locationType = .indoor
 
+        // Any strictly increasing value works; milliseconds keep two saves of the same
+        // workout in quick succession (finish, then an immediate edit) distinguishable.
+        let syncVersion = Int(Date.now.timeIntervalSince1970 * 1000)
         var metadata: [String: Any] = [
             HKMetadataKeySyncIdentifier: payload.id.uuidString,
-            // Any strictly increasing value works; milliseconds keep two saves of the same
-            // workout in quick succession (finish, then an immediate edit) distinguishable.
-            HKMetadataKeySyncVersion: Int(Date.now.timeIntervalSince1970 * 1000),
+            HKMetadataKeySyncVersion: syncVersion,
         ]
         if let name = payload.name, !name.isEmpty {
             metadata[HKMetadataKeyWorkoutBrandName] = name
@@ -175,6 +188,22 @@ final class HealthKitSyncManager: ObservableObject {
         let builder = HKWorkoutBuilder(healthStore: healthStore, configuration: configuration, device: .local())
         do {
             try await builder.beginCollection(at: payload.start)
+            // The estimated active energy rides along as a sample with its own sync
+            // identifier, so a re-export replaces the old sample instead of double-counting
+            // toward the Move ring.
+            if let kilocalories = payload.activeKilocalories, isAuthorizedForActiveEnergy {
+                let energySample = HKQuantitySample(
+                    type: HKQuantityType(.activeEnergyBurned),
+                    quantity: HKQuantity(unit: .kilocalorie(), doubleValue: Double(kilocalories)),
+                    start: payload.start,
+                    end: payload.end,
+                    metadata: [
+                        HKMetadataKeySyncIdentifier: Self.energySyncIdentifier(for: payload.id),
+                        HKMetadataKeySyncVersion: syncVersion,
+                    ]
+                )
+                try await builder.addSamples([energySample])
+            }
             try await builder.addMetadata(metadata)
             try await builder.endCollection(at: payload.end)
             _ = try await builder.finishWorkout()
@@ -182,15 +211,40 @@ final class HealthKitSyncManager: ObservableObject {
             builder.discardWorkout()
             throw error
         }
+
+        // A re-export without energy (estimates turned off, or the body weight entry was
+        // deleted) must also retire the previously exported sample — the replaced workout
+        // doesn't take its associated samples with it.
+        if payload.activeKilocalories == nil {
+            try? await deleteObjects(
+                of: HKQuantityType(.activeEnergyBurned),
+                syncIdentifier: Self.energySyncIdentifier(for: payload.id)
+            )
+        }
     }
 
     private func deleteExportedWorkout(id: UUID) async throws {
+        // The energy sample first, and tolerantly — most workouts have one workout object
+        // but not necessarily an energy sample, and a missing sample must not keep the
+        // workout itself from being deleted.
+        try? await deleteObjects(
+            of: HKQuantityType(.activeEnergyBurned),
+            syncIdentifier: Self.energySyncIdentifier(for: id)
+        )
+        try await deleteObjects(of: .workoutType(), syncIdentifier: id.uuidString)
+    }
+
+    private static func energySyncIdentifier(for id: UUID) -> String {
+        id.uuidString + "-energy"
+    }
+
+    private func deleteObjects(of type: HKObjectType, syncIdentifier: String) async throws {
         let predicate = HKQuery.predicateForObjects(
             withMetadataKey: HKMetadataKeySyncIdentifier,
-            allowedValues: [id.uuidString]
+            allowedValues: [syncIdentifier]
         )
         _ = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Int, Error>) in
-            healthStore.deleteObjects(of: .workoutType(), predicate: predicate) { _, deletedCount, error in
+            healthStore.deleteObjects(of: type, predicate: predicate) { _, deletedCount, error in
                 if let error {
                     continuation.resume(throwing: error)
                 } else {
@@ -210,6 +264,15 @@ extension Workout {
         guard let id, let date, let endDate,
               HealthKitSyncManager.isExportable(start: date, end: endDate)
         else { return nil }
-        return HealthKitSyncManager.WorkoutPayload(id: id, name: name, start: date, end: endDate)
+        let estimatesEnabled = UserDefaults.standard.bool(forKey: CalorieEstimator.enabledKey)
+        return HealthKitSyncManager.WorkoutPayload(
+            id: id,
+            name: name,
+            start: date,
+            end: endDate,
+            activeKilocalories: estimatesEnabled
+                ? CalorieEstimator.estimate(for: self)?.activeKilocalories
+                : nil
+        )
     }
 }

--- a/LOGIT/Features/SettingsScreen.swift
+++ b/LOGIT/Features/SettingsScreen.swift
@@ -19,6 +19,7 @@ struct SettingsScreen: View {
     @AppStorage("distanceUnit") var distanceUnit: DistanceUnit = .km
     @AppStorage("preventAutoLock") var preventAutoLock: Bool = true
     @AppStorage("timerIsMuted") var timerIsMuted: Bool = false
+    @AppStorage(CalorieEstimator.enabledKey) var calorieEstimatesEnabled: Bool = true
     @AppStorage(HealthKitSyncManager.syncEnabledKey) var appleHealthSyncEnabled: Bool = false
 
     // MARK: - State
@@ -138,6 +139,14 @@ struct SettingsScreen: View {
                 Toggle(NSLocalizedString("timerIsMuted", comment: ""), isOn: $timerIsMuted)
                     .padding(CELL_PADDING)
                     .tileStyle()
+                VStack(alignment: .leading) {
+                    Toggle(NSLocalizedString("calorieEstimates", comment: ""), isOn: $calorieEstimatesEnabled)
+                    Text(NSLocalizedString("calorieEstimatesDescription", comment: ""))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .padding(CELL_PADDING)
+                .tileStyle()
             }
         }
     }

--- a/LOGIT/Features/Workout/WorkoutCalorieRow.swift
+++ b/LOGIT/Features/Workout/WorkoutCalorieRow.swift
@@ -1,0 +1,227 @@
+//
+//  WorkoutCalorieRow.swift
+//  LOGIT
+//
+//  Created by Lukas Kaibel on 22.07.26.
+//
+
+import SwiftUI
+
+/// The slim estimated-calories row on the workout detail screen.
+///
+/// Deliberately quieter than the measured stat tiles above it — one settings-row-height
+/// line, secondary label, tilde value — because the number is derived, not measured, and
+/// calories are not a primary feature. Tapping it opens `CalorieEstimateSheet`, which
+/// decomposes the number into exactly the inputs the estimator used.
+struct WorkoutCalorieRow: View {
+    @ObservedObject var workout: Workout
+    let estimate: CalorieEstimator.Estimate?
+    /// True when the only thing missing for an estimate is a logged body weight — the row
+    /// then explains that instead of showing a number. All other nil reasons hide the row.
+    let isMissingBodyWeight: Bool
+
+    @State private var isShowingEstimateSheet = false
+    @State private var isShowingBodyWeightScreen = false
+
+    var body: some View {
+        if let estimate {
+            Button {
+                isShowingEstimateSheet = true
+            } label: {
+                row {
+                    Text("~\(estimate.activeKilocalories)")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(Color.label)
+                        + Text(" kcal")
+                        .font(.footnote.weight(.medium))
+                        .foregroundStyle(Color.secondaryLabel)
+                    Image(systemName: "info.circle")
+                        .font(.footnote)
+                        .foregroundStyle(Color.secondaryLabel)
+                }
+            }
+            .sheet(isPresented: $isShowingEstimateSheet) {
+                CalorieEstimateSheet(workout: workout, estimate: estimate)
+            }
+        } else if isMissingBodyWeight {
+            Button {
+                isShowingBodyWeightScreen = true
+            } label: {
+                row(dimmed: true) {
+                    Text(NSLocalizedString("add", comment: ""))
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(Color.accentColor)
+                    NavigationChevron()
+                }
+            }
+            .sheet(isPresented: $isShowingBodyWeightScreen) {
+                NavigationStack {
+                    MeasurementDetailScreen(measurementType: .bodyweight)
+                }
+            }
+        }
+    }
+
+    /// The shared single-line frame: flame, label, then the trailing content.
+    private func row(dimmed: Bool = false, @ViewBuilder trailing: () -> some View) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: "flame.fill")
+                .font(.footnote)
+                .foregroundStyle(dimmed ? Color.secondaryLabel : Color.accentColor)
+            Text(NSLocalizedString(dimmed ? "logBodyWeightToEstimate" : "estCalories", comment: ""))
+                .font(.subheadline)
+                .foregroundStyle(Color.secondaryLabel)
+                .lineLimit(1)
+                .minimumScaleFactor(0.8)
+            Spacer(minLength: 8)
+            trailing()
+        }
+        .padding(.horizontal, CELL_PADDING)
+        .padding(.vertical, 11)
+        .tileStyle()
+        .contentShape(Rectangle())
+    }
+}
+
+// MARK: - Estimate Sheet
+
+/// Decomposes the calorie estimate into the inputs it was computed from — every line
+/// traceable to something the user logged. This transparency is the feature: an estimate
+/// whose inputs are inspectable doesn't read as random.
+struct CalorieEstimateSheet: View {
+    @ObservedObject var workout: Workout
+    let estimate: CalorieEstimator.Estimate
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                Text(NSLocalizedString("estimatedCalories", comment: ""))
+                    .font(.title2.weight(.bold))
+                Text("\(workout.name ?? "") · \(workout.date?.description(.medium) ?? "")")
+                    .font(.footnote)
+                    .foregroundStyle(Color.secondaryLabel)
+                    .padding(.bottom, 16)
+
+                HStack(alignment: .firstTextBaseline, spacing: 4) {
+                    Text("~\(estimate.activeKilocalories)")
+                        .font(.system(size: 38, weight: .bold))
+                    Text("kcal")
+                        .font(.headline)
+                        .foregroundStyle(Color.secondaryLabel)
+                }
+
+                splitBar
+                    .padding(.top, 14)
+                    .padding(.bottom, 20)
+
+                inputRow(
+                    NSLocalizedString("duration", comment: ""),
+                    value: formattedWorkoutDuration(minutes: estimate.billableSeconds / 60)
+                )
+                inputRow(
+                    NSLocalizedString("workingTime", comment: ""),
+                    value: "~\(formattedWorkoutDuration(minutes: max(1, estimate.workingSeconds / 60)))",
+                    detail: NSLocalizedString("fromYourLoggedSets", comment: "")
+                )
+                inputRow(
+                    NSLocalizedString("bodyweight", comment: ""),
+                    value: "\(convertWeightForDisplaying(Int64(estimate.bodyWeightKilograms * 1000))) \(WeightUnit.used.rawValue)",
+                    detail: estimate.bodyWeightDate.map {
+                        String(
+                            format: NSLocalizedString("loggedDateFormat", comment: ""),
+                            $0.description(.medium)
+                        )
+                    }
+                )
+                inputRow(
+                    NSLocalizedString("sessionIntensity", comment: ""),
+                    value: String(format: "%.1f METs", estimate.sessionMET),
+                    detail: NSLocalizedString("publishedStrengthRange", comment: ""),
+                    showsDivider: false
+                )
+
+                Text(NSLocalizedString("calorieEstimateExplanation", comment: ""))
+                    .font(.caption)
+                    .foregroundStyle(Color.secondaryLabel)
+                    .padding(.top, 16)
+                Text(NSLocalizedString("calorieEstimateHealthNote", comment: ""))
+                    .font(.caption)
+                    .foregroundStyle(Color.secondaryLabel)
+                    .padding(.top, 8)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding()
+            .padding(.top, 8)
+        }
+        .presentationDetents([.fraction(0.8), .large])
+        .presentationDragIndicator(.visible)
+    }
+
+    /// Working vs. rest share of the billed duration — drawn honestly from the same numbers
+    /// the formula used.
+    private var splitBar: some View {
+        let workingShare = min(
+            Double(estimate.workingSeconds) / Double(max(estimate.billableSeconds, 1)), 1
+        )
+        let restMinutes = max(0, estimate.billableSeconds - estimate.workingSeconds) / 60
+        return VStack(spacing: 6) {
+            GeometryReader { proxy in
+                HStack(spacing: 3) {
+                    Capsule()
+                        .fill(Color.accentColor)
+                        .frame(width: max(8, proxy.size.width * workingShare))
+                    Capsule()
+                        .fill(Color.fill)
+                }
+            }
+            .frame(height: 8)
+            HStack {
+                legendText(
+                    minutes: max(1, estimate.workingSeconds / 60),
+                    label: NSLocalizedString("workingShareLabel", comment: "")
+                )
+                Spacer()
+                legendText(
+                    minutes: restMinutes,
+                    label: NSLocalizedString("restShareLabel", comment: "")
+                )
+            }
+        }
+    }
+
+    private func legendText(minutes: Int, label: String) -> Text {
+        Text(formattedWorkoutDuration(minutes: minutes))
+            .font(.caption.weight(.semibold))
+            .foregroundColor(Color.label)
+            + Text(" \(label)")
+            .font(.caption)
+            .foregroundColor(Color.secondaryLabel)
+    }
+
+    private func inputRow(
+        _ title: String, value: String, detail: String? = nil, showsDivider: Bool = true
+    ) -> some View {
+        VStack(spacing: 0) {
+            HStack(alignment: .firstTextBaseline) {
+                Text(title)
+                    .font(.subheadline)
+                    .foregroundStyle(Color.secondaryLabel)
+                Spacer()
+                VStack(alignment: .trailing, spacing: 1) {
+                    Text(value)
+                        .font(.subheadline.weight(.semibold))
+                    if let detail {
+                        Text(detail)
+                            .font(.caption2)
+                            .foregroundStyle(Color.secondaryLabel)
+                    }
+                }
+                .multilineTextAlignment(.trailing)
+            }
+            .padding(.vertical, 10)
+            if showsDivider {
+                Divider()
+            }
+        }
+    }
+}

--- a/LOGIT/Features/Workout/WorkoutCalorieRow.swift
+++ b/LOGIT/Features/Workout/WorkoutCalorieRow.swift
@@ -62,15 +62,21 @@ struct WorkoutCalorieRow: View {
         }
     }
 
-    /// The shared single-line frame: flame, label, then the trailing content.
+    /// The shared single-line frame: flame, label, then the trailing content. The flame wears
+    /// the workout's muscle-group gradient — the same identity treatment as the stat tiles'
+    /// run bars and the detail header's donut.
     private func row(dimmed: Bool = false, @ViewBuilder trailing: () -> some View) -> some View {
         HStack(spacing: 8) {
             Image(systemName: "flame.fill")
                 .font(.footnote)
-                .foregroundStyle(dimmed ? Color.secondaryLabel : Color.accentColor)
+                .foregroundStyle(
+                    dimmed
+                        ? AnyShapeStyle(Color.secondaryLabel)
+                        : workout.sets.muscleGroupGradientStyle(startPoint: .bottomLeading, endPoint: .topTrailing)
+                )
             Text(NSLocalizedString(dimmed ? "logBodyWeightToEstimate" : "estCalories", comment: ""))
                 .font(.subheadline)
-                .foregroundStyle(Color.secondaryLabel)
+                .foregroundStyle(dimmed ? Color.secondaryLabel : Color.label)
                 .lineLimit(1)
                 .minimumScaleFactor(0.8)
             Spacer(minLength: 8)
@@ -168,7 +174,7 @@ struct CalorieEstimateSheet: View {
             GeometryReader { proxy in
                 HStack(spacing: 3) {
                     Capsule()
-                        .fill(Color.accentColor)
+                        .fill(workout.sets.muscleGroupGradient(startPoint: .leading, endPoint: .trailing))
                         .frame(width: max(8, proxy.size.width * workingShare))
                     Capsule()
                         .fill(Color.fill)

--- a/LOGIT/Features/Workout/WorkoutDetailScreen.swift
+++ b/LOGIT/Features/Workout/WorkoutDetailScreen.swift
@@ -25,6 +25,8 @@ struct WorkoutDetailScreen: View {
 
     // MARK: - State
 
+    @AppStorage(CalorieEstimator.enabledKey) private var calorieEstimatesEnabled = true
+
     @State private var isShowingDeleteWorkoutAlert: Bool = false
     @State private var sheetType: SheetType? = nil
     @State private var newTemplateFromWorkout: Template?
@@ -32,6 +34,8 @@ struct WorkoutDetailScreen: View {
     @State private var selectedStatMetric: WorkoutStatMetric?
     @State private var headerTextHeight: CGFloat = 64
     @State private var progressReport: WorkoutProgressReport?
+    @State private var calorieEstimate: CalorieEstimator.Estimate?
+    @State private var calorieBodyWeightMissing = false
     @State private var isShowingPersonalRecords: Bool = false
     @State private var workoutShareFileURL: URL?
     @State private var templateShareFileURL: URL?
@@ -58,6 +62,13 @@ struct WorkoutDetailScreen: View {
                     WorkoutStatTileGrid(workout: workout) { metric in
                         selectedStatMetric = metric
                     }
+                    if calorieEstimatesEnabled {
+                        WorkoutCalorieRow(
+                            workout: workout,
+                            estimate: calorieEstimate,
+                            isMissingBodyWeight: calorieBodyWeightMissing
+                        )
+                    }
                     progressAndVolumeRow
                 }
 
@@ -83,11 +94,13 @@ struct WorkoutDetailScreen: View {
         }
         .onAppear {
             progressReport = WorkoutProgressReport.compute(for: workout, database: database)
+            refreshCalorieEstimate()
         }
         .onReceive(
             workout.objectWillChange.debounce(for: .seconds(0.5), scheduler: RunLoop.main)
         ) { _ in
             progressReport = WorkoutProgressReport.compute(for: workout, database: database)
+            refreshCalorieEstimate()
         }
         .background(
             VStack {
@@ -205,6 +218,20 @@ struct WorkoutDetailScreen: View {
         }
         .navigationDestination(isPresented: $isShowingPersonalRecords) {
             WorkoutPersonalRecordsScreen(workout: workout, report: progressReport ?? .empty)
+        }
+    }
+
+    /// Recomputes the calorie estimate (and whether only a body weight is missing — the
+    /// teaser state). Cheap: one measurement fetch plus a pass over the sets' entries.
+    private func refreshCalorieEstimate() {
+        calorieEstimate = CalorieEstimator.estimate(for: workout)
+        if calorieEstimate == nil,
+           let start = workout.date, let end = workout.endDate, end > start,
+           !workout.sets.isEmpty,
+           let context = workout.managedObjectContext {
+            calorieBodyWeightMissing = CalorieEstimator.bodyWeight(nearestTo: start, in: context) == nil
+        } else {
+            calorieBodyWeightMissing = false
         }
     }
 

--- a/LOGITTests/ServicesTests.swift
+++ b/LOGITTests/ServicesTests.swift
@@ -1110,3 +1110,129 @@ final class HealthKitSyncManagerTests: XCTestCase {
         XCTAssertNil(workout.healthKitPayload)
     }
 }
+
+// MARK: - CalorieEstimatorTests
+
+final class CalorieEstimatorTests: XCTestCase {
+
+    /// The plan's worked example: 58 min, 18 sets, 172 reps, 76 kg → working share ~0.17,
+    /// ~3.5 METs, ~185 kcal.
+    func testTypicalSessionLandsOnCompendiumAverage() {
+        let estimate = CalorieEstimator.estimate(
+            workingSeconds: 172 * 3.5,
+            performedSetCount: 18,
+            wallClockSeconds: 58 * 60,
+            bodyWeightKilograms: 76
+        )
+        XCTAssertEqual(estimate?.activeKilocalories, 185)
+        XCTAssertEqual(estimate!.sessionMET, 3.49, accuracy: 0.01)
+    }
+
+    func testDenserSessionBurnsMorePerMinute() {
+        // Same work squeezed into half the time: higher MET, and the per-minute rate rises
+        // even though the shorter duration lowers the absolute total.
+        let relaxed = CalorieEstimator.estimate(
+            workingSeconds: 600, performedSetCount: 18,
+            wallClockSeconds: 3600, bodyWeightKilograms: 80
+        )!
+        let dense = CalorieEstimator.estimate(
+            workingSeconds: 600, performedSetCount: 18,
+            wallClockSeconds: 1800, bodyWeightKilograms: 80
+        )!
+        XCTAssertGreaterThan(dense.sessionMET, relaxed.sessionMET)
+        let relaxedRate = Double(relaxed.activeKilocalories) / 60
+        let denseRate = Double(dense.activeKilocalories) / 30
+        XCTAssertGreaterThan(denseRate, relaxedRate)
+    }
+
+    func testForgottenRecorderCannotInflateTheBill() {
+        // 12 sets logged, recorder left running for 4 hours: billable time caps at
+        // working + 12×4min + 10min, so tripling the wall clock changes nothing.
+        let honest = CalorieEstimator.estimate(
+            workingSeconds: 500, performedSetCount: 12,
+            wallClockSeconds: 4 * 3600, bodyWeightKilograms: 80
+        )!
+        let cappedSeconds = 500.0 + 12 * 240 + 600
+        XCTAssertEqual(honest.billableSeconds, Int(cappedSeconds))
+        let evenLonger = CalorieEstimator.estimate(
+            workingSeconds: 500, performedSetCount: 12,
+            wallClockSeconds: 12 * 3600, bodyWeightKilograms: 80
+        )!
+        XCTAssertEqual(honest.activeKilocalories, evenLonger.activeKilocalories)
+    }
+
+    func testMETStaysInPublishedRange() {
+        // Degenerate sparse data (2 sets in 3 hours) floors at 3.0; degenerate dense data
+        // (all work, no rest) ceils at 6.0.
+        let sparse = CalorieEstimator.estimate(
+            workingSeconds: 70, performedSetCount: 2,
+            wallClockSeconds: 3 * 3600, bodyWeightKilograms: 80
+        )!
+        XCTAssertEqual(sparse.sessionMET, 3.0)
+        let dense = CalorieEstimator.estimate(
+            workingSeconds: 1200, performedSetCount: 30,
+            wallClockSeconds: 1200, bodyWeightKilograms: 80
+        )!
+        XCTAssertEqual(dense.sessionMET, 6.0)
+    }
+
+    func testNoEstimateWithoutHonestInputs() {
+        XCTAssertNil(CalorieEstimator.estimate(
+            workingSeconds: 0, performedSetCount: 0,
+            wallClockSeconds: 3600, bodyWeightKilograms: 80
+        ), "Nothing performed → no estimate")
+        XCTAssertNil(CalorieEstimator.estimate(
+            workingSeconds: 600, performedSetCount: 10,
+            wallClockSeconds: 3600, bodyWeightKilograms: 0
+        ), "No body weight → no estimate, never a default")
+        XCTAssertNil(CalorieEstimator.estimate(
+            workingSeconds: 600, performedSetCount: 10,
+            wallClockSeconds: 0, bodyWeightKilograms: 80
+        ), "No duration → no estimate")
+    }
+
+    func testWorkingSecondsPerMeasurementType() {
+        // Duration wins when logged; reps convert at 3.5 s; distance-only converts at
+        // 1 m/s capped at 3 min; unperformed entries contribute nothing.
+        let values: [SetEntryValues] = [
+            SetEntryValues(type: .repsAndWeight, order: 0, repetitions: 10, weight: 80_000, duration: 0),
+            SetEntryValues(type: .duration, order: 1, repetitions: 0, weight: 0, duration: 60),
+            SetEntryValues(type: .weightAndDistance, order: 2, repetitions: 0, weight: 20_000, duration: 0, distance: 40),
+            SetEntryValues(type: .weightAndDistance, order: 3, repetitions: 0, weight: 20_000, duration: 0, distance: 4000),
+            SetEntryValues(type: .repsAndWeight, order: 4, repetitions: 0, weight: 80_000, duration: 0),
+        ]
+        let seconds = CalorieEstimator.workingSeconds(for: values)
+        // 10×3.5 + 60 + 40 + capped 180 + 0
+        XCTAssertEqual(seconds, 35 + 60 + 40 + 180, accuracy: 0.001)
+    }
+
+    func testRoundsToFiveKilocalories() {
+        let estimate = CalorieEstimator.estimate(
+            workingSeconds: 600, performedSetCount: 15,
+            wallClockSeconds: 3600, bodyWeightKilograms: 77
+        )!
+        XCTAssertEqual(estimate.activeKilocalories % 5, 0)
+    }
+
+    func testBodyWeightNearestToWorkoutDate() {
+        let database = Database(isPreview: false, inMemory: true)
+        let context = database.context
+
+        func addEntry(kilograms: Double, daysAgo: Int) {
+            let entry = MeasurementEntry(context: context)
+            entry.type = .bodyweight
+            entry.value_ = Int64(kilograms * 1000)
+            entry.date = Calendar.current.date(byAdding: .day, value: -daysAgo, to: .now)
+        }
+        addEntry(kilograms: 82, daysAgo: 300)
+        addEntry(kilograms: 78, daysAgo: 30)
+        addEntry(kilograms: 76, daysAgo: 1)
+
+        let oldWorkoutDate = Calendar.current.date(byAdding: .day, value: -290, to: .now)!
+        XCTAssertEqual(
+            CalorieEstimator.bodyWeight(nearestTo: oldWorkoutDate, in: context)?.kilograms, 82,
+            "Backfilled history must use the weight the user had then"
+        )
+        XCTAssertEqual(CalorieEstimator.bodyWeight(nearestTo: .now, in: context)?.kilograms, 76)
+    }
+}


### PR DESCRIPTION
Fills the empty calorie field on synced Health workouts — with an estimate designed to never feel random.

## The model (see the design plan artifact)

1. **Working time** from whatever each set entry has — logged durations directly, reps at 3.5 s each, distance-only entries at a capped 1 m/s carry pace. Works across all seven set measurement types incl. #96's distance axis; nothing requires fields a set doesn't track.
2. **Density → intensity** — the working share of the (billable) duration interpolates the session MET across the published 3.0–6.0 resistance-training range, anchored so a typical session lands on the Compendium's 3.5. Active kcal = (MET − 1) × body weight × hours — net of resting burn, i.e. Apple's Active Calories definition, so the in-app number and the Health number are the same number.

**Anti-"random" guardrails:** billable duration is capped (a recorder left running for hours bills like the workout it plausibly was); MET clamped to the published range; **no estimate without a logged body weight** (nearest measurement to each workout's date — backfilled history uses the weight you had then); rounded to 5 kcal with a tilde; fully deterministic.

## UI (deliberately secondary)

- One slim, settings-row-height line under the workout detail's stat grid — `flame.fill`, "Est. Calories", "~140 kcal", `info.circle`. No trend pill, no run bars: derived data doesn't masquerade as a measured tile.
- Tapping opens an explainer sheet that decomposes the number into exactly the inputs the math used (duration, working time, body weight + when it was logged, session METs) plus an honest working/rest split bar.
- When only body weight is missing: the same quiet row becomes a one-line teaser linking to Measurements. Never a number from a guessed weight.
- "Calorie Estimates" toggle in Settings › Workout (default on) governs the row **and** the Health export.

## Apple Health

- The estimate exports as an `activeEnergyBurned` sample with its own sync identifier → idempotent upserts, no Move-ring double counting on edits; stale samples are retired when estimates are turned off.
- Authorization now also requests energy write access (incremental system sheet; users who enabled sync before this simply sync without energy until they touch a toggle).
- Re-running "Export Past Workouts" retrofits calories onto already-synced history.

## Verification

- 8 new unit tests: the worked-example anchor (58 min / 18 sets / 172 reps / 76 kg → 3.5 METs → 185 kcal), density monotonicity, the forgotten-recorder cap, MET clamps, per-type working-time math, nearest-body-weight lookup, rounding, nil-without-honest-inputs.
- Simulator end-to-end: detail row + explainer sheet (Arm Day fixture: ~140 kcal @ 3.7 METs — hand-checked against the formula), teaser state in scenario `one`, settings toggle, Health access sheet with both types, 60-workout backfill, and the Health app showing the Active Energy category populated plus the workout detail listing "Total Active Energy 140 kcal".
- Standing empty/one/many/free scenario suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)