### PR TITLE
Fix overlapping and truncated chart x-axis labels across all charts

### DIFF
--- a/LOGIT/Core/Enums/StatPeriod.swift
+++ b/LOGIT/Core/Enums/StatPeriod.swift
@@ -217,6 +217,39 @@ extension StatPeriod {
         }
     }
 
+    /// The explicit x-axis mark dates for the scrollable chart: period starts counted back from the
+    /// current period in `scrollAxisStride` steps, across the whole scrollable domain. The stride is
+    /// anchored at "now" rather than at the domain's start (whose parity shifts with where the data
+    /// happens to begin) so the current period always carries a mark — the label the chart bolds.
+    func scrollAxisValues(firstDataDate: Date?, now: Date = .now) -> [Date] {
+        let domainStart = scrollableXDomain(firstDataDate: firstDataDate, now: now).lowerBound
+        let stride = scrollAxisStride
+        var marks: [Date] = []
+        var mark = currentRange(containing: now).lowerBound
+        while mark >= domainStart {
+            marks.append(mark)
+            guard let previous = Calendar.current.date(
+                byAdding: stride.component, value: -stride.count, to: mark
+            ) else { break }
+            mark = currentRange(containing: previous).lowerBound
+        }
+        return marks.reversed()
+    }
+
+    /// Whether the mark at `date` yields its label to the current period's: true only for the mark
+    /// one stride before the current period on the week axis. The current label hangs trailing off
+    /// its mark (so the plot edge can't clip it), and the week axis is the one granularity whose
+    /// day-month labels are wide enough relative to the two-week stride that the two would collide —
+    /// month letters and year numbers keep clear of it on their own.
+    func axisLabelYieldsToCurrent(_ date: Date, now: Date = .now) -> Bool {
+        guard self == .week else { return false }
+        let stride = scrollAxisStride
+        guard let next = Calendar.current.date(
+            byAdding: stride.component, value: stride.count, to: date
+        ) else { return false }
+        return currentRange(containing: now).contains(next)
+    }
+
     /// The visible window as a date range — `[scrollPosition, scrollPosition + one window]` — for the
     /// header's moving "average" caption and the visible-window average it labels.
     func visibleWindowRange(from scrollPosition: Date, now: Date = .now) -> ClosedRange<Date> {

--- a/LOGIT/Features/Measurement/MeasurementDetailScreen.swift
+++ b/LOGIT/Features/Measurement/MeasurementDetailScreen.swift
@@ -210,19 +210,7 @@ struct MeasurementDetailScreen: View {
             .chartXSelection(value: $selectedDate)
             .chartXVisibleDomain(length: visibleDomainSeconds)
             .chartXAxis {
-                let axisStride = chartRange.axisStride(firstDataDate: firstDataDate)
-                AxisMarks(
-                    position: .bottom,
-                    values: .stride(by: axisStride.component, count: axisStride.count)
-                ) { value in
-                    if let date = value.as(Date.self) {
-                        AxisGridLine()
-                            .foregroundStyle(Color.gray.opacity(0.5))
-                        AxisValueLabel(chartRange.axisLabel(for: date, firstDataDate: firstDataDate))
-                            .foregroundStyle(chartRange.isCurrentAxisMark(date, firstDataDate: firstDataDate) ? Color.primary : .secondary)
-                            .font(.caption.weight(.bold))
-                    }
-                }
+                chartRange.xAxisMarks(firstDataDate: firstDataDate)
             }
             .chartYAxis {
                 AxisMarks(values: [0.0, yMax / 2.0, yMax])

--- a/LOGIT/Features/Workout/WorkoutStatScreen.swift
+++ b/LOGIT/Features/Workout/WorkoutStatScreen.swift
@@ -236,19 +236,7 @@ struct WorkoutStatScreen: View {
         .chartXSelection(value: $selectedDate)
         .chartXVisibleDomain(length: visibleDomainSeconds(firstDataDate: firstDataDate))
         .chartXAxis {
-            let axisStride = chartRange.axisStride(firstDataDate: firstDataDate)
-            AxisMarks(
-                position: .bottom,
-                values: .stride(by: axisStride.component, count: axisStride.count)
-            ) { value in
-                if let date = value.as(Date.self) {
-                    AxisGridLine()
-                        .foregroundStyle(Color.gray.opacity(0.5))
-                    AxisValueLabel(chartRange.axisLabel(for: date, firstDataDate: firstDataDate))
-                        .foregroundStyle(chartRange.isCurrentAxisMark(date, firstDataDate: firstDataDate) ? Color.primary : .secondary)
-                        .font(.caption.weight(.bold))
-                }
-            }
+            chartRange.xAxisMarks(firstDataDate: firstDataDate)
         }
         .chartYAxis {
             AxisMarks(values: [0, yScaleMax / 2, yScaleMax]) { _ in

--- a/LOGIT/SharedUI/Charts/CapabilityChartView.swift
+++ b/LOGIT/SharedUI/Charts/CapabilityChartView.swift
@@ -200,19 +200,7 @@ struct CapabilityChartView: View {
             .chartXSelection(value: $selectedDate)
             .chartXVisibleDomain(length: chartRange.visibleDomainSeconds(firstDataDate: firstDataDate))
             .chartXAxis {
-                let axisStride = chartRange.axisStride(firstDataDate: firstDataDate)
-                AxisMarks(
-                    position: .bottom,
-                    values: .stride(by: axisStride.component, count: axisStride.count)
-                ) { value in
-                    if let date = value.as(Date.self) {
-                        AxisGridLine()
-                            .foregroundStyle(Color.gray.opacity(0.5))
-                        AxisValueLabel(chartRange.axisLabel(for: date, firstDataDate: firstDataDate))
-                            .foregroundStyle(chartRange.isCurrentAxisMark(date, firstDataDate: firstDataDate) ? Color.primary : .secondary)
-                            .font(.caption.weight(.bold))
-                    }
-                }
+                chartRange.xAxisMarks(firstDataDate: firstDataDate)
             }
             .chartYAxis {
                 AxisMarks(values: [0, yScaleMax / 2, yScaleMax])
@@ -285,5 +273,43 @@ struct CapabilityChartView: View {
         guard let current = bestAnchor?.value, current > 0,
               let visible = visibleBest, visible > 0 else { return nil }
         return (Double(current) - Double(visible)) / Double(visible) * 100
+    }
+}
+
+extension ChartRange {
+    /// The one x-axis every `ChartRange` chart shares — this capability chart, the measurement
+    /// detail and the workout stat screens — so cadence, styling and edge handling can't drift
+    /// apart. Styling lives on the `Text` inside the label closure (hierarchical styles on the
+    /// AxisMark resolve against the chart's accent on iOS 26). The weekly day-month labels are the
+    /// wide ones that need edge handling: the domain's last mark sits close enough to the right
+    /// edge that its centered label truncates ("7/…" for "7/19"), so it hangs trailing instead —
+    /// and the mark it hangs toward gives up its own label (keeping the grid line) so the two
+    /// can't collide, same as the period-history chart. The narrow month letters and the year
+    /// numbers (whose last mark sits months from the edge) stay centered, every label kept.
+    func xAxisMarks(firstDataDate: Date?) -> some AxisContent {
+        let stride = axisStride(firstDataDate: firstDataDate)
+        return AxisMarks(
+            position: .bottom,
+            values: .stride(by: stride.component, count: stride.count)
+        ) { value in
+            if let date = value.as(Date.self) {
+                AxisGridLine()
+                    .foregroundStyle(Color.gray.opacity(0.5))
+                let weekly = stride.component == .weekOfYear
+                let hugsTrailingEdge = weekly && value.index == value.count - 1
+                let yieldsToEdgeLabel = weekly && value.index == value.count - 2
+                if !yieldsToEdgeLabel {
+                    AxisValueLabel(anchor: hugsTrailingEdge ? .topTrailing : nil) {
+                        Text(axisLabel(for: date, firstDataDate: firstDataDate))
+                            .font(.caption.weight(.bold))
+                            .foregroundStyle(
+                                isCurrentAxisMark(date, firstDataDate: firstDataDate)
+                                    ? Color.primary
+                                    : Color.secondary
+                            )
+                    }
+                }
+            }
+        }
     }
 }

--- a/LOGIT/SharedUI/Charts/PeriodHistoryChart.swift
+++ b/LOGIT/SharedUI/Charts/PeriodHistoryChart.swift
@@ -10,9 +10,11 @@ import SwiftUI
 
 /// The shared recent-periods bar chart behind every period-scoped stat detail — the Summary stat
 /// screens, the exercise Sets / Volume screens, and the muscle-group detail's sets tile. One bar per
-/// period (`StatPeriod.historyBucketCount` of them, current highlighted), at most ~4 axis labels
-/// counted back from the current bucket so "now" is always labeled. The newest label is anchored
-/// trailing so it renders fully instead of truncating at the plot edge ("Jul 4", not "J…").
+/// period (`StatPeriod.historyBucketCount` of them, current highlighted), with axis marks counted
+/// back from the current period at `StatPeriod.scrollAxisStride` so "now" is always labeled. The
+/// newest label is anchored trailing so it renders fully instead of truncating at the plot edge
+/// ("Jul 4", not "J…"), and on the week axis the mark right before it stays label-less so the two
+/// can't overlap.
 ///
 /// Tap or press-and-hold any bar to inspect it: a rule mark and a value card name the exact value and
 /// period, the touched bar lights up and the rest dim — the same gesture the scrollable capability
@@ -107,8 +109,7 @@ struct PeriodHistoryChart: View {
             .chartXSelection(value: $selectedDate)
             .chartXAxis {
                 if showsXAxisLabels {
-                    let axisStride = period.scrollAxisStride
-                    AxisMarks(values: .stride(by: axisStride.component, count: axisStride.count)) { value in
+                    AxisMarks(values: period.scrollAxisValues(firstDataDate: firstDataDate)) { value in
                         if let date = value.as(Date.self) {
                             let isCurrent = period.currentRange().contains(date)
                             AxisGridLine()
@@ -116,11 +117,17 @@ struct PeriodHistoryChart: View {
                             // Styling lives on the Text inside the label closure — hierarchical styles
                             // on the AxisMark resolve against the chart's accent on iOS 26 (labels
                             // turned lime). The current period hugs the right edge on first load, so
-                            // hang its label trailing off the mark to keep the edge from clipping it.
-                            AxisValueLabel(anchor: isCurrent ? .topTrailing : nil) {
-                                Text(period.axisLabel(for: date))
-                                    .font(.caption.weight(isCurrent ? .bold : .semibold))
-                                    .foregroundStyle(isCurrent ? Color.label : Color.secondaryLabel)
+                            // hang its label trailing off the mark to keep the edge from clipping it —
+                            // and the mark it hangs toward gives up its own label to make the room.
+                            // Except on the year axis: its single-period stride leaves no label-less
+                            // neighbor to hang into ("2025" must stay), and the year-wide gap to the
+                            // plot edge fits the centered label anyway.
+                            if !period.axisLabelYieldsToCurrent(date) {
+                                AxisValueLabel(anchor: isCurrent && period != .year ? .topTrailing : nil) {
+                                    Text(period.axisLabel(for: date))
+                                        .font(.caption.weight(isCurrent ? .bold : .semibold))
+                                        .foregroundStyle(isCurrent ? Color.label : Color.secondaryLabel)
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
## What

Three related x-axis label defects in the stat/capability charts, all fixed. The reported one: on the exercise/Summary period charts the current period's bold label collided with its neighbor (`6. Jul` under `20. Jul`) — or, on other weeks, the current period got no label at all.

### The three defects (one cause each)

- **Period charts** (Summary/exercise Volume, Sets, …): axis marks were strided from the **domain start**, so whether the current period got a mark — and whether its bold, trailing-anchored label collided with the neighbor — was parity luck. Marks are now counted back from the current period (`StatPeriod.scrollAxisValues`), so "now" is always labeled; on the week axis the mark it hangs toward **yields its label** (keeping its gridline) so the two can never overlap, in any locale.
- **Year axis**: the trailing-anchored current label pushed `2026` on top of `2025`. A year label has a full year-width of clearance to its right, so the current year label now centers like the rest — every year keeps its label.
- **Rolling-range charts** (capability, measurement, workout stats): the domain's last weekly mark sat close enough to the plot edge that its centered label truncated (`7/…`). Swift Charts truncates near-edge centered labels rather than overflowing, so it now hangs trailing off its mark and the mark before it yields its label — the same treatment as the period charts.

The three hand-copied `ChartRange` axes (capability / measurement / workout stat) are replaced by one shared `ChartRange.xAxisMarks(firstDataDate:)`.

## Verification

Captured the simulator matrix (iPhone 17 Pro, iOS 26.4) across **Week/Month/Year** and **3M/1Y/All** on the exercise Sets/Volume/Weight screens, Summary Volume, workout stats, measurement detail, and the muscle-balance candles, plus the single-workout scenario — all clean. Charts whose labels were already safe (narrow month letters, muscle-balance candles) were checked and left untouched. With zero workouts the stat screens aren't reachable, so there's no empty-state chart; the change touches nothing Pro-gated.

Before/after contact sheet: https://claude.ai/code/artifact/20445460-e091-4b78-aa45-cdb7fb87465d

## Files

- `LOGIT/Core/Enums/StatPeriod.swift` — `scrollAxisValues` + `axisLabelYieldsToCurrent`
- `LOGIT/SharedUI/Charts/PeriodHistoryChart.swift` — explicit marks; year label centers
- `LOGIT/SharedUI/Charts/CapabilityChartView.swift` — shared `ChartRange.xAxisMarks`
- `LOGIT/Features/Measurement/MeasurementDetailScreen.swift`, `LOGIT/Features/Workout/WorkoutStatScreen.swift` — use the shared builder

🤖 Generated with [Claude Code](https://claude.com/claude-code)