### PR TITLE
Superset: containerless per-exercise pager on the workout thread

### DIFF
--- a/LOGIT/App/TestScenarios.swift
+++ b/LOGIT/App/TestScenarios.swift
@@ -274,6 +274,41 @@ enum TestScenario: String {
             }
         }
 
+        // A superset at the very end (same coordinate-stability reason): the horizontal
+        // per-exercise pager, its bulge sockets, per-exercise badges and the thread's
+        // fork/merge rails need a superset in the recorder to be verifiable. Two pull
+        // exercises so the names are unique within this push workout, both with seeded
+        // history so each page's badge has a real current best.
+        let supersetGroup = database.newWorkoutSetGroup(
+            createFirstSetAutomatically: false,
+            exercise: rows,
+            workout: current
+        )
+        supersetGroup.secondaryExercise = bicepsCurls
+        // Weights sit just above the seeded histories' current bests so the two pages'
+        // badges show live gains (rows lands a record) rather than huge declines.
+        for setIndex in 0 ..< 3 {
+            let entered = setIndex < 2
+            database.newSuperSet(
+                repetitionsFirstExercise: entered ? 12 - setIndex : 0,
+                repetitionsSecondExercise: entered ? 12 - setIndex : 0,
+                weightFirstExercise: entered ? 140_000 : 0,
+                weightSecondExercise: entered ? 95000 : 0,
+                setGroup: supersetGroup
+            )
+        }
+
+        // One standard group after the superset so the thread's merge rail (drawn only when
+        // another group follows) is part of the verifiable picture.
+        let closingGroup = database.newWorkoutSetGroup(
+            createFirstSetAutomatically: false,
+            exercise: latPulldowns,
+            workout: current
+        )
+        for _ in 0 ..< 2 {
+            database.newStandardSet(setGroup: closingGroup)
+        }
+
         database.save()
         NSLog("TestScenario: seeded stress scenario (%d workouts)", sessionCount + 1)
     }

--- a/LOGIT/Core/Environment/de.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/de.lproj/Localizable.strings
@@ -69,6 +69,7 @@
 "creatingTemplateFailed" = "Generieren Fehlgeschlagen";
 "creatingTemplateFailedText" = "Stelle sicher, dass das Bild ein Workout enthält.";
 "currentBest" = "Aktueller Bestwert";
+"groupIndexOfTotal" = "%1$d von %2$d";
 "previousBest" = "Vorheriger Bestwert";
 "lastBest" = "Letzter Bestwert";
 "lastBestInfo" = "Wird angezeigt, wenn du diese Übung seit über 4 Wochen nicht trainiert hast – dein Bestwert aus der letzten Trainingseinheit.";

--- a/LOGIT/Core/Environment/en.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/en.lproj/Localizable.strings
@@ -69,6 +69,7 @@
 "creatingTemplateFailed" = "Creating Template Failed";
 "creatingTemplateFailedText" = "Make sure the selected image contains a workout.";
 "currentBest" = "Current Best";
+"groupIndexOfTotal" = "%1$d of %2$d";
 "previousBest" = "Previous Best";
 "lastBest" = "Last Best";
 "lastBestInfo" = "Shown when you haven't trained this exercise in over 4 weeks — your best from the most recent session you logged.";

--- a/LOGIT/Core/Environment/es.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/es.lproj/Localizable.strings
@@ -69,6 +69,7 @@
 "creatingTemplateFailed" = "Error al crear la plantilla";
 "creatingTemplateFailedText" = "Asegúrese de que la imagen seleccionada contenga un entrenamiento.";
 "currentBest" = "Mejor marca actual";
+"groupIndexOfTotal" = "%1$d de %2$d";
 "previousBest" = "Mejor marca anterior";
 "lastBest" = "Última mejor marca";
 "lastBestInfo" = "Se muestra cuando no entrenas este ejercicio desde hace más de 4 semanas: tu mejor marca de la sesión más reciente.";

--- a/LOGIT/Core/Environment/fr.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/fr.lproj/Localizable.strings
@@ -69,6 +69,7 @@
 "creatingTemplateFailed" = "Échec de la création du modèle";
 "creatingTemplateFailedText" = "Assurez-vous que l'image sélectionnée contient un entraînement.";
 "currentBest" = "Meilleur actuel";
+"groupIndexOfTotal" = "%1$d sur %2$d";
 "previousBest" = "Meilleur précédent";
 "lastBest" = "Dernier meilleur";
 "lastBestInfo" = "Affiché lorsque vous n'avez pas entraîné cet exercice depuis plus de 4 semaines : votre meilleur résultat de la séance la plus récente.";

--- a/LOGIT/Core/Environment/it.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/it.lproj/Localizable.strings
@@ -69,6 +69,7 @@
 "creatingTemplateFailed" = "Creazione del modello non riuscita";
 "creatingTemplateFailedText" = "Assicurati che l'immagine selezionata contenga un allenamento.";
 "currentBest" = "Migliore attuale";
+"groupIndexOfTotal" = "%1$d di %2$d";
 "previousBest" = "Migliore precedente";
 "lastBest" = "Ultima migliore";
 "lastBestInfo" = "Mostrato quando non alleni questo esercizio da più di 4 settimane: il tuo risultato migliore dall'ultima sessione.";

--- a/LOGIT/Core/Environment/ja.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/ja.lproj/Localizable.strings
@@ -69,6 +69,7 @@
 "creatingTemplateFailed" = "テンプレートの作成に失敗しました";
 "creatingTemplateFailedText" = "選択した画像にワークアウトが含まれていることを確認してください。";
 "currentBest" = "現在のベスト";
+"groupIndexOfTotal" = "%1$d / %2$d";
 "previousBest" = "以前のベスト";
 "lastBest" = "前回のベスト";
 "lastBestInfo" = "このエクササイズを4週間以上記録していないときに表示されます。直近のセッションでのベスト値です。";

--- a/LOGIT/Core/Environment/ko.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/ko.lproj/Localizable.strings
@@ -69,6 +69,7 @@
 "creatingTemplateFailed" = "템플릿 생성 실패";
 "creatingTemplateFailedText" = "선택한 이미지에 운동이 포함되어 있는지 확인하세요.";
 "currentBest" = "현재 최고";
+"groupIndexOfTotal" = "%1$d / %2$d";
 "previousBest" = "이전 최고";
 "lastBest" = "최근 최고";
 "lastBestInfo" = "이 운동을 4주 이상 기록하지 않았을 때 표시됩니다. 가장 최근 세션에서의 최고 기록입니다.";

--- a/LOGIT/Core/Environment/pt-BR.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/pt-BR.lproj/Localizable.strings
@@ -69,6 +69,7 @@
 "creatingTemplateFailed" = "Falha na criação do modelo";
 "creatingTemplateFailedText" = "Certifique-se de que a imagem selecionada contenha um treino.";
 "currentBest" = "Melhor atual";
+"groupIndexOfTotal" = "%1$d de %2$d";
 "previousBest" = "Melhor anterior";
 "lastBest" = "Última melhor";
 "lastBestInfo" = "Exibido quando você não treina este exercício há mais de 4 semanas: seu melhor resultado da sessão mais recente.";

--- a/LOGIT/Core/Extentions/Color+.swift
+++ b/LOGIT/Core/Extentions/Color+.swift
@@ -19,6 +19,12 @@ extension Color {
     static var secondaryBackground: Color { Color(UIColor.secondarySystemBackground) }
     static var tertiaryBackground: Color { Color(UIColor.tertiarySystemBackground) }
 
+    /// The workout thread (trunk between set groups, superset rails). Deliberately an OPAQUE
+    /// gray rather than the hierarchical `.secondary`: the thread's segments overlap by a
+    /// couple of points to seal their joins, and translucent strokes would compound into
+    /// brighter patches wherever they cross.
+    static var threadLine: Color { Color(UIColor.systemGray) }
+
     static var fill: Color { Color(UIColor.systemFill) }
     static var secondaryFill: Color { Color(UIColor.secondarySystemFill) }
     static var tertiaryFill: Color { Color(UIColor.tertiarySystemFill) }

--- a/LOGIT/Features/Workout/Cells/WorkoutSetCells/WorkoutSetCell.swift
+++ b/LOGIT/Features/Workout/Cells/WorkoutSetCells/WorkoutSetCell.swift
@@ -19,6 +19,10 @@ struct WorkoutSetCell: View {
     @ObservedObject var workoutSet: WorkoutSet
     @Binding var focusedIntegerFieldIndex: IntegerField.Index?
     let referenceSet: WorkoutSet?
+    /// When set, only the entries owned by this exercise render — the superset pager shows one
+    /// exercise's card per page. The entries keep their original positions in the set's entry
+    /// array so the keyboard-focus indices stay identical to the stacked layout.
+    let visibleExercise: Exercise?
     let onEditRestDuration: (() -> Void)?
     let onTapPreviousSet: ((Exercise) -> Void)?
 
@@ -30,12 +34,14 @@ struct WorkoutSetCell: View {
         workoutSet: WorkoutSet,
         focusedIntegerFieldIndex: Binding<IntegerField.Index?>,
         referenceSet: WorkoutSet? = nil,
+        visibleExercise: Exercise? = nil,
         onEditRestDuration: (() -> Void)? = nil,
         onTapPreviousSet: ((Exercise) -> Void)? = nil
     ) {
         self.workoutSet = workoutSet
         _focusedIntegerFieldIndex = focusedIntegerFieldIndex
         self.referenceSet = referenceSet
+        self.visibleExercise = visibleExercise
         self.onEditRestDuration = onEditRestDuration
         self.onTapPreviousSet = onTapPreviousSet
     }
@@ -121,7 +127,7 @@ struct WorkoutSetCell: View {
                 workoutRecorder.templateSet(for: workoutSet)?.entryValues ?? []
             VStack(spacing: 0) {
                 ForEach(
-                    Array(workoutSet.entries.enumerated()), id: \.element.objectID
+                    visibleIndexedEntries, id: \.element.objectID
                 ) { entryIndex, entry in
                     let entryExercise = workoutSet.owningExercise(of: entry)
                     SetEntryFieldsRow(
@@ -143,6 +149,15 @@ struct WorkoutSetCell: View {
 
     private var indexInWorkout: Int? {
         workoutSet.workout?.sets.firstIndex(of: workoutSet)
+    }
+
+    /// The set's entries with their original array positions, restricted to `visibleExercise`
+    /// when one is set (superset pages). Keeping the original offsets keeps the focus indices —
+    /// (set, entry, field) — identical however the entries are laid out.
+    private var visibleIndexedEntries: [(offset: Int, element: SetEntry)] {
+        let all = Array(workoutSet.entries.enumerated())
+        guard let visibleExercise else { return all }
+        return all.filter { workoutSet.owningExercise(of: $0.element) == visibleExercise }
     }
 
     /// The like-for-like reference entry from the previous workout's matching set: compound

--- a/LOGIT/Features/Workout/Cells/WorkoutSetGroupCell.swift
+++ b/LOGIT/Features/Workout/Cells/WorkoutSetGroupCell.swift
@@ -39,11 +39,17 @@ struct WorkoutSetGroupCell: View {
     /// `==`: the set cells derive their keyboard-focus indices from flat set positions, so a
     /// structural change in an earlier group has to re-render this cell's children too.
     var firstSetIndexInWorkout: Int = 0
+    /// Total number of set groups in the workout, for the "2 of 5" bulge label. Passed by the
+    /// list (and part of `==`) because adding or removing *another* group changes this cell's
+    /// total even when its own index stays put. Nil derives it from the workout (previews).
+    var groupCount: Int? = nil
     var onTapRestDuration: ((WorkoutSet) -> Void)? = nil
     var onReorderSetGroups: (() -> Void)? = nil
     var onTapPreviousSet: ((Exercise) -> Void)? = nil
     var onTapExerciseName: ((Exercise) -> Void)? = nil
-    var onTapMetricBadge: ((WorkoutSetGroup, CGRect) -> Void)? = nil
+    /// The tapped badge's set group, its subject exercise (each superset page has its own badge),
+    /// and the badge frame to anchor the info popover at.
+    var onTapMetricBadge: ((WorkoutSetGroup, Exercise?, CGRect) -> Void)? = nil
 
     // MARK: - State
 
@@ -59,6 +65,19 @@ struct WorkoutSetGroupCell: View {
     /// width budget can be derived as (column − badge reservation) and handed to `ExerciseHeader`.
     @State private var nameSlotWidth: CGFloat = 0
     @FocusState private var isNoteFieldFocused: Bool
+    /// Which exercise's page the superset pager is snapped to (objectID; nil = first page).
+    /// Also driven programmatically: when keyboard "next" focuses a field on the partner
+    /// exercise's page, the pager follows (see `autopageIfNeeded`).
+    @State private var pagedExerciseID: NSManagedObjectID?
+
+    // MARK: - Superset pager metrics
+
+    /// Horizontal inset of a snapped page — the neighbor page peeks by this minus the spacing.
+    static let pageInset: CGFloat = 24
+    static let pageSpacing: CGFloat = 12
+    /// Height of the band above (and below) the pages where the thread's horizontal rail and
+    /// its drops into the bulges are drawn.
+    static let railZoneHeight: CGFloat = 16
 
     // MARK: - Body
 
@@ -130,16 +149,76 @@ struct WorkoutSetGroupCell: View {
             }
         }
         .accentColor(setGroup.exercise?.muscleGroup?.color ?? .accentColor)
-        .padding(.bottom, canEdit || isReordering ? CELL_PADDING : CELL_PADDING / 2)
-        .background(
-            RoundedRectangle(cornerRadius: 30)
-                .fill(.shadow(.inner(color: .white.opacity(0.04), radius: 3)))
-                .foregroundStyle(Color.secondaryBackground)
-        )
-        .cornerRadius(30)
     }
 
+    /// A superset with both exercises chosen renders as containerless side-by-side pages; while
+    /// reordering (compact header row) or before the second exercise is picked it falls back to
+    /// the classic single card, whose header still offers the "select exercise" entry point.
+    @ViewBuilder
     private func content(previousSetGroup: WorkoutSetGroup?) -> some View {
+        if isPagedSuperset {
+            supersetPager(previousSetGroup: previousSetGroup)
+        } else {
+            standardCard(previousSetGroup: previousSetGroup)
+        }
+    }
+
+    private var isPagedSuperset: Bool {
+        setGroup.setType == .superSet
+            && setGroup.exercise != nil
+            && setGroup.secondaryExercise != nil
+            && !isReordering
+    }
+
+    // MARK: - Index bulge
+
+    private var resolvedIndexInWorkout: Int? {
+        indexInWorkout ?? setGroup.workout?.setGroups.firstIndex(of: setGroup)
+    }
+
+    private var resolvedGroupCount: Int {
+        groupCount ?? setGroup.workout?.setGroups.count ?? 0
+    }
+
+    /// "2 of 5" — the group's place in the workout, shown in the bulge socket on top of the card
+    /// (each superset page repeats it) instead of the old header number.
+    private var bulgeLabel: String? {
+        guard let index = resolvedIndexInWorkout, resolvedGroupCount > 0 else { return nil }
+        return String.localizedStringWithFormat(
+            NSLocalizedString("groupIndexOfTotal", comment: ""), index + 1, resolvedGroupCount
+        )
+    }
+
+    /// Whether the thread's merge rail is drawn under the superset pages — only when another
+    /// group follows, so the converged line has somewhere to continue to (the list draws the
+    /// trunk segment between cells).
+    private var showsMergeRail: Bool {
+        guard let index = resolvedIndexInWorkout else { return false }
+        return index < resolvedGroupCount - 1
+    }
+
+    /// Whether the fork rail is drawn above the superset pages — only when a group precedes,
+    /// so the rail has a trunk feeding it. On a first-group superset a floating rail with
+    /// nothing above just looks broken.
+    private var showsForkRail: Bool {
+        (resolvedIndexInWorkout ?? 0) > 0
+    }
+
+    // MARK: - Standard card
+
+    private func standardCard(previousSetGroup: WorkoutSetGroup?) -> some View {
+        standardCardBody(previousSetGroup: previousSetGroup)
+            .padding(.bottom, canEdit || isReordering ? CELL_PADDING : CELL_PADDING / 2)
+            .background(
+                RoundedRectangle(cornerRadius: 30)
+                    .fill(.shadow(.inner(color: .white.opacity(0.04), radius: 3)))
+                    .foregroundStyle(Color.secondaryBackground)
+            )
+            .cornerRadius(30)
+            .bulgeSocket(label: bulgeLabel)
+    }
+
+    private func standardCardBody(previousSetGroup: WorkoutSetGroup?) -> some View {
         VStack(spacing: CELL_PADDING) {
             header
                 .padding([.top, .horizontal], CELL_PADDING)
@@ -262,6 +341,7 @@ struct WorkoutSetGroupCell: View {
             if !isReordering, let workout = setGroup.workout {
                 MetricBadgeView(
                     setGroup: setGroup,
+                    subjectExercise: setGroup.exercise,
                     workout: workout,
                     isEditing: isFieldFocused,
                     onTapBadge: onTapMetricBadge
@@ -275,6 +355,96 @@ struct WorkoutSetGroupCell: View {
                 }
             }
         }
+    }
+
+    // MARK: - Superset pager
+
+    /// The containerless superset: one full-size card per exercise, paged horizontally, each
+    /// with its own bulge socket, metric badge and add-set controls. The thread's horizontal
+    /// rail rides in the band above the pages (and below them when another group follows) and
+    /// scrolls WITH the pages, so the fixed trunk the list draws between cells always meets it
+    /// at a right angle, whatever the scroll position.
+    private func supersetPager(previousSetGroup: WorkoutSetGroup?) -> some View {
+        let exercises = [setGroup.exercise, setGroup.secondaryExercise].compactMap { $0 }
+        return ScrollView(.horizontal) {
+            HStack(alignment: .top, spacing: Self.pageSpacing) {
+                ForEach(exercises, id: \.objectID) { exercise in
+                    SupersetExercisePage(
+                        setGroup: setGroup,
+                        exercise: exercise,
+                        isPrimaryPage: exercise == setGroup.exercise,
+                        bulgeLabel: bulgeLabel,
+                        focusedIntegerFieldIndex: $focusedIntegerFieldIndex,
+                        previousSetGroup: previousSetGroup,
+                        supplementaryText: supplementaryText,
+                        showDetailAsSheet: showDetailAsSheet,
+                        showPendingRestInTertiary: showPendingRestInTertiary,
+                        isFieldFocused: isFieldFocused,
+                        isEditingNote: $isEditingNote,
+                        onTapRestDuration: onTapRestDuration,
+                        onTapPreviousSet: onTapPreviousSet,
+                        onTapExerciseName: onTapExerciseName,
+                        onTapMetricBadge: onTapMetricBadge,
+                        groupMenu: AnyView(menu)
+                    )
+                    .containerRelativeFrame(.horizontal) { length, _ in
+                        max(length - Self.pageInset * 2, 100)
+                    }
+                }
+            }
+            .scrollTargetLayout()
+            .padding(.top, showsForkRail ? Self.railZoneHeight : 0)
+            .padding(.bottom, showsMergeRail ? Self.railZoneHeight : 0)
+            .overlay(alignment: .top) {
+                if showsForkRail {
+                    SupersetRailShape(pageCount: exercises.count, pageSpacing: Self.pageSpacing)
+                        .stroke(style: StrokeStyle(lineWidth: 3, lineCap: .round))
+                        .foregroundStyle(Color.threadLine)
+                        .frame(height: Self.railZoneHeight)
+                }
+            }
+            .overlay(alignment: .bottom) {
+                if showsMergeRail {
+                    SupersetRailShape(
+                        pageCount: exercises.count,
+                        pageSpacing: Self.pageSpacing,
+                        flipped: true
+                    )
+                    .stroke(style: StrokeStyle(lineWidth: 3, lineCap: .round))
+                    .foregroundStyle(Color.threadLine)
+                    .frame(height: Self.railZoneHeight)
+                }
+            }
+        }
+        // No content margins: the snapped first page sits flush with the leading edge (and
+        // the last page, clamped at the scroll bound, flush with the trailing edge) exactly
+        // like every non-superset cell. The pages being narrower than the column, their
+        // centers sit inside the fixed trunk's x — so the trunk always meets the rail's
+        // straight middle, and the elbows curve outward to the offset sockets. No scroll
+        // position can leave the trunk hanging past the rail's end.
+        .scrollTargetBehavior(.viewAligned)
+        .scrollClipDisabled()
+        .scrollIndicators(.hidden)
+        .scrollPosition(id: $pagedExerciseID)
+        .onChange(of: focusedIntegerFieldIndex) { _, newValue in
+            autopageIfNeeded(for: newValue, exercises: exercises)
+        }
+    }
+
+    /// Keyboard next/previous walks a set's entries, which alternate exercises in a superset —
+    /// when focus lands on a field whose entry belongs to the other exercise, the pager follows
+    /// so the focused field is never on an off-screen page.
+    private func autopageIfNeeded(for index: IntegerField.Index?, exercises: [Exercise]) {
+        guard let index else { return }
+        let localSetIndex = index.primary - firstSetIndexInWorkout
+        guard setGroup.sets.indices.contains(localSetIndex) else { return }
+        let workoutSet = setGroup.sets[localSetIndex]
+        guard workoutSet.entries.indices.contains(index.secondary),
+              let owner = workoutSet.owningExercise(of: workoutSet.entries[index.secondary])
+        else { return }
+        let currentID = pagedExerciseID ?? exercises.first?.objectID
+        guard owner.objectID != currentID else { return }
+        withAnimation(.snappy) { pagedExerciseID = owner.objectID }
     }
 
     // MARK: - Supporting Views
@@ -302,13 +472,6 @@ struct WorkoutSetGroupCell: View {
     private var header: some View {
         VStack(spacing: 8) {
             HStack(spacing: 10) {
-                if let indexInWorkout = indexInWorkout ?? setGroup.workout?.setGroups.firstIndex(of: setGroup) {
-                    Text("\(indexInWorkout + 1)")
-                        .font(.title)
-                        .fontWeight(.medium)
-                        .fontDesign(.rounded)
-                        .foregroundStyle(.secondary)
-                }
                 VStack(alignment: .leading, spacing: 0) {
                     ExerciseHeader(
                         exercise: setGroup.exercise,
@@ -556,6 +719,429 @@ extension WorkoutSetGroupCell: Equatable {
             && lhs.isFieldFocused == rhs.isFieldFocused
             && lhs.indexInWorkout == rhs.indexInWorkout
             && lhs.firstSetIndexInWorkout == rhs.firstSetIndexInWorkout
+            && lhs.groupCount == rhs.groupCount
+            // Superset cells DO re-render on focus moves (unlike everything else, which only
+            // cares whether the keyboard is up): their pager auto-pages to the exercise that
+            // owns the newly-focused field, and a skipped body would leave that `onChange`
+            // holding a stale focus value. Bounded cost — a workout has at most a few supersets.
+            && (lhs.setGroup.setType != .superSet
+                || lhs.focusedIntegerFieldIndex == rhs.focusedIntegerFieldIndex)
+    }
+}
+
+// MARK: - Index bulge
+
+/// The socket on top of every set-group card: a low rounded bump growing out of the card's top
+/// edge (concave fillets where it meets the card) that carries the group's "2 of 5" position
+/// and receives the thread the list draws between cells. The bump is deliberately lower than
+/// the label — the label's bottom half dips inside the card — and its fill continues a few
+/// points below the edge so the card's inner top highlight can't draw a seam under it. Layered
+/// with `bulgeSocket(label:)`, which draws it OVER the card.
+struct SetGroupIndexBulge: View {
+    let label: String
+
+    /// Height of the bump above the card's top edge — just enough headroom over the label's
+    /// peeking top, so the bump stays a low hill.
+    static let protrusion: CGFloat = 8
+    /// How far the bump's fill continues below the card edge.
+    static let underlap: CGFloat = 8
+    /// Horizontal run of each S-curved shoulder.
+    static let shoulderRun: CGFloat = 12
+    /// How tightly the shoulder S hugs its endpoints: 0.5 is a plain slope, towards 1 the
+    /// curve stays flat at both ends and turns in the middle. 0.75 is the chosen gentle S.
+    static let shoulderTension: CGFloat = 0.75
+    /// Horizontal padding between the label and the shoulders.
+    static let labelPadding: CGFloat = 8
+
+    var body: some View {
+        Text(label)
+            .font(.system(.caption2, design: .rounded, weight: .bold))
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, Self.labelPadding)
+            // Push the label down so it straddles the card edge — most of it sits inside
+            // the card, only its top peeks into the bump.
+            .offset(y: 3)
+            .frame(height: Self.protrusion + Self.underlap)
+            .background {
+                SetGroupBulgeShape(
+                    shoulderRun: Self.shoulderRun,
+                    shoulderTension: Self.shoulderTension,
+                    underlap: Self.underlap
+                )
+                .fill(Color.secondaryBackground)
+                // The shoulders flare beyond the label's bounds on both sides.
+                .padding(.horizontal, -Self.shoulderRun)
+            }
+    }
+}
+
+extension View {
+    /// Mounts the index bulge on top of a set-group card: drawn over the card (so the label's
+    /// lower half and the underlap sit on the card's fill), extending above it by the bump's
+    /// protrusion, which is reserved as layout space.
+    @ViewBuilder
+    func bulgeSocket(label: String?) -> some View {
+        if let label {
+            overlay(alignment: .top) {
+                SetGroupIndexBulge(label: label)
+                    .alignmentGuide(.top) { $0[.top] + SetGroupIndexBulge.protrusion }
+            }
+            .padding(.top, SetGroupIndexBulge.protrusion)
+        } else {
+            self
+        }
+    }
+}
+
+/// The bulge's outline: a smooth hill. Each side is one S-curve with horizontal tangents at
+/// both ends, so the concave blend into the card's edge and the convex top shoulder are both
+/// generously rounded — no straight walls, no sharp corners anywhere. Below the card edge the
+/// fill continues `underlap` points as a plain rectangle, hiding the card's inner top
+/// highlight under the bump. The rect includes the shoulders and the underlap.
+struct SetGroupBulgeShape: Shape {
+    var shoulderRun: CGFloat = 18
+    /// 0.5 = shallowest slope; towards 1 the S hugs its endpoints and turns harder mid-curve.
+    var shoulderTension: CGFloat = 0.55
+    var underlap: CGFloat = 8
+
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+        let edge = rect.maxY - underlap
+        let top = rect.minY
+        path.move(to: CGPoint(x: rect.minX, y: edge))
+        // Left shoulder: card edge up to the flat top in one S.
+        path.addCurve(
+            to: CGPoint(x: rect.minX + shoulderRun, y: top),
+            control1: CGPoint(x: rect.minX + shoulderRun * shoulderTension, y: edge),
+            control2: CGPoint(x: rect.minX + shoulderRun * (1 - shoulderTension), y: top)
+        )
+        path.addLine(to: CGPoint(x: rect.maxX - shoulderRun, y: top))
+        // Right shoulder, mirrored.
+        path.addCurve(
+            to: CGPoint(x: rect.maxX, y: edge),
+            control1: CGPoint(x: rect.maxX - shoulderRun * (1 - shoulderTension), y: top),
+            control2: CGPoint(x: rect.maxX - shoulderRun * shoulderTension, y: edge)
+        )
+        // Continue below the card edge so the bump covers the card's inner top highlight.
+        path.addLine(to: CGPoint(x: rect.maxX, y: rect.maxY))
+        path.addLine(to: CGPoint(x: rect.minX, y: rect.maxY))
+        path.closeSubpath()
+        return path
+    }
+}
+
+// MARK: - Superset thread rail
+
+/// The thread's horizontal rail across a superset's pages, drawn in the band above (or, flipped,
+/// below) them and scrolling with them: rounded elbows turn down into the first and last page's
+/// center, straight drops serve any pages in between. Page centers are derived from the band's
+/// own width, so the shape needs no measured geometry.
+struct SupersetRailShape: Shape {
+    let pageCount: Int
+    let pageSpacing: CGFloat
+    var flipped: Bool = false
+    var cornerRadius: CGFloat = 10
+
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+        guard pageCount > 0 else { return path }
+        let pageWidth = (rect.width - CGFloat(pageCount - 1) * pageSpacing) / CGFloat(pageCount)
+        let centers = (0 ..< pageCount).map { pageWidth / 2 + CGFloat($0) * (pageWidth + pageSpacing) }
+        let railY: CGFloat = 1.5
+        // Verticals overshoot the band by a couple of points into the neighboring fill (bulge
+        // below, card above once flipped) so no join can open an antialiasing hairline.
+        let overshoot = rect.height + 2
+        guard let first = centers.first, let last = centers.last, pageCount > 1 else {
+            path.move(to: CGPoint(x: centers[0], y: 0))
+            path.addLine(to: CGPoint(x: centers[0], y: overshoot))
+            return flipped ? path.flippedVertically(height: rect.height) : path
+        }
+        path.move(to: CGPoint(x: first, y: overshoot))
+        path.addLine(to: CGPoint(x: first, y: railY + cornerRadius))
+        path.addArc(
+            center: CGPoint(x: first + cornerRadius, y: railY + cornerRadius),
+            radius: cornerRadius,
+            startAngle: .degrees(180), endAngle: .degrees(270), clockwise: false
+        )
+        path.addLine(to: CGPoint(x: last - cornerRadius, y: railY))
+        path.addArc(
+            center: CGPoint(x: last - cornerRadius, y: railY + cornerRadius),
+            radius: cornerRadius,
+            startAngle: .degrees(270), endAngle: .degrees(0), clockwise: false
+        )
+        path.addLine(to: CGPoint(x: last, y: overshoot))
+        for center in centers.dropFirst().dropLast() {
+            path.move(to: CGPoint(x: center, y: railY))
+            path.addLine(to: CGPoint(x: center, y: overshoot))
+        }
+        return flipped ? path.flippedVertically(height: rect.height) : path
+    }
+}
+
+private extension Path {
+    func flippedVertically(height: CGFloat) -> Path {
+        applying(CGAffineTransform(scaleX: 1, y: -1).translatedBy(x: 0, y: -height))
+    }
+}
+
+// MARK: - Superset exercise page
+
+/// One exercise's card inside the superset pager: its own bulge socket, header, metric badge,
+/// set column (only this exercise's entry per set) and add-set controls. The group-level menu is
+/// built by the cell (it owns the exercise-selection and note state) and passed in.
+private struct SupersetExercisePage: View {
+    @Environment(\.canEdit) var canEdit: Bool
+    @EnvironmentObject var database: Database
+
+    @ObservedObject var setGroup: WorkoutSetGroup
+    let exercise: Exercise
+    let isPrimaryPage: Bool
+    let bulgeLabel: String?
+    @Binding var focusedIntegerFieldIndex: IntegerField.Index?
+    let previousSetGroup: WorkoutSetGroup?
+    let supplementaryText: String?
+    let showDetailAsSheet: Bool
+    let showPendingRestInTertiary: Bool
+    let isFieldFocused: Bool
+    @Binding var isEditingNote: Bool
+    let onTapRestDuration: ((WorkoutSet) -> Void)?
+    let onTapPreviousSet: ((Exercise) -> Void)?
+    let onTapExerciseName: ((Exercise) -> Void)?
+    let onTapMetricBadge: ((WorkoutSetGroup, Exercise?, CGRect) -> Void)?
+    let groupMenu: AnyView
+
+    @State private var metricBadgeWidth: CGFloat = 0
+    @State private var nameSlotWidth: CGFloat = 0
+    @FocusState private var isNoteFieldFocused: Bool
+
+    var body: some View {
+        card
+            .bulgeSocket(label: bulgeLabel)
+            .accentColor(exercise.muscleGroup?.color ?? .accentColor)
+    }
+
+    private var card: some View {
+        VStack(spacing: CELL_PADDING) {
+            header
+                .padding([.top, .horizontal], CELL_PADDING)
+            VStack(spacing: CELL_SPACING) {
+                ForEach(setGroup.sets, id: \.objectID) { workoutSet in
+                    VStack(spacing: CELL_SPACING) {
+                        WorkoutSetCell(
+                            workoutSet: workoutSet,
+                            focusedIntegerFieldIndex: $focusedIntegerFieldIndex,
+                            referenceSet: referenceSet(for: workoutSet),
+                            visibleExercise: exercise,
+                            onEditRestDuration: onTapRestDuration.map { callback in
+                                { callback(workoutSet) }
+                            },
+                            onTapPreviousSet: onTapPreviousSet
+                        )
+                        .contentShape(Rectangle())
+                        .background(
+                            RoundedRectangle(cornerRadius: 15)
+                                .fill(.shadow(.inner(color: .black.opacity(0.4), radius: 5)))
+                                .foregroundStyle(Color.tertiaryBackground)
+                        )
+                        .cornerRadius(15)
+                        .onDeleteView(disabled: !canEdit) {
+                            withAnimation(.interactiveSpring()) {
+                                database.delete(workoutSet)
+                            }
+                        }
+                        if setGroup.sets.last != workoutSet {
+                            if canEdit {
+                                RestTimerBetweenSetsView(
+                                    workoutSet: workoutSet,
+                                    showPendingRestInTertiary: showPendingRestInTertiary,
+                                    onTapRestDuration: onTapRestDuration.map { callback in
+                                        { callback(workoutSet) }
+                                    }
+                                )
+                            } else if workoutSet.restDurationSeconds > 0 {
+                                RestDurationLabel(seconds: workoutSet.restDurationSeconds)
+                                    .padding(.vertical, 2)
+                            }
+                        }
+                    }
+                }
+            }
+            .padding(.horizontal, CELL_PADDING / 2)
+            .animation(.interactiveSpring(), value: setGroup.sets)
+            if canEdit {
+                controls
+                    .padding(.horizontal, CELL_PADDING)
+            }
+        }
+        .padding(.bottom, canEdit ? CELL_PADDING : CELL_PADDING / 2)
+        .background(
+            RoundedRectangle(cornerRadius: 30)
+                .fill(.shadow(.inner(color: .white.opacity(0.04), radius: 3)))
+                .foregroundStyle(Color.secondaryBackground)
+        )
+        .cornerRadius(30)
+        .overlay(alignment: .topTrailing) {
+            badgeOverlay
+        }
+    }
+
+    private var header: some View {
+        VStack(spacing: 8) {
+            HStack(spacing: 10) {
+                VStack(alignment: .leading, spacing: 0) {
+                    ExerciseHeader(
+                        exercise: exercise,
+                        secondaryExercise: nil,
+                        noExerciseAction: {},
+                        noSecondaryExerciseAction: nil,
+                        isSuperSet: false,
+                        navigationToDetailEnabled: true,
+                        showDetailAsSheet: showDetailAsSheet,
+                        onTapExerciseName: onTapExerciseName,
+                        nameMaxWidth: exerciseNameWidth
+                    )
+                    HStack {
+                        Text(exercise.muscleGroup?.description ?? "")
+                            .foregroundColor(exercise.muscleGroup?.color ?? .accentColor)
+                        Spacer()
+                        if isPrimaryPage, let supplementaryText {
+                            Text(supplementaryText)
+                                .foregroundStyle(.secondary)
+                                .fontWeight(.medium)
+                        }
+                    }
+                    .font(.system(.footnote, design: .rounded, weight: .bold))
+                }
+                .onGeometryChange(for: CGFloat.self) { proxy in
+                    proxy.size.width
+                } action: { _, newWidth in
+                    nameSlotWidth = newWidth
+                }
+                Spacer()
+            }
+            // The note is a group-level field, rendered on every page (bound to the same text)
+            // so the pages keep identical heights and the thread's merge rail meets them evenly.
+            if isEditingNote || !(setGroup.note?.isEmpty ?? true) {
+                TextField(
+                    "Note",
+                    text: Binding(get: { setGroup.note ?? "" }, set: { setGroup.note = $0 }),
+                    prompt: Text(NSLocalizedString("addNote...", comment: "")),
+                    axis: .vertical
+                )
+                .focused($isNoteFieldFocused)
+                .onSubmit(of: .text) {
+                    setGroup.note = (setGroup.note ?? "") + "\n"
+                    isNoteFieldFocused = true
+                }
+                .lineLimit(1 ... 5)
+                .fixedSize(horizontal: false, vertical: true)
+                .font(.footnote)
+                .foregroundStyle(.tertiary)
+            }
+        }
+        .onChange(of: isNoteFieldFocused) {
+            if !isNoteFieldFocused {
+                isEditingNote = false
+            }
+        }
+    }
+
+    private var controls: some View {
+        HStack(spacing: 8) {
+            Button {
+                UIImpactFeedbackGenerator(style: .soft).impactOccurred()
+                withAnimation(.interactiveSpring()) {
+                    database.duplicateLastSet(from: setGroup)
+                }
+            } label: {
+                Image(systemName: "plus.square.on.square")
+                    .foregroundStyle((exercise.muscleGroup?.color ?? .accentColor).gradient)
+                    .font(.system(.body, design: .rounded, weight: .bold))
+                    .padding(15)
+                    .background(Color.accentColor.secondaryTranslucentBackground)
+                    .clipShape(Capsule())
+            }
+            .contextMenu {
+                Button {
+                    withAnimation(.interactiveSpring()) {
+                        database.duplicateLastWeight(from: setGroup)
+                    }
+                } label: {
+                    Label(NSLocalizedString("copyWeight", comment: ""), systemImage: "scalemass")
+                }
+                Button {
+                    withAnimation(.interactiveSpring()) {
+                        database.duplicateLastRepetitions(from: setGroup)
+                    }
+                } label: {
+                    Label(NSLocalizedString("copyRepetitions", comment: ""), systemImage: "repeat.circle")
+                }
+                Button {
+                    withAnimation(.interactiveSpring()) {
+                        database.duplicateLastSet(from: setGroup)
+                    }
+                } label: {
+                    Label(NSLocalizedString("copySet", comment: ""), systemImage: "plus.square.on.square")
+                }
+            }
+            Button {
+                UIImpactFeedbackGenerator(style: .soft).impactOccurred()
+                withAnimation(.interactiveSpring()) {
+                    database.addSet(to: setGroup)
+                }
+            } label: {
+                Label(
+                    NSLocalizedString("addSet", comment: ""),
+                    systemImage: "plus.circle.fill"
+                )
+                .foregroundStyle((exercise.muscleGroup?.color ?? .accentColor).gradient)
+                .font(.system(.body, design: .rounded, weight: .bold))
+                .padding(.vertical, 15)
+                .frame(maxWidth: .infinity)
+                .background(Color.accentColor.secondaryTranslucentBackground)
+                .clipShape(Capsule())
+            }
+            groupMenu
+        }
+    }
+
+    @ViewBuilder
+    private var badgeOverlay: some View {
+        if let workout = setGroup.workout {
+            MetricBadgeView(
+                setGroup: setGroup,
+                subjectExercise: exercise,
+                workout: workout,
+                isEditing: isFieldFocused,
+                onTapBadge: onTapMetricBadge
+            )
+            .onGeometryChange(for: CGFloat.self) { proxy in
+                proxy.size.width
+            } action: { _, newWidth in
+                metricBadgeWidth = newWidth
+            }
+        }
+    }
+
+    private var exerciseNameTrailingInset: CGFloat {
+        guard setGroup.workout != nil else { return 0 }
+        return max(0, metricBadgeWidth - CELL_PADDING + 8)
+    }
+
+    private var exerciseNameWidth: CGFloat? {
+        let inset = exerciseNameTrailingInset
+        guard inset > 0, nameSlotWidth > 0 else { return nil }
+        return max(40, nameSlotWidth - inset)
+    }
+
+    /// Same position-matched reference as the cell's; the set cell then matches the entry within
+    /// it by exercise (see `WorkoutSetCell.reference(for:at:in:)`).
+    private func referenceSet(for workoutSet: WorkoutSet) -> WorkoutSet? {
+        guard
+            let index = setGroup.sets.firstIndex(of: workoutSet),
+            let previousSetGroup
+        else { return nil }
+        return previousSetGroup.sets.value(at: index)
     }
 }
 
@@ -684,10 +1270,15 @@ private final class ExerciseHistoryBestsCache: @unchecked Sendable {
 /// so the badge's pill and the panel's spelled-out values can never tell different stories.
 private struct SetGroupMetricComparison {
     let setGroup: WorkoutSetGroup
+    /// The exercise this comparison scores. Each superset page passes its own; nil falls back to
+    /// the group's primary exercise (the only one there is everywhere else).
+    var subjectExercise: Exercise? = nil
+
+    private var exercise: Exercise? { subjectExercise ?? setGroup.exercise }
 
     /// This set group's best for `metric` — what the *session* achieved.
     func sessionBest(_ metric: ExercisePrimaryMetric) -> Int {
-        guard let exercise = setGroup.exercise else { return 0 }
+        guard let exercise else { return 0 }
         switch metric {
         case .estimatedOneRepMax: return setGroup.sets.map { $0.estimatedOneRepMax(for: exercise) }.max() ?? 0
         case .weight: return setGroup.sets.map { $0.maximum(.weight, for: exercise) }.max() ?? 0
@@ -706,7 +1297,7 @@ private struct SetGroupMetricComparison {
     /// comparison keeps telling that day's story even after later sessions surpass it. While
     /// recording, the window stays anchored at now — the two coincide there anyway.
     func currentBest(_ metric: ExercisePrimaryMetric) -> Int? {
-        guard let exercise = setGroup.exercise else { return nil }
+        guard let exercise else { return nil }
         let anchor = setGroup.workout?.isCurrentWorkout == true ? nil : setGroup.workout?.date
         return ExerciseHistoryBestsCache.shared.value(
             .currentBest,
@@ -720,7 +1311,7 @@ private struct SetGroupMetricComparison {
     }
 
     private func currentBestImpl(_ metric: ExercisePrimaryMetric) -> Int? {
-        guard let exercise = setGroup.exercise else { return nil }
+        guard let exercise else { return nil }
         let anchor = setGroup.workout?.isCurrentWorkout == true ? nil : setGroup.workout?.date
         var priorSets = exercise.sets.filter { $0.workout != setGroup.workout }
         if let anchor {
@@ -762,7 +1353,7 @@ private struct SetGroupMetricComparison {
     /// record has to clear (all-time, intentionally NOT the current-best window). Excludes the
     /// current workout.
     func previousAllTimeBest(_ metric: ExercisePrimaryMetric) -> Int {
-        guard let exercise = setGroup.exercise else { return 0 }
+        guard let exercise else { return 0 }
         return ExerciseHistoryBestsCache.shared.value(
             .allTimeBest,
             exercise: exercise,
@@ -775,7 +1366,7 @@ private struct SetGroupMetricComparison {
     }
 
     private func previousAllTimeBestImpl(_ metric: ExercisePrimaryMetric) -> Int {
-        guard let exercise = setGroup.exercise else { return 0 }
+        guard let exercise else { return 0 }
         let priorSets = exercise.sets.filter { $0.workout != setGroup.workout }
         switch metric {
         case .estimatedOneRepMax: return priorSets.map { $0.estimatedOneRepMax(for: exercise) }.max() ?? 0
@@ -811,6 +1402,9 @@ private struct SetGroupMetricComparison {
 /// they dismiss each other (UIKit only presents one thing per view controller at a time).
 private struct MetricBadgeView: View {
     @ObservedObject var setGroup: WorkoutSetGroup
+    /// The exercise this badge scores — each superset page shows its own badge; nil falls back
+    /// to the group's primary exercise.
+    let subjectExercise: Exercise?
     /// Observed so the badge re-renders on every recorder change. Editing a set mutates the set —
     /// and, via the recorder's autosave, the workout — but NOT this set group, so without observing
     /// the workout the badge would never re-evaluate while the user types, and live values plus PR
@@ -825,7 +1419,7 @@ private struct MetricBadgeView: View {
     /// presents the panel from the sheet's own context. Nil elsewhere, where the popover is fine.
     /// A plain parameter (not an environment value) so the recorder's per-render closure can't
     /// register every badge as environment-dependent on it.
-    let onTapBadge: ((WorkoutSetGroup, CGRect) -> Void)?
+    let onTapBadge: ((WorkoutSetGroup, Exercise?, CGRect) -> Void)?
     @StateObject private var peek = MetricPeekController()
 
     @State private var primaryMetric: ExercisePrimaryMetric = .estimatedOneRepMax
@@ -841,29 +1435,37 @@ private struct MetricBadgeView: View {
     /// The metric on screen — a peeked record while one plays, otherwise the chosen metric.
     private var displayedMetric: ExercisePrimaryMetric { peek.activeMetric ?? primaryMetric }
 
+    private var exercise: Exercise? { subjectExercise ?? setGroup.exercise }
+
     /// Session-vs-current-best math, shared with `MetricInfoPanel` so badge and panel always agree.
-    private var comparison: SetGroupMetricComparison { SetGroupMetricComparison(setGroup: setGroup) }
+    private var comparison: SetGroupMetricComparison {
+        SetGroupMetricComparison(setGroup: setGroup, subjectExercise: subjectExercise)
+    }
 
     private var displayedIsRecord: Bool { comparison.isPersonalRecord(displayedMetric) }
 
     init(
         setGroup: WorkoutSetGroup,
+        subjectExercise: Exercise? = nil,
         workout: Workout,
         isEditing: Bool,
-        onTapBadge: ((WorkoutSetGroup, CGRect) -> Void)? = nil
+        onTapBadge: ((WorkoutSetGroup, Exercise?, CGRect) -> Void)? = nil
     ) {
         _setGroup = ObservedObject(wrappedValue: setGroup)
+        self.subjectExercise = subjectExercise
         _workout = ObservedObject(wrappedValue: workout)
         self.isEditing = isEditing
         self.onTapBadge = onTapBadge
         // Resolve the committed metric up front so the very first render already evaluates the right
         // metric: the idle/empty decision below shouldn't wait on `onAppear`, and it spares a
         // first-frame roll up from the `.estimatedOneRepMax` default.
-        _primaryMetric = State(initialValue: setGroup.exercise?.primaryMetric ?? .defaultMetric)
+        _primaryMetric = State(
+            initialValue: (subjectExercise ?? setGroup.exercise)?.primaryMetric ?? .defaultMetric
+        )
     }
 
     var body: some View {
-        let accent = setGroup.exercise?.muscleGroup?.color ?? .accentColor
+        let accent = exercise?.muscleGroup?.color ?? .accentColor
         let displayed = displayedMetric
         let sessionBest = comparison.sessionBest(displayed)
         // Before this session's first entry there's nothing to trend, so rather than a dead "0 %"
@@ -889,20 +1491,20 @@ private struct MetricBadgeView: View {
                         UIImpactFeedbackGenerator(style: .soft).impactOccurred()
                         if let onTapBadge {
                             if badgeFrame != .zero {
-                                onTapBadge(setGroup, badgeFrame)
+                                onTapBadge(setGroup, exercise, badgeFrame)
                             }
                         } else {
                             isShowingInfo = true
                         }
                     }
                     .popover(isPresented: $isShowingInfo) {
-                        MetricInfoPanel(setGroup: setGroup, onOpenDetail: { metric in
+                        MetricInfoPanel(setGroup: setGroup, exercise: exercise, onOpenDetail: { metric in
                             detailMetric = metric
                             isShowingInfo = false
                             // Present after the popover's dismissal settles — competing presentations
                             // from the same host cancel each other.
                             DispatchQueue.main.asyncAfter(deadline: .now() + 0.45) {
-                                detailExercise = setGroup.exercise
+                                detailExercise = exercise
                             }
                         })
                         .padding()
@@ -919,7 +1521,7 @@ private struct MetricBadgeView: View {
                     .accessibilityLabel(Text(accessibilityDescription))
                     .accessibilityHint(Text(NSLocalizedString("tapForMetricInfo", comment: "")))
                     .onAppear {
-                        primaryMetric = setGroup.exercise?.primaryMetric ?? .defaultMetric
+                        primaryMetric = exercise?.primaryMetric ?? .defaultMetric
                         peek.seed(prSnapshot())
                         peek.setEditing(isEditing)
                     }
@@ -933,7 +1535,7 @@ private struct MetricBadgeView: View {
                 prs: prSnapshot(),
                 primary: primaryMetric,
                 order: ExercisePrimaryMetric.allowed(
-                    for: setGroup.exercise?.measurementType ?? .repsAndWeight
+                    for: exercise?.measurementType ?? .repsAndWeight
                 )
             )
         }
@@ -949,7 +1551,7 @@ private struct MetricBadgeView: View {
             // changes it itself — the info panel's picker (presented separately in the recorder)
             // and the exercise editor write it. Re-sync to it, cancelling any running peek so the
             // user's explicit choice is what lands on screen.
-            let current = setGroup.exercise?.primaryMetric ?? .defaultMetric
+            let current = exercise?.primaryMetric ?? .defaultMetric
             guard current != primaryMetric else { return }
             peek.cancelForManualCycle()
             withAnimation(MetricPeekController.rollAnimation) {
@@ -1290,21 +1892,35 @@ struct MetricInfoPanel: View {
     /// Called when the value/chart row is tapped — the host opens the exercise detail at this
     /// metric's chart screen. The row isn't tappable when nil.
     var onOpenDetail: ((ExercisePrimaryMetric) -> Void)?
+    /// The exercise the panel scores and charts — the tapped badge's subject (each superset page
+    /// carries its own badge). Nil falls back to the group's primary exercise.
+    let subjectExercise: Exercise?
     @State private var selectedMetric: ExercisePrimaryMetric
 
     private let metrics = ExercisePrimaryMetric.allCases
 
-    /// Same math as the badge — see the type's doc.
-    private var comparison: SetGroupMetricComparison { SetGroupMetricComparison(setGroup: setGroup) }
+    private var exercise: Exercise? { subjectExercise ?? setGroup.exercise }
 
-    init(setGroup: WorkoutSetGroup, onOpenDetail: ((ExercisePrimaryMetric) -> Void)? = nil) {
+    /// Same math as the badge — see the type's doc.
+    private var comparison: SetGroupMetricComparison {
+        SetGroupMetricComparison(setGroup: setGroup, subjectExercise: subjectExercise)
+    }
+
+    init(
+        setGroup: WorkoutSetGroup,
+        exercise: Exercise? = nil,
+        onOpenDetail: ((ExercisePrimaryMetric) -> Void)? = nil
+    ) {
         _setGroup = ObservedObject(wrappedValue: setGroup)
+        self.subjectExercise = exercise
         self.onOpenDetail = onOpenDetail
-        _selectedMetric = State(initialValue: setGroup.exercise?.primaryMetric ?? .defaultMetric)
+        _selectedMetric = State(
+            initialValue: (exercise ?? setGroup.exercise)?.primaryMetric ?? .defaultMetric
+        )
     }
 
     var body: some View {
-        let color = setGroup.exercise?.muscleGroup?.color ?? .accentColor
+        let color = exercise?.muscleGroup?.color ?? .accentColor
         // Nothing has ever been logged for this metric — a brand-new exercise, or e1RM on one only
         // ever trained above 12 reps. The scoreboard would read "––" vs "––" over a blank chart, so
         // show the shared empty state instead (see `emptyState`). `metricPoints` spans the whole
@@ -1415,7 +2031,7 @@ struct MetricInfoPanel: View {
         guard metric != selectedMetric else { return }
         UISelectionFeedbackGenerator().selectionChanged()
         selectedMetric = metric
-        setGroup.exercise?.primaryMetric = metric
+        exercise?.primaryMetric = metric
     }
 
     private func explanation(for metric: ExercisePrimaryMetric) -> String {
@@ -1476,7 +2092,7 @@ struct MetricInfoPanel: View {
     /// where the comparison's does (the domain would clip them anyway, but a Catmull-Rom segment
     /// into a clipped point still bends the visible line).
     private func metricPoints(for metric: ExercisePrimaryMetric) -> [TileSparklinePoint] {
-        guard let exercise = setGroup.exercise else { return [] }
+        guard let exercise else { return [] }
         let grouped = Dictionary(grouping: exercise.sets) {
             Calendar.current.startOfDay(for: $0.workout?.date ?? .now)
         }

--- a/LOGIT/Features/Workout/WorkoutRecorder/WorkoutRecorderScreen.swift
+++ b/LOGIT/Features/Workout/WorkoutRecorder/WorkoutRecorderScreen.swift
@@ -62,6 +62,8 @@ struct WorkoutRecorderScreen: View {
     /// screen it should jump to; nil for the regular name/previous-set entry points.
     @State private var exerciseDetailAutoMetric: ExercisePrimaryMetric?
     @State private var metricInfoSetGroup: WorkoutSetGroup?
+    /// The tapped badge's subject exercise — each superset page has its own badge.
+    @State private var metricInfoExercise: Exercise?
     @State private var metricInfoSourceRect: CGRect?
     @State private var scrollToRecentAttempts = false
     /// Plain `@State` holding a reference type on purpose: the screen must keep the instance
@@ -112,8 +114,9 @@ struct WorkoutRecorderScreen: View {
                                     // popover presented from it would dismiss that sheet. The popover
                                     // is instead presented from the sheet's own view controller
                                     // (below), anchored back to the badge, so the sheet survives.
-                                    onTapMetricBadge: { setGroup, frame in
+                                    onTapMetricBadge: { setGroup, exercise, frame in
                                         metricInfoSetGroup = setGroup
+                                        metricInfoExercise = exercise
                                         metricInfoSourceRect = frame
                                     }
                                 )
@@ -247,17 +250,20 @@ struct WorkoutRecorderScreen: View {
                                     .background(
                                         MetricInfoPopoverPresenter(
                                             setGroup: metricInfoSetGroup,
+                                            exercise: metricInfoExercise,
                                             anchorRect: metricInfoSourceRect,
                                             purchaseManager: purchaseManager,
                                             networkMonitor: networkMonitor,
                                             onDismiss: {
                                                 metricInfoSetGroup = nil
+                                                metricInfoExercise = nil
                                                 metricInfoSourceRect = nil
                                             },
                                             onOpenDetail: { exercise, metric in
                                                 // Close the popover first; presenting the detail
                                                 // sheet mid-dismissal would cancel one of the two.
                                                 metricInfoSetGroup = nil
+                                                metricInfoExercise = nil
                                                 metricInfoSourceRect = nil
                                                 scrollToRecentAttempts = false
                                                 exerciseDetailAutoMetric = metric
@@ -936,6 +942,9 @@ struct WorkoutRecorderView_Previews: PreviewProvider {
 /// positions next to the rect in window space.
 private struct MetricInfoPopoverPresenter: UIViewRepresentable {
     let setGroup: WorkoutSetGroup?
+    /// The tapped badge's subject exercise (a superset page's own); nil falls back to the
+    /// group's primary exercise inside the panel.
+    let exercise: Exercise?
     let anchorRect: CGRect?
     /// Injected into the panel's hosting controller — environment objects don't cross the UIKit
     /// bridge, and the panel's Pro gate (and the upgrade screen it presents) needs them.
@@ -960,6 +969,7 @@ private struct MetricInfoPopoverPresenter: UIViewRepresentable {
         if let setGroup, let anchorRect {
             context.coordinator.presentIfNeeded(
                 for: setGroup,
+                exercise: exercise,
                 anchoredAt: anchorRect,
                 embeddedIn: uiView,
                 purchaseManager: purchaseManager,
@@ -979,6 +989,7 @@ private struct MetricInfoPopoverPresenter: UIViewRepresentable {
 
         func presentIfNeeded(
             for setGroup: WorkoutSetGroup,
+            exercise: Exercise?,
             anchoredAt globalRect: CGRect,
             embeddedIn embeddedView: UIView,
             purchaseManager: PurchaseManager,
@@ -999,8 +1010,8 @@ private struct MetricInfoPopoverPresenter: UIViewRepresentable {
                 while let presented = presenter.presentedViewController { presenter = presented }
 
                 let host = UIHostingController(
-                    rootView: MetricInfoPanel(setGroup: setGroup, onOpenDetail: { [weak self] metric in
-                        guard let exercise = setGroup.exercise else { return }
+                    rootView: MetricInfoPanel(setGroup: setGroup, exercise: exercise, onOpenDetail: { [weak self] metric in
+                        guard let exercise = exercise ?? setGroup.exercise else { return }
                         self?.onOpenDetail(exercise, metric)
                     })
                     .padding()

--- a/LOGIT/Features/Workout/WorkoutSetGroupList.swift
+++ b/LOGIT/Features/Workout/WorkoutSetGroupList.swift
@@ -24,8 +24,13 @@ struct WorkoutSetGroupList: View, Equatable {
     var onTapPreviousSet: ((Exercise) -> Void)? = nil
     var onTapExerciseName: ((Exercise) -> Void)? = nil
     /// Recorder only: routes a metric-badge tap up so the popover is presented from the
-    /// recorder's persistent sheet (see `MetricBadgeView.onTapBadge`).
-    var onTapMetricBadge: ((WorkoutSetGroup, CGRect) -> Void)? = nil
+    /// recorder's persistent sheet (see `MetricBadgeView.onTapBadge`). The exercise is the
+    /// tapped badge's subject — each superset page carries its own badge.
+    var onTapMetricBadge: ((WorkoutSetGroup, Exercise?, CGRect) -> Void)? = nil
+
+    /// Trunk length between consecutive set groups — deliberately tighter than
+    /// `SECTION_SPACING`; the bulge's protrusion adds its own visual air on top.
+    static let groupConnectorHeight: CGFloat = 12
 
     // MARK: - State
 
@@ -34,8 +39,9 @@ struct WorkoutSetGroupList: View, Equatable {
     // MARK: - Body
 
     var body: some View {
-        VStack(spacing: 0) {
-            ForEach(indexedSetGroups, id: \.setGroup.id) { entry in
+        let indexedGroups = indexedSetGroups
+        return VStack(spacing: 0) {
+            ForEach(indexedGroups, id: \.setGroup.id) { entry in
                 VStack(spacing: 0) {
                     WorkoutSetGroupCell(
                         setGroup: entry.setGroup,
@@ -46,16 +52,25 @@ struct WorkoutSetGroupList: View, Equatable {
                         isFieldFocused: focusedIntegerFieldIndex != nil,
                         indexInWorkout: entry.index,
                         firstSetIndexInWorkout: entry.firstSetIndex,
+                        groupCount: indexedGroups.count,
                         onTapRestDuration: onTapRestDuration,
                         onReorderSetGroups: onReorderSetGroups,
                         onTapPreviousSet: onTapPreviousSet,
                         onTapExerciseName: onTapExerciseName,
                         onTapMetricBadge: onTapMetricBadge
                     )
-                    .shadow(color: .black.opacity(reduceShadow ? 0.5 : 1.0), radius: 5)
-                    .zIndex(1)
                     setGroupConnector(for: entry.setGroup)
                 }
+                // One compositing group per row so the drop shadow applies to the row's
+                // union silhouette. Shadowing the raw subtree shadows every primitive
+                // individually, and the cards' black shadows blacked out the thread
+                // wherever a line met a card, a bulge or a superset rail — reading as
+                // gaps in the line.
+                .compositingGroup()
+                .shadow(color: .black.opacity(reduceShadow ? 0.5 : 1.0), radius: 5)
+                // Earlier rows render above later ones so the connector's tip enters the
+                // next cell's bulge OVER that row's shadow instead of being eaten by it.
+                .zIndex(Double(indexedGroups.count - entry.index))
                 .transition(.scale)
                 .id(entry.setGroup)
             }
@@ -87,18 +102,25 @@ struct WorkoutSetGroupList: View, Equatable {
                 restCapsule(for: lastSet)
             }
         } else {
+            // The trunk overshoots 2pt into the cell above (behind the superset rail or card
+            // edge) and into the bulge below, sealing the joins against antialiasing hairlines.
+            // Layout height stays untouched — only the drawing overflows. Opaque thread color:
+            // the overshoots cross other thread strokes, and translucent ones would compound
+            // into brighter patches there.
             if hasRest, let lastSet {
                 restCapsule(for: lastSet)
-                    .padding(.vertical, SECTION_SPACING / 2)
+                    .padding(.vertical, Self.groupConnectorHeight / 2)
                     .background(
                         Rectangle()
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(Color.threadLine)
                             .frame(width: 3)
+                            .padding(.vertical, -2)
                     )
             } else {
                 Rectangle()
-                    .foregroundStyle(.secondary)
-                    .frame(width: 3, height: SECTION_SPACING)
+                    .foregroundStyle(Color.threadLine)
+                    .frame(width: 3, height: Self.groupConnectorHeight + 4)
+                    .frame(height: Self.groupConnectorHeight)
             }
         }
     }

--- a/LOGITUITests/ScenarioScreenshots.swift
+++ b/LOGITUITests/ScenarioScreenshots.swift
@@ -86,6 +86,67 @@ final class ScenarioScreenshots: XCTestCase {
         attach(app, "plank_detail_duration_tiles")
     }
 
+    /// Read-only superset pager on a finished workout: the fixture Arm Day starts with a
+    /// Biceps Curls + Triceps Extensions superset. Uses the marketing pipeline's
+    /// `workoutDetail` deep link, which pushes the detail directly — tapping the History
+    /// cell flakily landed on the floating start-workout button instead.
+    func testWorkoutDetailSuperset() {
+        let app = XCUIApplication(bundleIdentifier: ".com.lukaskbl.LOGIT")
+        app.launchArguments += [
+            "-UITEST_FIXTURES",
+            "-UITEST_DEEPLINK", "workoutDetail",
+            "-AppleLanguages", "(en)",
+            "-AppleLocale", "en_US",
+        ]
+        app.launch()
+
+        // The superset is Arm Day's first group — visible without scrolling.
+        let curlsHeader = app.staticTexts["Biceps Curls"].firstMatch
+        XCTAssertTrue(
+            curlsHeader.waitForExistence(timeout: 20),
+            "Superset group not reachable in workout detail"
+        )
+        waitABit(2)
+        attach(app, "workout_detail_superset")
+    }
+
+    /// The containerless superset pager at the end of the stress current workout: page 1
+    /// (Incline Bench Press) with its bulge socket and the thread's fork/merge rails, then a
+    /// horizontal swipe to the partner page (Barbell Rows) with its own metric badge.
+    func testRecorderSupersetPager() {
+        let app = launchApp(
+            scenario: "stress",
+            extraArguments: ["-UITEST_SHOW_RECORDER", "-UITEST_NO_SHEET"]
+        )
+
+        let nameField = app.textFields.matching(NSPredicate(format: "value == 'Push Day'")).firstMatch
+        XCTAssertTrue(nameField.waitForExistence(timeout: 15), "Recorder never presented")
+        waitABit(2)
+
+        let rowsHeader = app.staticTexts["Barbell Rows"].firstMatch
+        for _ in 0 ..< 14 where !rowsHeader.isHittable {
+            app.swipeUp()
+        }
+        XCTAssertTrue(rowsHeader.waitForExistence(timeout: 5), "Superset group not reachable")
+        waitABit(1)
+        attach(app, "recorder_superset_page1")
+
+        // Swipe the pager itself (a horizontal drag across the card) to the partner page.
+        let base = rowsHeader.coordinate(withNormalizedOffset: .zero)
+        base.withOffset(CGVector(dx: 240, dy: 90)).press(
+            forDuration: 0.05,
+            thenDragTo: base.withOffset(CGVector(dx: -80, dy: 90)),
+            withVelocity: 800,
+            thenHoldForDuration: 0.3
+        )
+        waitABit(1)
+        XCTAssertTrue(
+            app.staticTexts["Biceps Curls"].firstMatch.waitForExistence(timeout: 5),
+            "Partner page not shown after horizontal swipe"
+        )
+        attach(app, "recorder_superset_page2")
+    }
+
     // MARK: - Workout recorder (Transmission presentation)
     //
     // Note on element queries: while the persistent exercise tray sheet is


### PR DESCRIPTION
## What

Redesigns the superset UI around two ideas: **per-exercise pages** and a **connecting thread**.

- A superset renders as full-size per-exercise cells paged horizontally — no parent card. Pages snap flush with the leading/trailing edges like every non-superset cell; the partner peeks beside them.
- Each page has its own header, muscle accent, add-set controls and **its own metric badge** — the secondary exercise gets real progress feedback for the first time (`MetricBadgeView`/`SetGroupMetricComparison`/`MetricInfoPanel` take a subject exercise, threaded through the recorder's popover presenter).
- Every set-group card wears a low, S-curved **bulge socket** carrying "n of N" (replaces the big header index number; new `groupIndexOfTotal` key in all 8 locales).
- A gray **thread** runs the workout: a 12pt trunk between groups, forking at 90° into a horizontal rail across a superset's pages — drawn inside the scroll content so it slides with them, with elbows curving out to the first/last sockets and straight drops for middles — and merging below. Fork/merge only draw when a group precedes/follows.
- Keyboard next/previous walks a set's entries, which alternate exercises — the pager auto-follows the exercise owning the newly focused field (superset cells opt into focus-value re-renders in `Equatable`; everything else keeps the cheap skip).

## Rendering invariants

- The thread is **opaque** (`Color.threadLine`): joins are sealed with ~2pt overshoots, and translucent strokes would compound into brighter patches where they cross.
- List rows (cell + connector) shadow as one `compositingGroup` with descending zIndex — per-primitive shadows blacked out the thin lines (read as gaps).
- `WorkoutSetCell.visibleExercise` filters entries per page while keeping original entry offsets, so keyboard focus indices are identical to the stacked layout.

## Fixtures & tests

- Stress recorder workout gains a rows+curls superset and a closing group so the pager, badges, fork and merge are all in the standing verification suite.
- New: `testRecorderSupersetPager` (swipe to partner page) and `testWorkoutDetailSuperset` (read-only detail via the `workoutDetail` deep link — History-cell taps flakily landed on the floating start button).
- Verified: full scenario matrix (empty/one/many/free), all six recorder presentation tests, and native-pixel junction crops at every scroll position.

Follow-ups (not in this PR): template editor still uses the stacked superset layout; >2-exercise supersets need the data-model change; auto-advance on set completion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)