### PR TITLE
Templates: adopt the workout set-group design, and keep the two in lock-step

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -221,6 +221,38 @@ that are committed to the repo.
   navigation inside `LOGITUITests/LOGITScreenshots.swift` rather than
   skipping the test.
 
+### Templates mirror workouts (keep them in lock-step)
+
+A template is the blueprint of a workout, so the two must look and behave like
+one product. **Any change to how a workout's set groups or sets are presented
+must be applied to the template side in the same change** - never leave the
+template editor/detail looking like the previous generation of the workout UI.
+
+The paired surfaces are:
+
+| Workout | Template |
+| --- | --- |
+| `WorkoutSetGroupCell` | `TemplateSetGroupCell` |
+| `WorkoutSetCell` | `TemplateSetCell` |
+| `WorkoutSetGroupList` (recorder + `WorkoutDetailScreen`) | `TemplateEditorScreen` + `TemplateDetailScreen` lists |
+
+Shared visual vocabulary lives in `LOGIT/SharedUI/Views/SetGroupThread.swift`
+(the thread's trunk, index bulge, superset rails, row shadow/z-order) and in
+`Color.threadLine`. Put anything both sides draw there rather than duplicating
+it, so a tweak lands on both at once.
+
+**Only mirror what actually exists on both sides.** Some concepts are
+workout-only because a template has no session to compare against or run:
+per-exercise metric/improvement badges, previous-set reference values,
+personal-record peeks, the live rest timer/chronograph, and the session note.
+Templates likewise own things workouts don't (planned rest display states). When
+a workout change touches a workout-only concept, note that in the PR instead of
+inventing a template equivalent.
+
+When you do change a paired surface, verify the template screens too - the
+scenario matrix already captures Templates (`*_04_templates`), and
+`ScenarioScreenshots.testTemplateEditorSuperset` covers the superset layout.
+
 ## Known quirks
 
 - **Leading-dot bundle ID.** The registered App IDs in Apple's Developer

--- a/LOGIT.xcodeproj/project.pbxproj
+++ b/LOGIT.xcodeproj/project.pbxproj
@@ -163,6 +163,7 @@
 		801BBDE62DF7338A00CDB1FB /* ExerciseRepetitionsTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBCEA2DF7338A00CDB1FB /* ExerciseRepetitionsTile.swift */; };
 		801BBDE72DF7338A00CDB1FB /* UIConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBCAB2DF7338A00CDB1FB /* UIConstants.swift */; };
 		801BBDE82DF7338A00CDB1FB /* ExerciseHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBD4F2DF7338A00CDB1FB /* ExerciseHeader.swift */; };
+		80TH00022F80AA0100TH0002 /* SetGroupThread.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80TH00012F80AA0100TH0001 /* SetGroupThread.swift */; };
 		801BBDE92DF7338A00CDB1FB /* UIScreen+ScreenCorners.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBCB42DF7338A00CDB1FB /* UIScreen+ScreenCorners.swift */; };
 		801BBDEA2DF7338A00CDB1FB /* EnvironmentValues+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBCA72DF7338A00CDB1FB /* EnvironmentValues+.swift */; };
 		801BBDEB2DF7338A00CDB1FB /* WorkoutDetailScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBD272DF7338A00CDB1FB /* WorkoutDetailScreen.swift */; };
@@ -524,6 +525,7 @@
 		801BBD4C2DF7338A00CDB1FB /* TileStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TileStyle.swift; sourceTree = "<group>"; };
 		801BBD4E2DF7338A00CDB1FB /* CurrentWorkoutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentWorkoutView.swift; sourceTree = "<group>"; };
 		801BBD4F2DF7338A00CDB1FB /* ExerciseHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseHeader.swift; sourceTree = "<group>"; };
+		80TH00012F80AA0100TH0001 /* SetGroupThread.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetGroupThread.swift; sourceTree = "<group>"; };
 		801BBD502DF7338A00CDB1FB /* FlashView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlashView.swift; sourceTree = "<group>"; };
 		801BBD512DF7338A00CDB1FB /* InfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoView.swift; sourceTree = "<group>"; };
 		801BBD522DF7338A00CDB1FB /* IntegerField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegerField.swift; sourceTree = "<group>"; };
@@ -1269,6 +1271,7 @@
 				8054E6B52F1DB513003F150D /* ComparisonBar.swift */,
 				801BBD4E2DF7338A00CDB1FB /* CurrentWorkoutView.swift */,
 				801BBD4F2DF7338A00CDB1FB /* ExerciseHeader.swift */,
+				80TH00012F80AA0100TH0001 /* SetGroupThread.swift */,
 				801BBD502DF7338A00CDB1FB /* FlashView.swift */,
 				801BBD512DF7338A00CDB1FB /* InfoView.swift */,
 				E1E1E1000000000000000F07 /* AboutSection.swift */,
@@ -1795,6 +1798,7 @@
 				80DI00062F84DD0100DI0006 /* ExerciseDistanceTile.swift in Sources */,
 				801BBDE72DF7338A00CDB1FB /* UIConstants.swift in Sources */,
 				801BBDE82DF7338A00CDB1FB /* ExerciseHeader.swift in Sources */,
+				80TH00022F80AA0100TH0002 /* SetGroupThread.swift in Sources */,
 				801BBDE92DF7338A00CDB1FB /* UIScreen+ScreenCorners.swift in Sources */,
 				801BBDEA2DF7338A00CDB1FB /* EnvironmentValues+.swift in Sources */,
 				801BBDEB2DF7338A00CDB1FB /* WorkoutDetailScreen.swift in Sources */,

--- a/LOGIT/Data/Database/Database+Preview.swift
+++ b/LOGIT/Data/Database/Database+Preview.swift
@@ -150,8 +150,23 @@ extension Database {
         addTemplateSet(exercise: benchpress, template: pushTemplate, reps: 8, weight: 70000, extraSets: 3)
         addTemplateSet(exercise: inclinedBenchpress, template: pushTemplate, reps: 10, weight: 55000)
         addTemplateSet(exercise: overheadPress, template: pushTemplate, reps: 8, weight: 45000)
-        addTemplateSet(exercise: tricepsExtensions, template: pushTemplate, reps: 12, weight: 25000)
-        addTemplateSet(exercise: lateralRaises, template: pushTemplate, reps: 15, weight: 12000)
+        // A superset finisher — templates render these as the containerless per-exercise pager
+        // (see `TemplateSetGroupCell`), so the fixtures have to contain one.
+        let pushFinisher = database.newTemplateSetGroup(
+            createFirstSetAutomatically: false,
+            exercise: tricepsExtensions,
+            template: pushTemplate
+        )
+        pushFinisher.secondaryExercise = lateralRaises
+        for _ in 0 ..< 3 {
+            database.newTemplateSuperSet(
+                repetitionsFirstExercise: 12,
+                repetitionsSecondExercise: 15,
+                weightFirstExercise: 25000,
+                weightSecondExercise: 12000,
+                setGroup: pushFinisher
+            )
+        }
 
         let pullTemplate = database.newTemplate(name: NSLocalizedString("previewPullDay", comment: ""))
         addTemplateSet(exercise: deadlift, template: pullTemplate, reps: 5, weight: 120000, extraSets: 3)

--- a/LOGIT/Features/Template/Cells/TemplateSetCells/TemplateSetCell.swift
+++ b/LOGIT/Features/Template/Cells/TemplateSetCells/TemplateSetCell.swift
@@ -17,6 +17,10 @@ struct TemplateSetCell: View {
 
     @ObservedObject var templateSet: TemplateSet
     @Binding var focusedIntegerFieldIndex: IntegerField.Index?
+    /// When set, only the entries owned by this exercise render — the superset pager shows one
+    /// exercise's card per page. The entries keep their original positions in the set's entry
+    /// array so the keyboard-focus indices stay identical to the stacked layout.
+    var visibleExercise: Exercise? = nil
     let onEditRestDuration: (() -> Void)?
 
     // MARK: - Body
@@ -88,7 +92,7 @@ struct TemplateSetCell: View {
         if let setID = templateSet.id {
             VStack(spacing: 0) {
                 ForEach(
-                    Array(templateSet.entries.enumerated()), id: \.element.objectID
+                    visibleIndexedEntries, id: \.element.objectID
                 ) { entryIndex, entry in
                     let entryExercise = templateSet.owningExercise(of: entry)
                     SetEntryFieldsRow(
@@ -213,6 +217,15 @@ struct TemplateSetCell: View {
     }
 
     // MARK: - Supporting Methods
+
+    /// The set's entries with their original array positions, restricted to `visibleExercise`
+    /// when one is set (superset pages). Keeping the original offsets keeps the focus indices —
+    /// (set id, entry, field) — identical however the entries are laid out.
+    private var visibleIndexedEntries: [(offset: Int, element: TemplateSetEntry)] {
+        let all = Array(templateSet.entries.enumerated())
+        guard let visibleExercise else { return all }
+        return all.filter { templateSet.owningExercise(of: $0.element) == visibleExercise }
+    }
 
     private var indexInSetGroup: Int? {
         templateSet.setGroup?.sets.firstIndex(of: templateSet)

--- a/LOGIT/Features/Template/Cells/TemplateSetGroupCell.swift
+++ b/LOGIT/Features/Template/Cells/TemplateSetGroupCell.swift
@@ -5,8 +5,13 @@
 //  Created by Lukas Kaibel on 30.07.23.
 //
 
+import CoreData
 import SwiftUI
 
+/// A template's set group, mirroring `WorkoutSetGroupCell`: a superset renders containerless as
+/// one full-size card per exercise paged horizontally, every card wears the thread's index
+/// bulge, and the rails fork/merge across the pages. Workout-only concepts (metric badges,
+/// previous-set references, the session note) have no template counterpart and are absent.
 struct TemplateSetGroupCell: View {
     // MARK: - Environment
 
@@ -23,6 +28,11 @@ struct TemplateSetGroupCell: View {
 
     let supplementaryText: String?
     var showDetailAsSheet: Bool = false
+    /// Position of this group in the template, passed by the list so a structural change
+    /// elsewhere refreshes this cell's bulge label. Nil derives it from the template.
+    var indexInTemplate: Int? = nil
+    /// Total number of set groups, for the "2 of 5" bulge label. Nil derives it.
+    var groupCount: Int? = nil
     var onTapRestDuration: ((TemplateSet) -> Void)? = nil
 
     // MARK: - State
@@ -30,10 +40,129 @@ struct TemplateSetGroupCell: View {
     @State private var isSelectingPrimaryExercise = false
     @State private var primaryExerciseSelectionSheetDetend: PresentationDetent? = .large
     @State private var isSelectingSecondaryExercise = false
+    /// Which exercise's page the superset pager is snapped to (objectID; nil = first page).
+    /// Also driven programmatically when keyboard focus lands on the partner's fields.
+    @State private var pagedExerciseID: NSManagedObjectID?
 
     // MARK: - Body
 
     var body: some View {
+        content
+            .sheet(isPresented: $isSelectingPrimaryExercise) {
+                NavigationStack {
+                    ExerciseSelectionScreen(
+                        selectedExercise: setGroup.exercise,
+                        setExercise: {
+                            setGroup.exercise = $0
+                            isSelectingPrimaryExercise = false
+                        },
+                        forSecondary: false,
+                        currentWorkoutExercises: [],
+                        supersetPrimaryExercise: nil,
+                        presentationDetentSelection: .constant(.large)
+                    )
+                    .presentationDetents([.large], selection: .constant(.large))
+                    .navigationTitle(NSLocalizedString("replaceExercise", comment: ""))
+                    .toolbar {
+                        ToolbarItem(placement: .topBarLeading) {
+                            Button(NSLocalizedString("cancel", comment: "")) {
+                                isSelectingPrimaryExercise = false
+                            }
+                        }
+                    }
+                }
+            }
+            .sheet(isPresented: $isSelectingSecondaryExercise) {
+                NavigationStack {
+                    ExerciseSelectionScreen(
+                        selectedExercise: setGroup.secondaryExercise,
+                        setExercise: {
+                            setGroup.secondaryExercise = $0
+                            isSelectingSecondaryExercise = false
+                        },
+                        forSecondary: true,
+                        currentWorkoutExercises: [],
+                        supersetPrimaryExercise: setGroup.exercise,
+                        presentationDetentSelection: .constant(.large)
+                    )
+                    .presentationDetents([.large], selection: .constant(.large))
+                    .navigationTitle(NSLocalizedString("selectSecondaryExercise", comment: ""))
+                    .toolbar {
+                        ToolbarItem(placement: .topBarLeading) {
+                            Button(NSLocalizedString("cancel", comment: "")) {
+                                if setGroup.secondaryExercise == nil {
+                                    database.convertSetGroupToStandardSets(setGroup)
+                                }
+                                isSelectingSecondaryExercise = false
+                            }
+                        }
+                    }
+                }
+            }
+            .accentColor(setGroup.exercise?.muscleGroup?.color ?? .accentColor)
+    }
+
+    /// A superset with both exercises chosen renders as containerless side-by-side pages; while
+    /// reordering (compact header row) or before the second exercise is picked it falls back to
+    /// the classic single card, whose header still offers the "select exercise" entry point.
+    @ViewBuilder
+    private var content: some View {
+        if isPagedSuperset {
+            supersetPager
+        } else {
+            standardCard
+        }
+    }
+
+    private var isPagedSuperset: Bool {
+        setGroup.setType == .superSet
+            && setGroup.exercise != nil
+            && setGroup.secondaryExercise != nil
+            && !isReordering
+    }
+
+    // MARK: - Index bulge
+
+    private var resolvedIndexInTemplate: Int? {
+        indexInTemplate ?? setGroup.workout?.setGroups.firstIndex(of: setGroup)
+    }
+
+    private var resolvedGroupCount: Int {
+        groupCount ?? setGroup.workout?.setGroups.count ?? 0
+    }
+
+    private var bulgeLabel: String? {
+        SetGroupThread.indexLabel(index: resolvedIndexInTemplate, count: resolvedGroupCount)
+    }
+
+    /// The merge rail is drawn under the pages only when another group follows, so the
+    /// converged line has somewhere to continue to (the list draws the trunk between cells).
+    private var showsMergeRail: Bool {
+        guard let index = resolvedIndexInTemplate else { return false }
+        return index < resolvedGroupCount - 1
+    }
+
+    /// The fork rail only when a group precedes — a floating rail above the first group with
+    /// nothing feeding it just looks broken.
+    private var showsForkRail: Bool {
+        (resolvedIndexInTemplate ?? 0) > 0
+    }
+
+    // MARK: - Standard card
+
+    private var standardCard: some View {
+        standardCardBody
+            .padding(.bottom, canEdit || isReordering ? CELL_PADDING : CELL_PADDING / 2)
+            .background(
+                RoundedRectangle(cornerRadius: 30)
+                    .fill(.shadow(.inner(color: .white.opacity(0.04), radius: 3)))
+                    .foregroundStyle(Color.secondaryBackground)
+            )
+            .cornerRadius(30)
+            .bulgeSocket(label: bulgeLabel)
+    }
+
+    private var standardCardBody: some View {
         VStack(spacing: CELL_PADDING) {
             header
             if !isReordering {
@@ -45,25 +174,7 @@ struct TemplateSetGroupCell: View {
                             isReordering: .constant(false)
                         ) { templateSet in
                             VStack(spacing: CELL_SPACING) {
-                                TemplateSetCell(
-                                    templateSet: templateSet,
-                                    focusedIntegerFieldIndex: $focusedIntegerFieldIndex,
-                                    onEditRestDuration: onTapRestDuration.map { callback in
-                                        { callback(templateSet) }
-                                    }
-                                )
-                                .contentShape(Rectangle())
-                                .background(
-                                    RoundedRectangle(cornerRadius: 15)
-                                        .fill(.shadow(.inner(color: .black.opacity(0.4), radius: 5)))
-                                        .foregroundStyle(Color.tertiaryBackground)
-                                )
-                                .cornerRadius(15)
-                                .onDeleteView(disabled: !canEdit) {
-                                    withAnimation(.interactiveSpring()) {
-                                        database.delete(templateSet)
-                                    }
-                                }
+                                setCell(for: templateSet, visibleExercise: nil)
                                 if !isLastSet(templateSet), templateSet.restDurationSeconds > 0 {
                                     restLabel(for: templateSet)
                                 }
@@ -73,110 +184,103 @@ struct TemplateSetGroupCell: View {
                     .padding(.horizontal, CELL_PADDING / 2)
                     .animation(.interactiveSpring(), value: setGroup.sets)
                     if canEdit {
-                        HStack(spacing: 8) {
-                            Button {
-                                UIImpactFeedbackGenerator(style: .soft).impactOccurred()
-                                withAnimation(.interactiveSpring()) {
-                                    database.duplicateLastSet(from: setGroup)
-                                }
-                            } label: {
-                                Image(systemName: "plus.square.on.square")
-                                    .foregroundStyle((setGroup.exercise?.muscleGroup?.color ?? .accentColor).gradient)
-                                    .font(.system(.body, design: .rounded, weight: .bold))
-                                    .padding(15)
-                                    .background(Color.accentColor.secondaryTranslucentBackground)
-                                    .clipShape(Capsule())
-                            }
-                            Button {
-                                UIImpactFeedbackGenerator(style: .soft).impactOccurred()
-                                withAnimation(.interactiveSpring()) {
-                                    database.addSet(to: setGroup)
-                                }
-                            } label: {
-                                Label(
-                                    NSLocalizedString("addSet", comment: ""),
-                                    systemImage: "plus.circle.fill"
-                                )
-                                .foregroundStyle((setGroup.exercise?.muscleGroup?.color ?? .accentColor).gradient)
-                                .font(.system(.body, design: .rounded, weight: .bold))
-                                .padding(.vertical, 15)
-                                .frame(maxWidth: .infinity)
-                                .background(Color.accentColor.secondaryTranslucentBackground)
-                                .clipShape(Capsule())
-                            }
-                            menu
-                        }
-                        .padding(.horizontal, CELL_PADDING)
+                        controls(for: setGroup.exercise)
+                            .padding(.horizontal, CELL_PADDING)
                     }
                 }
             }
         }
-        .sheet(isPresented: $isSelectingPrimaryExercise) {
-            NavigationStack {
-                ExerciseSelectionScreen(
-                    selectedExercise: setGroup.exercise,
-                    setExercise: {
-                        setGroup.exercise = $0
-                        isSelectingPrimaryExercise = false
-                    },
-                    forSecondary: false,
-                    currentWorkoutExercises: [],
-                    supersetPrimaryExercise: nil,
-                    presentationDetentSelection: .constant(.large)
-                )
-                .presentationDetents([.large], selection: .constant(.large))
-                .navigationTitle(NSLocalizedString("replaceExercise", comment: ""))
-                .toolbar {
-                    ToolbarItem(placement: .topBarLeading) {
-                        Button(NSLocalizedString("cancel", comment: "")) {
-                            isSelectingPrimaryExercise = false
-                        }
+    }
+
+    // MARK: - Superset pager
+
+    /// The containerless superset: one full-size card per exercise, paged horizontally, each
+    /// with its own bulge socket and add-set controls. The thread's rails ride in the bands
+    /// above and below the pages and scroll WITH them, so the fixed trunk the list draws
+    /// between cells always meets a rail at a right angle, whatever the scroll position.
+    private var supersetPager: some View {
+        let exercises = [setGroup.exercise, setGroup.secondaryExercise].compactMap { $0 }
+        return ScrollView(.horizontal) {
+            HStack(alignment: .top, spacing: SetGroupThread.pageSpacing) {
+                ForEach(exercises, id: \.objectID) { exercise in
+                    TemplateSupersetExercisePage(
+                        setGroup: setGroup,
+                        exercise: exercise,
+                        isPrimaryPage: exercise == setGroup.exercise,
+                        bulgeLabel: bulgeLabel,
+                        focusedIntegerFieldIndex: $focusedIntegerFieldIndex,
+                        supplementaryText: supplementaryText,
+                        showDetailAsSheet: showDetailAsSheet,
+                        onTapRestDuration: onTapRestDuration,
+                        groupMenu: AnyView(menu)
+                    )
+                    .containerRelativeFrame(.horizontal) { length, _ in
+                        max(length - SetGroupThread.pageInset * 2, 100)
                     }
                 }
             }
+            .scrollTargetLayout()
+            .supersetThreadRails(
+                pageCount: exercises.count,
+                showsFork: showsForkRail,
+                showsMerge: showsMergeRail
+            )
         }
-        .sheet(isPresented: $isSelectingSecondaryExercise) {
-            NavigationStack {
-                ExerciseSelectionScreen(
-                    selectedExercise: setGroup.secondaryExercise,
-                    setExercise: {
-                        setGroup.secondaryExercise = $0
-                        isSelectingSecondaryExercise = false
-                    },
-                    forSecondary: true,
-                    currentWorkoutExercises: [],
-                    supersetPrimaryExercise: nil,
-                    presentationDetentSelection: .constant(.large)
-                )
-                .presentationDetents([.large], selection: .constant(.large))
-                .navigationTitle(NSLocalizedString("selectSecondaryExercise", comment: ""))
-                .toolbar {
-                    ToolbarItem(placement: .topBarLeading) {
-                        Button(NSLocalizedString("cancel", comment: "")) {
-                            if setGroup.secondaryExercise == nil {
-                                database.convertSetGroupToStandardSets(setGroup)
-                            }
-                            isSelectingSecondaryExercise = false
-                        }
-                    }
-                }
-            }
+        // No content margins: the snapped first page sits flush with the leading edge (and the
+        // last page, clamped at the scroll bound, flush with the trailing edge) exactly like
+        // every non-superset cell — see `WorkoutSetGroupCell.supersetPager`.
+        .scrollTargetBehavior(.viewAligned)
+        .scrollClipDisabled()
+        .scrollIndicators(.hidden)
+        .scrollPosition(id: $pagedExerciseID)
+        .onChange(of: focusedIntegerFieldIndex) { _, newValue in
+            autopageIfNeeded(for: newValue, exercises: exercises)
         }
-    .accentColor(setGroup.exercise?.muscleGroup?.color ?? .accentColor)
-    .padding(.bottom, canEdit || isReordering ? CELL_PADDING : CELL_PADDING / 2)
-    .background(
-        RoundedRectangle(cornerRadius: 30)
-            .fill(.shadow(.inner(color: .white.opacity(0.04), radius: 3)))
-            .foregroundStyle(Color.secondaryBackground)
-    )
-    .cornerRadius(30)
+    }
+
+    /// Keyboard next/previous walks a set's entries, which alternate exercises in a superset —
+    /// when focus lands on a field whose entry belongs to the other exercise, the pager follows
+    /// so the focused field is never on an off-screen page.
+    private func autopageIfNeeded(for index: IntegerField.Index?, exercises: [Exercise]) {
+        guard let index,
+              let templateSet = setGroup.sets.first(where: { $0.id == index.setID }),
+              templateSet.entries.indices.contains(index.secondary),
+              let owner = templateSet.owningExercise(of: templateSet.entries[index.secondary])
+        else { return }
+        let currentID = pagedExerciseID ?? exercises.first?.objectID
+        guard owner.objectID != currentID else { return }
+        withAnimation(.snappy) { pagedExerciseID = owner.objectID }
     }
 
     // MARK: - Supporting Views
 
+    /// One set row, optionally restricted to a single exercise's entries (superset pages).
+    fileprivate func setCell(for templateSet: TemplateSet, visibleExercise: Exercise?) -> some View {
+        TemplateSetCell(
+            templateSet: templateSet,
+            focusedIntegerFieldIndex: $focusedIntegerFieldIndex,
+            visibleExercise: visibleExercise,
+            onEditRestDuration: onTapRestDuration.map { callback in
+                { callback(templateSet) }
+            }
+        )
+        .contentShape(Rectangle())
+        .background(
+            RoundedRectangle(cornerRadius: 15)
+                .fill(.shadow(.inner(color: .black.opacity(0.4), radius: 5)))
+                .foregroundStyle(Color.tertiaryBackground)
+        )
+        .cornerRadius(15)
+        .onDeleteView(disabled: !canEdit) {
+            withAnimation(.interactiveSpring()) {
+                database.delete(templateSet)
+            }
+        }
+    }
+
     /// A static, tappable rest indicator shown between two sets (mirrors the recorder's
     /// `RestTimerBetweenSetsView`, but without the live chronograph since templates don't run a timer).
-    private func restLabel(for templateSet: TemplateSet) -> some View {
+    fileprivate func restLabel(for templateSet: TemplateSet) -> some View {
         let label = RestDurationLabel(
             seconds: templateSet.restDurationSeconds,
             foregroundColor: .secondary,
@@ -202,16 +306,46 @@ struct TemplateSetGroupCell: View {
         setGroup.sets.last == templateSet
     }
 
+    /// Duplicate-last-set, add-set and the group menu, tinted by the page's own exercise.
+    fileprivate func controls(for exercise: Exercise?) -> some View {
+        HStack(spacing: 8) {
+            Button {
+                UIImpactFeedbackGenerator(style: .soft).impactOccurred()
+                withAnimation(.interactiveSpring()) {
+                    database.duplicateLastSet(from: setGroup)
+                }
+            } label: {
+                Image(systemName: "plus.square.on.square")
+                    .foregroundStyle((exercise?.muscleGroup?.color ?? .accentColor).gradient)
+                    .font(.system(.body, design: .rounded, weight: .bold))
+                    .padding(15)
+                    .background(Color.accentColor.secondaryTranslucentBackground)
+                    .clipShape(Capsule())
+            }
+            Button {
+                UIImpactFeedbackGenerator(style: .soft).impactOccurred()
+                withAnimation(.interactiveSpring()) {
+                    database.addSet(to: setGroup)
+                }
+            } label: {
+                Label(
+                    NSLocalizedString("addSet", comment: ""),
+                    systemImage: "plus.circle.fill"
+                )
+                .foregroundStyle((exercise?.muscleGroup?.color ?? .accentColor).gradient)
+                .font(.system(.body, design: .rounded, weight: .bold))
+                .padding(.vertical, 15)
+                .frame(maxWidth: .infinity)
+                .background(Color.accentColor.secondaryTranslucentBackground)
+                .clipShape(Capsule())
+            }
+            menu
+        }
+    }
+
     private var header: some View {
         VStack(spacing: 8) {
             HStack(spacing: 10) {
-                if let indexInWorkout = setGroup.workout?.setGroups.firstIndex(of: setGroup) {
-                    Text("\(indexInWorkout + 1)")
-                        .font(.title)
-                        .fontWeight(.medium)
-                        .fontDesign(.rounded)
-                        .foregroundStyle(.secondary)
-                }
                 VStack(alignment: .leading, spacing: 0) {
                     ExerciseHeader(
                         exercise: setGroup.exercise,
@@ -251,7 +385,7 @@ struct TemplateSetGroupCell: View {
 
     // MARK: - Supporting Views
 
-    private var menu: some View {
+    fileprivate var menu: some View {
         Menu {
             Section {
                 Button(
@@ -373,45 +507,199 @@ struct TemplateSetGroupCell: View {
     }
 }
 
+// MARK: - Superset exercise page
+
+/// One exercise's card inside the template superset pager: its own bulge socket, header, set
+/// column (only this exercise's entry per set) and add-set controls. The group-level menu is
+/// built by the cell (it owns the exercise-selection state) and passed in.
+private struct TemplateSupersetExercisePage: View {
+    @Environment(\.canEdit) var canEdit: Bool
+    @EnvironmentObject var database: Database
+
+    @ObservedObject var setGroup: TemplateSetGroup
+    let exercise: Exercise
+    let isPrimaryPage: Bool
+    let bulgeLabel: String?
+    @Binding var focusedIntegerFieldIndex: IntegerField.Index?
+    let supplementaryText: String?
+    let showDetailAsSheet: Bool
+    let onTapRestDuration: ((TemplateSet) -> Void)?
+    let groupMenu: AnyView
+
+    var body: some View {
+        card
+            .bulgeSocket(label: bulgeLabel)
+            .accentColor(exercise.muscleGroup?.color ?? .accentColor)
+    }
+
+    private var card: some View {
+        VStack(spacing: CELL_PADDING) {
+            header
+                .padding([.top, .horizontal], CELL_PADDING)
+            VStack(spacing: CELL_SPACING) {
+                ForEach(setGroup.sets, id: \.objectID) { templateSet in
+                    VStack(spacing: CELL_SPACING) {
+                        TemplateSetCell(
+                            templateSet: templateSet,
+                            focusedIntegerFieldIndex: $focusedIntegerFieldIndex,
+                            visibleExercise: exercise,
+                            onEditRestDuration: onTapRestDuration.map { callback in
+                                { callback(templateSet) }
+                            }
+                        )
+                        .contentShape(Rectangle())
+                        .background(
+                            RoundedRectangle(cornerRadius: 15)
+                                .fill(.shadow(.inner(color: .black.opacity(0.4), radius: 5)))
+                                .foregroundStyle(Color.tertiaryBackground)
+                        )
+                        .cornerRadius(15)
+                        .onDeleteView(disabled: !canEdit) {
+                            withAnimation(.interactiveSpring()) {
+                                database.delete(templateSet)
+                            }
+                        }
+                        if setGroup.sets.last != templateSet, templateSet.restDurationSeconds > 0 {
+                            restLabel(for: templateSet)
+                        }
+                    }
+                }
+            }
+            .padding(.horizontal, CELL_PADDING / 2)
+            .animation(.interactiveSpring(), value: setGroup.sets)
+            if canEdit {
+                controls
+                    .padding(.horizontal, CELL_PADDING)
+            }
+        }
+        .padding(.bottom, canEdit ? CELL_PADDING : CELL_PADDING / 2)
+        .background(
+            RoundedRectangle(cornerRadius: 30)
+                .fill(.shadow(.inner(color: .white.opacity(0.04), radius: 3)))
+                .foregroundStyle(Color.secondaryBackground)
+        )
+        .cornerRadius(30)
+    }
+
+    private var header: some View {
+        HStack(spacing: 10) {
+            VStack(alignment: .leading, spacing: 0) {
+                ExerciseHeader(
+                    exercise: exercise,
+                    secondaryExercise: nil,
+                    noExerciseAction: {},
+                    noSecondaryExerciseAction: nil,
+                    isSuperSet: false,
+                    navigationToDetailEnabled: true,
+                    showDetailAsSheet: showDetailAsSheet
+                )
+                HStack {
+                    Text(exercise.muscleGroup?.description ?? "")
+                        .foregroundColor(exercise.muscleGroup?.color ?? .accentColor)
+                    Spacer()
+                    if isPrimaryPage, let supplementaryText {
+                        Text(supplementaryText)
+                            .foregroundStyle(.secondary)
+                            .fontWeight(.medium)
+                    }
+                }
+                .font(.system(.footnote, design: .rounded, weight: .bold))
+            }
+            Spacer()
+        }
+    }
+
+    private func restLabel(for templateSet: TemplateSet) -> some View {
+        let label = RestDurationLabel(
+            seconds: templateSet.restDurationSeconds,
+            foregroundColor: .secondary,
+            iconName: "timer",
+            textFont: .caption.weight(.semibold),
+            iconFont: .caption.weight(.semibold)
+        )
+        return Group {
+            if let onTapRestDuration {
+                Button {
+                    onTapRestDuration(templateSet)
+                } label: {
+                    label
+                }
+                .buttonStyle(.plain)
+            } else {
+                label
+            }
+        }
+    }
+
+    private var controls: some View {
+        HStack(spacing: 8) {
+            Button {
+                UIImpactFeedbackGenerator(style: .soft).impactOccurred()
+                withAnimation(.interactiveSpring()) {
+                    database.duplicateLastSet(from: setGroup)
+                }
+            } label: {
+                Image(systemName: "plus.square.on.square")
+                    .foregroundStyle((exercise.muscleGroup?.color ?? .accentColor).gradient)
+                    .font(.system(.body, design: .rounded, weight: .bold))
+                    .padding(15)
+                    .background(Color.accentColor.secondaryTranslucentBackground)
+                    .clipShape(Capsule())
+            }
+            Button {
+                UIImpactFeedbackGenerator(style: .soft).impactOccurred()
+                withAnimation(.interactiveSpring()) {
+                    database.addSet(to: setGroup)
+                }
+            } label: {
+                Label(
+                    NSLocalizedString("addSet", comment: ""),
+                    systemImage: "plus.circle.fill"
+                )
+                .foregroundStyle((exercise.muscleGroup?.color ?? .accentColor).gradient)
+                .font(.system(.body, design: .rounded, weight: .bold))
+                .padding(.vertical, 15)
+                .frame(maxWidth: .infinity)
+                .background(Color.accentColor.secondaryTranslucentBackground)
+                .clipShape(Capsule())
+            }
+            groupMenu
+        }
+    }
+}
+
 private struct PreviewWrapperView: View {
     @EnvironmentObject private var database: Database
 
     var body: some View {
         NavigationStack {
             ScrollView {
-                VStack {
-                    TemplateSetGroupCell(
-                        setGroup: database.testTemplate.setGroups.first!,
-                        focusedIntegerFieldIndex: .constant(nil),
-                        sheetType: .constant(nil),
-                        isReordering: .constant(false),
-                        supplementaryText: nil
-                    )
-                    .padding(CELL_PADDING)
-                    .tileStyle()
-                    .padding()
-                    TemplateSetGroupCell(
-                        setGroup: database.testTemplate.setGroups.first!,
-                        focusedIntegerFieldIndex: .constant(nil),
-                        sheetType: .constant(nil),
-                        isReordering: .constant(true),
-                        supplementaryText: "1 / 3"
-                    )
-                    .padding(CELL_PADDING)
-                    .tileStyle()
-                    .padding()
-                    TemplateSetGroupCell(
-                        setGroup: database.testTemplate.setGroups.first!,
-                        focusedIntegerFieldIndex: .constant(nil),
-                        sheetType: .constant(nil),
-                        isReordering: .constant(false),
-                        supplementaryText: "1 / 3"
-                    )
-                    .padding(CELL_PADDING)
-                    .tileStyle()
-                    .padding()
-                    .canEdit(false)
+                VStack(spacing: 0) {
+                    ForEach(
+                        Array(database.testTemplate.setGroups.enumerated()),
+                        id: \.element.objectID
+                    ) { index, setGroup in
+                        VStack(spacing: 0) {
+                            TemplateSetGroupCell(
+                                setGroup: setGroup,
+                                focusedIntegerFieldIndex: .constant(nil),
+                                sheetType: .constant(nil),
+                                isReordering: .constant(false),
+                                supplementaryText: nil,
+                                indexInTemplate: index,
+                                groupCount: database.testTemplate.setGroups.count
+                            )
+                            if index < database.testTemplate.setGroups.count - 1 {
+                                SetGroupTrunk()
+                            }
+                        }
+                        .setGroupRowStyle(
+                            index: index,
+                            count: database.testTemplate.setGroups.count
+                        )
+                    }
                 }
+                .padding()
             }
         }
     }

--- a/LOGIT/Features/Template/TemplateDetailScreen.swift
+++ b/LOGIT/Features/Template/TemplateDetailScreen.swift
@@ -270,26 +270,26 @@ struct TemplateDetailScreen: View {
 
     private var exercisesList: some View {
         VStack(spacing: 0) {
-            ForEach(template.setGroups) { templateSetGroup in
+            ForEach(
+                Array(template.setGroups.enumerated()),
+                id: \.element.objectID
+            ) { index, templateSetGroup in
                 VStack(spacing: 0) {
                     TemplateSetGroupCell(
                         setGroup: templateSetGroup,
                         focusedIntegerFieldIndex: .constant(nil),
                         sheetType: .constant(nil),
                         isReordering: .constant(false),
-                        supplementaryText: nil
+                        supplementaryText: nil,
+                        indexInTemplate: index,
+                        groupCount: template.setGroups.count
                     )
-                    .tileStyle()
                     .canEdit(false)
-                    .shadow(color: .black, radius: 5)
-                    .zIndex(1)
-                    if template.setGroups.last != templateSetGroup {
-                        Rectangle()
-                            .foregroundStyle(.secondary)
-                            .frame(width: 3, height: SECTION_SPACING)
-                            .zIndex(0)
+                    if index < template.setGroups.count - 1 {
+                        SetGroupTrunk()
                     }
                 }
+                .setGroupRowStyle(index: index, count: template.setGroups.count)
             }
         }
     }

--- a/LOGIT/Features/Template/TemplateEditorScreen.swift
+++ b/LOGIT/Features/Template/TemplateEditorScreen.swift
@@ -117,7 +117,10 @@ struct TemplateEditorScreen: View {
                         }
                         
                         VStack(spacing: 0) {
-                            ForEach(template.setGroups) { setGroup in
+                            ForEach(
+                                Array(template.setGroups.enumerated()),
+                                id: \.element.objectID
+                            ) { index, setGroup in
                                 VStack(spacing: 0) {
                                     TemplateSetGroupCell(
                                         setGroup: setGroup,
@@ -126,16 +129,20 @@ struct TemplateEditorScreen: View {
                                         isReordering: .constant(false),
                                         supplementaryText: nil,
                                         showDetailAsSheet: true,
+                                        indexInTemplate: index,
+                                        groupCount: template.setGroups.count,
                                         onTapRestDuration: { selectedRestDurationSet = $0 }
                                     )
-                                    .shadow(color: .black.opacity(0.5), radius: 5)
-                                    .zIndex(1)
                                     interSetGroupConnector(
                                         after: setGroup,
                                         showsTrailingLine: template.setGroups.last != setGroup
                                     )
-                                    .zIndex(0)
                                 }
+                                .setGroupRowStyle(
+                                    index: index,
+                                    count: template.setGroups.count,
+                                    reduceShadow: true
+                                )
                                 .transition(.scale)
                                 .id(setGroup)
                             }
@@ -397,9 +404,7 @@ struct TemplateEditorScreen: View {
         switch TemplateInterSetGroupRestDisplayState.afterSetGroup(setGroup) {
         case .hidden:
             if showsTrailingLine {
-                Rectangle()
-                    .foregroundStyle(.secondary)
-                    .frame(width: 3, height: SECTION_SPACING)
+                SetGroupTrunk()
             }
 
         case let .staticRest(seconds):
@@ -428,22 +433,23 @@ struct TemplateEditorScreen: View {
         }
     }
 
+    /// The rest capsule between two groups, riding the thread: the trunk runs behind it so the
+    /// line stays continuous (see `onSetGroupTrunk`). A rest after the LAST group has no
+    /// trailing line — the thread ends with the template.
     private func templateInterSetGroupRestIndicator<Content: View>(
         showsTrailingLine: Bool,
         @ViewBuilder content: () -> Content
     ) -> some View {
-        VStack(spacing: 4) {
-            Rectangle()
-                .foregroundStyle(.secondary)
-                .frame(width: 3, height: 6)
-            content()
+        Group {
             if showsTrailingLine {
-                Rectangle()
-                    .foregroundStyle(.secondary)
-                    .frame(width: 3, height: 6)
+                content().onSetGroupTrunk()
+            } else {
+                VStack(spacing: 0) {
+                    SetGroupTrunk(height: SetGroupThread.trunkHeight / 2)
+                    content()
+                }
             }
         }
-        .frame(minHeight: SECTION_SPACING + 10)
     }
 
     private func templateInterSetGroupRestCapsule<Content: View>(

--- a/LOGIT/Features/Workout/Cells/WorkoutSetGroupCell.swift
+++ b/LOGIT/Features/Workout/Cells/WorkoutSetGroupCell.swift
@@ -66,15 +66,6 @@ struct WorkoutSetGroupCell: View {
     /// exercise's page, the pager follows (see `autopageIfNeeded`).
     @State private var pagedExerciseID: NSManagedObjectID?
 
-    // MARK: - Superset pager metrics
-
-    /// Horizontal inset of a snapped page — the neighbor page peeks by this minus the spacing.
-    static let pageInset: CGFloat = 24
-    static let pageSpacing: CGFloat = 12
-    /// Height of the band above (and below) the pages where the thread's horizontal rail and
-    /// its drops into the bulges are drawn.
-    static let railZoneHeight: CGFloat = 16
-
     // MARK: - Body
 
     var body: some View {
@@ -179,10 +170,7 @@ struct WorkoutSetGroupCell: View {
     /// "2 of 5" — the group's place in the workout, shown in the bulge socket on top of the card
     /// (each superset page repeats it) instead of the old header number.
     private var bulgeLabel: String? {
-        guard let index = resolvedIndexInWorkout, resolvedGroupCount > 0 else { return nil }
-        return String.localizedStringWithFormat(
-            NSLocalizedString("groupIndexOfTotal", comment: ""), index + 1, resolvedGroupCount
-        )
+        SetGroupThread.indexLabel(index: resolvedIndexInWorkout, count: resolvedGroupCount)
     }
 
     /// Whether the thread's merge rail is drawn under the superset pages — only when another
@@ -363,7 +351,7 @@ struct WorkoutSetGroupCell: View {
     private func supersetPager(previousSetGroup: WorkoutSetGroup?) -> some View {
         let exercises = [setGroup.exercise, setGroup.secondaryExercise].compactMap { $0 }
         return ScrollView(.horizontal) {
-            HStack(alignment: .top, spacing: Self.pageSpacing) {
+            HStack(alignment: .top, spacing: SetGroupThread.pageSpacing) {
                 ForEach(exercises, id: \.objectID) { exercise in
                     SupersetExercisePage(
                         setGroup: setGroup,
@@ -384,33 +372,16 @@ struct WorkoutSetGroupCell: View {
                         groupMenu: AnyView(menu)
                     )
                     .containerRelativeFrame(.horizontal) { length, _ in
-                        max(length - Self.pageInset * 2, 100)
+                        max(length - SetGroupThread.pageInset * 2, 100)
                     }
                 }
             }
             .scrollTargetLayout()
-            .padding(.top, showsForkRail ? Self.railZoneHeight : 0)
-            .padding(.bottom, showsMergeRail ? Self.railZoneHeight : 0)
-            .overlay(alignment: .top) {
-                if showsForkRail {
-                    SupersetRailShape(pageCount: exercises.count, pageSpacing: Self.pageSpacing)
-                        .stroke(style: StrokeStyle(lineWidth: 3, lineCap: .round))
-                        .foregroundStyle(Color.threadLine)
-                        .frame(height: Self.railZoneHeight)
-                }
-            }
-            .overlay(alignment: .bottom) {
-                if showsMergeRail {
-                    SupersetRailShape(
-                        pageCount: exercises.count,
-                        pageSpacing: Self.pageSpacing,
-                        flipped: true
-                    )
-                    .stroke(style: StrokeStyle(lineWidth: 3, lineCap: .round))
-                    .foregroundStyle(Color.threadLine)
-                    .frame(height: Self.railZoneHeight)
-                }
-            }
+            .supersetThreadRails(
+                pageCount: exercises.count,
+                showsFork: showsForkRail,
+                showsMerge: showsMergeRail
+            )
         }
         // No content margins: the snapped first page sits flush with the leading edge (and
         // the last page, clamped at the scroll bound, flush with the trailing edge) exactly
@@ -742,161 +713,6 @@ extension WorkoutSetGroupCell: Equatable {
             // holding a stale focus value. Bounded cost — a workout has at most a few supersets.
             && (lhs.setGroup.setType != .superSet
                 || lhs.focusedIntegerFieldIndex == rhs.focusedIntegerFieldIndex)
-    }
-}
-
-// MARK: - Index bulge
-
-/// The socket on top of every set-group card: a low rounded bump growing out of the card's top
-/// edge (concave fillets where it meets the card) that carries the group's "2 of 5" position
-/// and receives the thread the list draws between cells. The bump is deliberately lower than
-/// the label — the label's bottom half dips inside the card — and its fill continues a few
-/// points below the edge so the card's inner top highlight can't draw a seam under it. Layered
-/// with `bulgeSocket(label:)`, which draws it OVER the card.
-struct SetGroupIndexBulge: View {
-    let label: String
-
-    /// Height of the bump above the card's top edge — just enough headroom over the label's
-    /// peeking top, so the bump stays a low hill.
-    static let protrusion: CGFloat = 8
-    /// How far the bump's fill continues below the card edge.
-    static let underlap: CGFloat = 8
-    /// Horizontal run of each S-curved shoulder.
-    static let shoulderRun: CGFloat = 12
-    /// How tightly the shoulder S hugs its endpoints: 0.5 is a plain slope, towards 1 the
-    /// curve stays flat at both ends and turns in the middle. 0.75 is the chosen gentle S.
-    static let shoulderTension: CGFloat = 0.75
-    /// Horizontal padding between the label and the shoulders.
-    static let labelPadding: CGFloat = 8
-
-    var body: some View {
-        Text(label)
-            .font(.system(.caption2, design: .rounded, weight: .bold))
-            .foregroundStyle(.secondary)
-            .padding(.horizontal, Self.labelPadding)
-            // Push the label down so it straddles the card edge — most of it sits inside
-            // the card, only its top peeks into the bump.
-            .offset(y: 3)
-            .frame(height: Self.protrusion + Self.underlap)
-            .background {
-                SetGroupBulgeShape(
-                    shoulderRun: Self.shoulderRun,
-                    shoulderTension: Self.shoulderTension,
-                    underlap: Self.underlap
-                )
-                .fill(Color.secondaryBackground)
-                // The shoulders flare beyond the label's bounds on both sides.
-                .padding(.horizontal, -Self.shoulderRun)
-            }
-    }
-}
-
-extension View {
-    /// Mounts the index bulge on top of a set-group card: drawn over the card (so the label's
-    /// lower half and the underlap sit on the card's fill), extending above it by the bump's
-    /// protrusion, which is reserved as layout space.
-    @ViewBuilder
-    func bulgeSocket(label: String?) -> some View {
-        if let label {
-            overlay(alignment: .top) {
-                SetGroupIndexBulge(label: label)
-                    .alignmentGuide(.top) { $0[.top] + SetGroupIndexBulge.protrusion }
-            }
-            .padding(.top, SetGroupIndexBulge.protrusion)
-        } else {
-            self
-        }
-    }
-}
-
-/// The bulge's outline: a smooth hill. Each side is one S-curve with horizontal tangents at
-/// both ends, so the concave blend into the card's edge and the convex top shoulder are both
-/// generously rounded — no straight walls, no sharp corners anywhere. Below the card edge the
-/// fill continues `underlap` points as a plain rectangle, hiding the card's inner top
-/// highlight under the bump. The rect includes the shoulders and the underlap.
-struct SetGroupBulgeShape: Shape {
-    var shoulderRun: CGFloat = 18
-    /// 0.5 = shallowest slope; towards 1 the S hugs its endpoints and turns harder mid-curve.
-    var shoulderTension: CGFloat = 0.55
-    var underlap: CGFloat = 8
-
-    func path(in rect: CGRect) -> Path {
-        var path = Path()
-        let edge = rect.maxY - underlap
-        let top = rect.minY
-        path.move(to: CGPoint(x: rect.minX, y: edge))
-        // Left shoulder: card edge up to the flat top in one S.
-        path.addCurve(
-            to: CGPoint(x: rect.minX + shoulderRun, y: top),
-            control1: CGPoint(x: rect.minX + shoulderRun * shoulderTension, y: edge),
-            control2: CGPoint(x: rect.minX + shoulderRun * (1 - shoulderTension), y: top)
-        )
-        path.addLine(to: CGPoint(x: rect.maxX - shoulderRun, y: top))
-        // Right shoulder, mirrored.
-        path.addCurve(
-            to: CGPoint(x: rect.maxX, y: edge),
-            control1: CGPoint(x: rect.maxX - shoulderRun * (1 - shoulderTension), y: top),
-            control2: CGPoint(x: rect.maxX - shoulderRun * shoulderTension, y: edge)
-        )
-        // Continue below the card edge so the bump covers the card's inner top highlight.
-        path.addLine(to: CGPoint(x: rect.maxX, y: rect.maxY))
-        path.addLine(to: CGPoint(x: rect.minX, y: rect.maxY))
-        path.closeSubpath()
-        return path
-    }
-}
-
-// MARK: - Superset thread rail
-
-/// The thread's horizontal rail across a superset's pages, drawn in the band above (or, flipped,
-/// below) them and scrolling with them: rounded elbows turn down into the first and last page's
-/// center, straight drops serve any pages in between. Page centers are derived from the band's
-/// own width, so the shape needs no measured geometry.
-struct SupersetRailShape: Shape {
-    let pageCount: Int
-    let pageSpacing: CGFloat
-    var flipped: Bool = false
-    var cornerRadius: CGFloat = 10
-
-    func path(in rect: CGRect) -> Path {
-        var path = Path()
-        guard pageCount > 0 else { return path }
-        let pageWidth = (rect.width - CGFloat(pageCount - 1) * pageSpacing) / CGFloat(pageCount)
-        let centers = (0 ..< pageCount).map { pageWidth / 2 + CGFloat($0) * (pageWidth + pageSpacing) }
-        let railY: CGFloat = 1.5
-        // Verticals overshoot the band by a couple of points into the neighboring fill (bulge
-        // below, card above once flipped) so no join can open an antialiasing hairline.
-        let overshoot = rect.height + 2
-        guard let first = centers.first, let last = centers.last, pageCount > 1 else {
-            path.move(to: CGPoint(x: centers[0], y: 0))
-            path.addLine(to: CGPoint(x: centers[0], y: overshoot))
-            return flipped ? path.flippedVertically(height: rect.height) : path
-        }
-        path.move(to: CGPoint(x: first, y: overshoot))
-        path.addLine(to: CGPoint(x: first, y: railY + cornerRadius))
-        path.addArc(
-            center: CGPoint(x: first + cornerRadius, y: railY + cornerRadius),
-            radius: cornerRadius,
-            startAngle: .degrees(180), endAngle: .degrees(270), clockwise: false
-        )
-        path.addLine(to: CGPoint(x: last - cornerRadius, y: railY))
-        path.addArc(
-            center: CGPoint(x: last - cornerRadius, y: railY + cornerRadius),
-            radius: cornerRadius,
-            startAngle: .degrees(270), endAngle: .degrees(0), clockwise: false
-        )
-        path.addLine(to: CGPoint(x: last, y: overshoot))
-        for center in centers.dropFirst().dropLast() {
-            path.move(to: CGPoint(x: center, y: railY))
-            path.addLine(to: CGPoint(x: center, y: overshoot))
-        }
-        return flipped ? path.flippedVertically(height: rect.height) : path
-    }
-}
-
-private extension Path {
-    func flippedVertically(height: CGFloat) -> Path {
-        applying(CGAffineTransform(scaleX: 1, y: -1).translatedBy(x: 0, y: -height))
     }
 }
 

--- a/LOGIT/Features/Workout/WorkoutSetGroupList.swift
+++ b/LOGIT/Features/Workout/WorkoutSetGroupList.swift
@@ -28,10 +28,6 @@ struct WorkoutSetGroupList: View, Equatable {
     /// tapped badge's subject — each superset page carries its own badge.
     var onTapMetricBadge: ((WorkoutSetGroup, Exercise?, CGRect) -> Void)? = nil
 
-    /// Trunk length between consecutive set groups — deliberately tighter than
-    /// `SECTION_SPACING`; the bulge's protrusion adds its own visual air on top.
-    static let groupConnectorHeight: CGFloat = 12
-
     // MARK: - State
 
     @State var isReordering = false
@@ -60,16 +56,11 @@ struct WorkoutSetGroupList: View, Equatable {
                     )
                     setGroupConnector(for: entry.setGroup)
                 }
-                // One compositing group per row so the drop shadow applies to the row's
-                // union silhouette. Shadowing the raw subtree shadows every primitive
-                // individually, and the cards' black shadows blacked out the thread
-                // wherever a line met a card, a bulge or a superset rail — reading as
-                // gaps in the line.
-                .compositingGroup()
-                .shadow(color: .black.opacity(reduceShadow ? 0.5 : 1.0), radius: 5)
-                // Earlier rows render above later ones so the connector's tip enters the
-                // next cell's bulge OVER that row's shadow instead of being eaten by it.
-                .zIndex(Double(indexedGroups.count - entry.index))
+                .setGroupRowStyle(
+                    index: entry.index,
+                    count: indexedGroups.count,
+                    reduceShadow: reduceShadow
+                )
                 .transition(.scale)
                 .id(entry.setGroup)
             }
@@ -97,25 +88,11 @@ struct WorkoutSetGroupList: View, Equatable {
                 restCapsule(for: lastSet)
             }
         } else {
-            // The trunk overshoots 2pt into the cell above (behind the superset rail or card
-            // edge) and into the bulge below, sealing the joins against antialiasing hairlines.
-            // Layout height stays untouched — only the drawing overflows. Opaque thread color:
-            // the overshoots cross other thread strokes, and translucent ones would compound
-            // into brighter patches there.
             if hasRest, let lastSet {
                 restCapsule(for: lastSet)
-                    .padding(.vertical, Self.groupConnectorHeight / 2)
-                    .background(
-                        Rectangle()
-                            .foregroundStyle(Color.threadLine)
-                            .frame(width: 3)
-                            .padding(.vertical, -2)
-                    )
+                    .onSetGroupTrunk()
             } else {
-                Rectangle()
-                    .foregroundStyle(Color.threadLine)
-                    .frame(width: 3, height: Self.groupConnectorHeight + 4)
-                    .frame(height: Self.groupConnectorHeight)
+                SetGroupTrunk()
             }
         }
     }

--- a/LOGIT/SharedUI/Views/SetGroupThread.swift
+++ b/LOGIT/SharedUI/Views/SetGroupThread.swift
@@ -1,0 +1,279 @@
+//
+//  SetGroupThread.swift
+//  LOGIT
+//
+//  The "thread": the connecting line that runs down a workout's (or template's) set-group
+//  list, plus the bulge sockets it plugs into and the rails it forks into across a superset's
+//  horizontally paged exercises.
+//
+//  Shared by the workout recorder/detail and the template editor/detail so both stay one
+//  visual system — see AGENT.md, "Templates mirror workouts". Anything defined here is the
+//  vocabulary; each feature only supplies its own content.
+//
+
+import SwiftUI
+
+// MARK: - Metrics
+
+/// One home for the thread's geometry so the workout and template sides can never drift.
+enum SetGroupThread {
+    /// Stroke width of every thread segment (trunk, rails).
+    static let lineWidth: CGFloat = 3
+    /// Trunk length between consecutive set groups — deliberately tighter than
+    /// `SECTION_SPACING`; the bulge's protrusion adds its own visual air on top.
+    static let trunkHeight: CGFloat = 12
+    /// How far a segment draws past its own bounds into the neighbouring fill. Joins are
+    /// sealed by overlap, never by exact edge-kissing — antialiasing opens hairlines there.
+    static let jointOverlap: CGFloat = 2
+    /// Height of the band above (and below) a superset's pages where the fork/merge rails
+    /// and their drops into the bulges are drawn.
+    static let railZoneHeight: CGFloat = 16
+    /// Horizontal inset of a snapped superset page: pages are this much narrower than the
+    /// column on each side, so the first page still sits flush with the list's leading edge
+    /// while the neighbour peeks. Keeps every page center inside the fixed trunk's x, so the
+    /// trunk always meets the rail's straight middle.
+    static let pageInset: CGFloat = 24
+    static let pageSpacing: CGFloat = 12
+
+    /// "2 of 5" — a group's place in its workout/template, shown in the bulge socket.
+    static func indexLabel(index: Int?, count: Int) -> String? {
+        guard let index, count > 0 else { return nil }
+        return String.localizedStringWithFormat(
+            NSLocalizedString("groupIndexOfTotal", comment: ""), index + 1, count
+        )
+    }
+}
+
+// MARK: - Trunk
+
+/// The thread segment between two set groups. Draws `jointOverlap` past its layout height at
+/// both ends — into the cell above and the bulge below — so no join can show a seam.
+struct SetGroupTrunk: View {
+    var height: CGFloat = SetGroupThread.trunkHeight
+
+    var body: some View {
+        Rectangle()
+            .foregroundStyle(Color.threadLine)
+            .frame(
+                width: SetGroupThread.lineWidth,
+                height: height + SetGroupThread.jointOverlap * 2
+            )
+            .frame(height: height)
+    }
+}
+
+extension View {
+    /// Runs the trunk behind a between-groups element (a rest capsule), so the line passes
+    /// under it rather than stopping at it.
+    func onSetGroupTrunk(height: CGFloat = SetGroupThread.trunkHeight) -> some View {
+        padding(.vertical, height / 2)
+            .background(
+                Rectangle()
+                    .foregroundStyle(Color.threadLine)
+                    .frame(width: SetGroupThread.lineWidth)
+                    .padding(.vertical, -SetGroupThread.jointOverlap)
+            )
+    }
+}
+
+// MARK: - Index bulge
+
+/// The socket on top of every set-group card: a low rounded bump growing out of the card's
+/// top edge that carries the group's "2 of 5" position and receives the thread. The bump is
+/// deliberately lower than the label — most of the label sits inside the card, only its top
+/// peeks into the bump — and its fill continues below the card edge so the card's inner top
+/// highlight can't draw a seam under it. Mounted with `bulgeSocket(label:)`, which draws it
+/// OVER the card.
+struct SetGroupIndexBulge: View {
+    let label: String
+
+    /// Height of the bump above the card's top edge.
+    static let protrusion: CGFloat = 8
+    /// How far the bump's fill continues below the card edge.
+    static let underlap: CGFloat = 8
+    /// Horizontal run of each S-curved shoulder.
+    static let shoulderRun: CGFloat = 12
+    /// How tightly the shoulder S hugs its endpoints: 0.5 is a plain slope, towards 1 the
+    /// curve stays flat at both ends and turns in the middle. 0.75 is the chosen gentle S.
+    static let shoulderTension: CGFloat = 0.75
+    /// Horizontal padding between the label and the shoulders.
+    static let labelPadding: CGFloat = 8
+
+    var body: some View {
+        Text(label)
+            .font(.system(.caption2, design: .rounded, weight: .bold))
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, Self.labelPadding)
+            // Push the label down so it straddles the card edge — most of it sits inside
+            // the card, only its top peeks into the bump.
+            .offset(y: 3)
+            .frame(height: Self.protrusion + Self.underlap)
+            .background {
+                SetGroupBulgeShape(
+                    shoulderRun: Self.shoulderRun,
+                    shoulderTension: Self.shoulderTension,
+                    underlap: Self.underlap
+                )
+                .fill(Color.secondaryBackground)
+                // The shoulders flare beyond the label's bounds on both sides.
+                .padding(.horizontal, -Self.shoulderRun)
+            }
+    }
+}
+
+extension View {
+    /// Mounts the index bulge on top of a set-group card: drawn over the card (so the label's
+    /// lower half and the underlap sit on the card's fill), extending above it by the bump's
+    /// protrusion, which is reserved as layout space.
+    @ViewBuilder
+    func bulgeSocket(label: String?) -> some View {
+        if let label {
+            overlay(alignment: .top) {
+                SetGroupIndexBulge(label: label)
+                    .alignmentGuide(.top) { $0[.top] + SetGroupIndexBulge.protrusion }
+            }
+            .padding(.top, SetGroupIndexBulge.protrusion)
+        } else {
+            self
+        }
+    }
+}
+
+/// The bulge's outline: a smooth hill. Each side is one S-curve with horizontal tangents at
+/// both ends, so the concave blend into the card's edge and the convex top shoulder are both
+/// generously rounded — no straight walls, no sharp corners anywhere. Below the card edge the
+/// fill continues `underlap` points as a plain rectangle. The rect includes the shoulders and
+/// the underlap.
+struct SetGroupBulgeShape: Shape {
+    var shoulderRun: CGFloat = 12
+    var shoulderTension: CGFloat = 0.75
+    var underlap: CGFloat = 8
+
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+        let edge = rect.maxY - underlap
+        let top = rect.minY
+        path.move(to: CGPoint(x: rect.minX, y: edge))
+        // Left shoulder: card edge up to the flat top in one S.
+        path.addCurve(
+            to: CGPoint(x: rect.minX + shoulderRun, y: top),
+            control1: CGPoint(x: rect.minX + shoulderRun * shoulderTension, y: edge),
+            control2: CGPoint(x: rect.minX + shoulderRun * (1 - shoulderTension), y: top)
+        )
+        path.addLine(to: CGPoint(x: rect.maxX - shoulderRun, y: top))
+        // Right shoulder, mirrored.
+        path.addCurve(
+            to: CGPoint(x: rect.maxX, y: edge),
+            control1: CGPoint(x: rect.maxX - shoulderRun * (1 - shoulderTension), y: top),
+            control2: CGPoint(x: rect.maxX - shoulderRun * shoulderTension, y: edge)
+        )
+        // Continue below the card edge so the bump covers the card's inner top highlight.
+        path.addLine(to: CGPoint(x: rect.maxX, y: rect.maxY))
+        path.addLine(to: CGPoint(x: rect.minX, y: rect.maxY))
+        path.closeSubpath()
+        return path
+    }
+}
+
+// MARK: - Superset rails
+
+extension View {
+    /// Wraps a superset's paged content in the thread's fork (above) and merge (below) rails,
+    /// reserving their bands as padding. Applied to the scroll CONTENT, so the rails move with
+    /// the pages while the list's trunk stays fixed — that's what keeps the T-junction square
+    /// at every scroll position. A rail is omitted when nothing feeds it: no group before the
+    /// superset means no fork, none after means no merge.
+    func supersetThreadRails(pageCount: Int, showsFork: Bool, showsMerge: Bool) -> some View {
+        padding(.top, showsFork ? SetGroupThread.railZoneHeight : 0)
+            .padding(.bottom, showsMerge ? SetGroupThread.railZoneHeight : 0)
+            .overlay(alignment: .top) {
+                if showsFork {
+                    supersetRail(pageCount: pageCount, flipped: false)
+                }
+            }
+            .overlay(alignment: .bottom) {
+                if showsMerge {
+                    supersetRail(pageCount: pageCount, flipped: true)
+                }
+            }
+    }
+
+    private func supersetRail(pageCount: Int, flipped: Bool) -> some View {
+        SupersetRailShape(
+            pageCount: pageCount,
+            pageSpacing: SetGroupThread.pageSpacing,
+            flipped: flipped
+        )
+        .stroke(style: StrokeStyle(lineWidth: SetGroupThread.lineWidth, lineCap: .round))
+        .foregroundStyle(Color.threadLine)
+        .frame(height: SetGroupThread.railZoneHeight)
+    }
+}
+
+/// The thread's horizontal rail across a superset's pages, drawn in the band above (or,
+/// flipped, below) them and scrolling with them: rounded elbows turn down into the first and
+/// last page's center, straight drops serve any pages in between. Page centers are derived
+/// from the band's own width, so the shape needs no measured geometry.
+struct SupersetRailShape: Shape {
+    let pageCount: Int
+    let pageSpacing: CGFloat
+    var flipped: Bool = false
+    var cornerRadius: CGFloat = 10
+
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+        guard pageCount > 0 else { return path }
+        let pageWidth = (rect.width - CGFloat(pageCount - 1) * pageSpacing) / CGFloat(pageCount)
+        let centers = (0 ..< pageCount).map { pageWidth / 2 + CGFloat($0) * (pageWidth + pageSpacing) }
+        let railY: CGFloat = SetGroupThread.lineWidth / 2
+        // Verticals overshoot the band by a couple of points into the neighboring fill (bulge
+        // below, card above once flipped) so no join can open an antialiasing hairline.
+        let overshoot = rect.height + SetGroupThread.jointOverlap
+        guard let first = centers.first, let last = centers.last, pageCount > 1 else {
+            path.move(to: CGPoint(x: centers[0], y: 0))
+            path.addLine(to: CGPoint(x: centers[0], y: overshoot))
+            return flipped ? path.flippedVertically(height: rect.height) : path
+        }
+        path.move(to: CGPoint(x: first, y: overshoot))
+        path.addLine(to: CGPoint(x: first, y: railY + cornerRadius))
+        path.addArc(
+            center: CGPoint(x: first + cornerRadius, y: railY + cornerRadius),
+            radius: cornerRadius,
+            startAngle: .degrees(180), endAngle: .degrees(270), clockwise: false
+        )
+        path.addLine(to: CGPoint(x: last - cornerRadius, y: railY))
+        path.addArc(
+            center: CGPoint(x: last - cornerRadius, y: railY + cornerRadius),
+            radius: cornerRadius,
+            startAngle: .degrees(270), endAngle: .degrees(0), clockwise: false
+        )
+        path.addLine(to: CGPoint(x: last, y: overshoot))
+        for center in centers.dropFirst().dropLast() {
+            path.move(to: CGPoint(x: center, y: railY))
+            path.addLine(to: CGPoint(x: center, y: overshoot))
+        }
+        return flipped ? path.flippedVertically(height: rect.height) : path
+    }
+}
+
+private extension Path {
+    func flippedVertically(height: CGFloat) -> Path {
+        applying(CGAffineTransform(scaleX: 1, y: -1).translatedBy(x: 0, y: -height))
+    }
+}
+
+// MARK: - List row
+
+extension View {
+    /// How a set-group row (cell + the trunk below it) joins the list: the row is composited
+    /// before its shadow so the shadow follows the row's union silhouette. Shadowing the raw
+    /// subtree shadows every primitive individually, and the cards' black shadows then black
+    /// out the thin thread wherever a line meets a card, a bulge or a rail — reading as gaps
+    /// in the line. Earlier rows draw above later ones so a trunk's tip enters the next
+    /// cell's bulge OVER that row's shadow instead of being eaten by it.
+    func setGroupRowStyle(index: Int, count: Int, reduceShadow: Bool = false) -> some View {
+        compositingGroup()
+            .shadow(color: .black.opacity(reduceShadow ? 0.5 : 1.0), radius: 5)
+            .zIndex(Double(count - index))
+    }
+}

--- a/LOGITUITests/ScenarioScreenshots.swift
+++ b/LOGITUITests/ScenarioScreenshots.swift
@@ -327,6 +327,81 @@ final class ScenarioScreenshots: XCTestCase {
         attach(app, "workout_detail_superset")
     }
 
+    /// Template parity (see AGENT.md, "Templates mirror workouts"): the template detail and
+    /// editor must render set groups exactly like the workout side — index bulges, the thread
+    /// between groups, and a superset as the containerless per-exercise pager. The preview Push
+    /// Day template ends with a Triceps Extensions + Lateral Raises superset.
+    func testTemplateEditorSuperset() {
+        let app = launchApp(scenario: "many")
+        let tabBar = app.tabBars.firstMatch
+        XCTAssertTrue(tabBar.waitForExistence(timeout: 30), "Tab bar never appeared")
+
+        tapTab(app, at: 2)
+        waitABit(2)
+        attach(app, "template_01_list")
+
+        // The list holds both the shipped default templates (subtitled with a description) and
+        // the preview ones (subtitled with their exercise names) — and both sets contain a
+        // "Push Day". Match the preview one by an exercise only it lists.
+        let previewPush = app.buttons
+            .matching(NSPredicate(format: "label CONTAINS 'Triceps Extensions'")).firstMatch
+        for _ in 0 ..< 12 where !(previewPush.exists && previewPush.isHittable) {
+            app.swipeUp()
+            waitABit()
+        }
+        XCTAssertTrue(previewPush.waitForExistence(timeout: 5), "Preview Push Day template missing")
+        previewPush.tap()
+        waitABit(2)
+
+        // Detail: scroll to the superset finisher at the end of the exercise list.
+        let tricepsHeader = app.staticTexts["Triceps Extensions"].firstMatch
+        for _ in 0 ..< 12 where !(tricepsHeader.exists && tricepsHeader.isHittable) {
+            app.swipeUp()
+            waitABit()
+        }
+        XCTAssertTrue(
+            tricepsHeader.waitForExistence(timeout: 5),
+            "Superset group not reachable in template detail"
+        )
+        attach(app, "template_02_detail_superset")
+
+        // Swipe the pager to the partner page — same gesture as the recorder's.
+        let base = tricepsHeader.coordinate(withNormalizedOffset: .zero)
+        base.withOffset(CGVector(dx: 240, dy: 90)).press(
+            forDuration: 0.05,
+            thenDragTo: base.withOffset(CGVector(dx: -80, dy: 90)),
+            withVelocity: 800,
+            thenHoldForDuration: 0.3
+        )
+        waitABit(1)
+        XCTAssertTrue(
+            app.staticTexts["Lateral Raises"].firstMatch.waitForExistence(timeout: 5),
+            "Partner page not shown after horizontal swipe in template detail"
+        )
+        attach(app, "template_03_detail_superset_page2")
+
+        // Editor: the same layout with the edit controls, opened from the detail's ⋯ menu.
+        let menuButton = app.navigationBars.buttons.element(boundBy: 1)
+        XCTAssertTrue(menuButton.waitForExistence(timeout: 5), "Template detail toolbar menu missing")
+        menuButton.tap()
+        waitABit(1)
+        let editButton = app.buttons["Edit"].firstMatch
+        XCTAssertTrue(editButton.waitForExistence(timeout: 5), "Edit not offered in the template menu")
+        editButton.tap()
+        waitABit(3)
+
+        let editorTriceps = app.staticTexts["Triceps Extensions"].firstMatch
+        for _ in 0 ..< 12 where !(editorTriceps.exists && editorTriceps.isHittable) {
+            app.swipeUp()
+            waitABit()
+        }
+        XCTAssertTrue(
+            editorTriceps.waitForExistence(timeout: 5),
+            "Superset group not reachable in the template editor"
+        )
+        attach(app, "template_04_editor_superset")
+    }
+
     /// The containerless superset pager at the end of the stress current workout: page 1
     /// (Incline Bench Press) with its bulge socket and the thread's fork/merge rails, then a
     /// horizontal swipe to the partner page (Barbell Rows) with its own metric badge.


### PR DESCRIPTION
## Why

The template editor and detail were still rendering the *previous generation* of the set-group UI — big gray header numbers, stacked supersets, a translucent line between groups — while the workout side shipped the new thread design in #103. A template is the blueprint of a workout, so the two should read as one product.

## What

**Template surfaces now match the workout side exactly:**
- Index **bulge sockets** carrying "n of N" replace the big header number.
- The opaque **thread**: 12pt trunk between groups, sealed joins, composite-then-shadow row styling (so card shadows can't eat the line).
- Supersets render as the **containerless per-exercise pager** — edge-aligned pages with the partner peeking, fork/merge rails that travel with the pages, and keyboard focus auto-paging to the exercise owning the focused field.
- `TemplateSetCell` gained the same per-exercise entry filter (`visibleExercise`) that keeps focus indices identical between stacked and paged layouts.
- `TemplateDetailScreen` drops its `.tileStyle()` wrapper — cells draw their own card now, as in the workout detail.

**Shared vocabulary extracted** to `LOGIT/SharedUI/Views/SetGroupThread.swift`: `SetGroupTrunk` / `onSetGroupTrunk`, `SetGroupIndexBulge` + `bulgeSocket(label:)`, `supersetThreadRails(...)`, `setGroupRowStyle(...)`, and the `SetGroupThread` metrics. The workout side is refactored onto it with **no behavior change** (re-verified below).

**Mirrored only what exists on both sides.** Workout-only, deliberately absent from templates: per-exercise metric/improvement badges, previous-set reference values, PR peeks, the live rest timer/chronograph, and the session note — a template has no session to compare against or run.

## The rule

`AGENT.md` gains a **"Templates mirror workouts (keep them in lock-step)"** convention: any change to how a workout's set groups or sets are presented must be applied to the template side in the same change. It names the paired files, points at the shared file for anything both sides draw, and lists the workout-only concepts *not* to invent template equivalents for.

## Verification

- New `testTemplateEditorSuperset`: Templates → detail → pager swipe → editor, asserting the superset renders in both surfaces. (The preview fixtures gained a template superset — there wasn't one, so this layout had no coverage at all.)
- Workout regressions after the extraction: `testRecorderSupersetPager`, `testWorkoutDetailSuperset`, `testRecorderMeasurementTypes`, `testRecorderInteractionFlow` — all pass.
- Full scenario matrix (empty / one / many / free) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)