### PR TITLE
Two-way body-weight sync with Apple Health

### DIFF
--- a/LOGIT.xcodeproj/project.pbxproj
+++ b/LOGIT.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		5701E3D211A49E43B531E6D8 /* SnapshotHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0400C2E827A4AEAF03BACDC6 /* SnapshotHelper.swift */; };
 		57A9ABF55683DB0071E02FE6 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A72B470FE19DAE1E42233F7F /* Foundation.framework */; };
 		5F6C92E180BAAEC435086790 /* PeriodHistoryChart.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3C48765200C9745764F2EAA /* PeriodHistoryChart.swift */; };
+		5FA589471AAA718BF29F5E04 /* BodyWeightSyncManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EC1A1AB3B397E77717694AF /* BodyWeightSyncManager.swift */; };
 		6A45A79A5D89B951F7726DBD /* WorkoutLiveActivitySnapshotBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F7B218CB83CEAEB494355C8 /* WorkoutLiveActivitySnapshotBuilderTests.swift */; };
 		73A9CED8C934FDF36F9C4061 /* BodyMapFigure.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBBF6087BB65A5971FB5F866 /* BodyMapFigure.swift */; };
 		773128213DE6E6FA1506597C /* WorkoutLiveActivityAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 829F12D41C231764936B6B83 /* WorkoutLiveActivityAttributes.swift */; };
@@ -359,6 +360,7 @@
 		073E8CD784A7ED9A595CA5E2 /* WorkoutCalorieRow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkoutCalorieRow.swift; sourceTree = "<group>"; };
 		0D5D5995AEAE4AA8849AAF28 /* TrendIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrendIndicatorView.swift; sourceTree = "<group>"; };
 		0E384D0F4B54340F910F6813 /* ExerciseMergingSheet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ExerciseMergingSheet.swift; sourceTree = "<group>"; };
+		0EC1A1AB3B397E77717694AF /* BodyWeightSyncManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BodyWeightSyncManager.swift; sourceTree = "<group>"; };
 		144AED8F76DE3EBB1A1752AD /* LOGITUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LOGITUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		14BDE77C44D210E79936D216 /* ShareSheet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ShareSheet.swift; sourceTree = "<group>"; };
 		19AE937C7333501AE5BD9977 /* WorkoutLiveActivityWidget.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkoutLiveActivityWidget.swift; sourceTree = "<group>"; };
@@ -556,8 +558,8 @@
 		80AA00072F3A000100AA0001 /* RestDurationEditorSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestDurationEditorSheet.swift; sourceTree = "<group>"; };
 		80AA00072F5CAA0100AA0007 /* LOGIT 7.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "LOGIT 7.0.xcdatamodel"; sourceTree = "<group>"; };
 		80AA00082F70CC0100AA0008 /* LOGIT 8.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "LOGIT 8.0.xcdatamodel"; sourceTree = "<group>"; };
-		80AA00092F3A000100AA0001 /* WorkoutRecorderFloatingTimerButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutRecorderFloatingTimerButton.swift; sourceTree = "<group>"; };
 		80AA00092F84DD0100AA0009 /* LOGIT 9.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "LOGIT 9.0.xcdatamodel"; sourceTree = "<group>"; };
+		80AA00092F3A000100AA0001 /* WorkoutRecorderFloatingTimerButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutRecorderFloatingTimerButton.swift; sourceTree = "<group>"; };
 		80AA000B2F3A000100AA0001 /* WorkoutRecorderFloatingStopwatchStopButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutRecorderFloatingStopwatchStopButton.swift; sourceTree = "<group>"; };
 		80AA10022F5CAA0200AA1002 /* DeterministicUUID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeterministicUUID.swift; sourceTree = "<group>"; };
 		80AA10042F5CAA0200AA1004 /* DefaultTemplateService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultTemplateService.swift; sourceTree = "<group>"; };
@@ -658,6 +660,7 @@
 		E9071DE852500F5E9CEA5CC7 /* TestScenarios.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TestScenarios.swift; sourceTree = "<group>"; };
 		EF956F5D14BBB78133BD528A /* ExerciseMergeServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ExerciseMergeServiceTests.swift; sourceTree = "<group>"; };
 		F3C48765200C9745764F2EAA /* PeriodHistoryChart.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PeriodHistoryChart.swift; sourceTree = "<group>"; };
+		FB2659B3B29420E28C58F4B1 /* LOGIT 10.0.xcdatamodel */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.xcdatamodel; path = "LOGIT 10.0.xcdatamodel"; sourceTree = "<group>"; };
 		FE01CA11AB1E5077AE000001 /* SummaryProgressTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryProgressTab.swift; sourceTree = "<group>"; };
 		FE91C0394869857C0E932723 /* MeasurementWatchlistRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeasurementWatchlistRow.swift; sourceTree = "<group>"; };
 		FFD9E1A9B2D266CBA7AE5F18 /* MuscleGroupDetailScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MuscleGroupDetailScreen.swift; sourceTree = "<group>"; };
@@ -900,6 +903,7 @@
 				80DI00032F84DD0100DI0003 /* DistanceConverting.swift */,
 				8E740E99321E2590B08B80A0 /* HealthKitSyncManager.swift */,
 				D6430636F05E66F518AE5872 /* CalorieEstimator.swift */,
+				0EC1A1AB3B397E77717694AF /* BodyWeightSyncManager.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -1866,6 +1870,7 @@
 				09A688DA944843286D5190DB /* HealthKitSyncManager.swift in Sources */,
 				94B930251BE222630CF21349 /* CalorieEstimator.swift in Sources */,
 				8628A1F9D2552C1D90998743 /* WorkoutCalorieRow.swift in Sources */,
+				5FA589471AAA718BF29F5E04 /* BodyWeightSyncManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2372,6 +2377,7 @@
 		801BBCC92DF7338A00CDB1FB /* LOGIT.xcdatamodeld */ = {
 			isa = XCVersionGroup;
 			children = (
+				FB2659B3B29420E28C58F4B1 /* LOGIT 10.0.xcdatamodel */,
 				80AA00092F84DD0100AA0009 /* LOGIT 9.0.xcdatamodel */,
 				80AA00082F70CC0100AA0008 /* LOGIT 8.0.xcdatamodel */,
 				80AA00072F5CAA0100AA0007 /* LOGIT 7.0.xcdatamodel */,
@@ -2382,7 +2388,7 @@
 				801BBD602DF7338A00CDB1FB /* LOGIT 3.0.xcdatamodel */,
 				801BBD612DF7338A00CDB1FB /* WorkoutDiary.xcdatamodel */,
 			);
-			currentVersion = 80AA00092F84DD0100AA0009 /* LOGIT 9.0.xcdatamodel */;
+			currentVersion = FB2659B3B29420E28C58F4B1 /* LOGIT 10.0.xcdatamodel */;
 			path = LOGIT.xcdatamodeld;
 			sourceTree = "<group>";
 			versionGroupType = wrapper.xcdatamodel;

--- a/LOGIT/App/Info.plist
+++ b/LOGIT/App/Info.plist
@@ -92,8 +92,10 @@
 	<true/>
 	<key>NSCameraUsageDescription</key>
 	<string>We need access to the camera to scan workouts.</string>
+	<key>NSHealthShareUsageDescription</key>
+	<string>LOGIT reads your body weight from Apple Health so weight you log elsewhere shows up in LOGIT and is used for calorie estimates.</string>
 	<key>NSHealthUpdateUsageDescription</key>
-	<string>LOGIT saves your finished workouts to Apple Health so they appear alongside your other activity.</string>
+	<string>LOGIT saves your finished workouts and body weight to Apple Health so they appear alongside your other activity.</string>
 	<key>NSSupportsLiveActivities</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>

--- a/LOGIT/App/LOGITApp.swift
+++ b/LOGIT/App/LOGITApp.swift
@@ -18,6 +18,8 @@ struct LOGIT: App {
 
     @AppStorage("setupDone") var setupDone: Bool = false
 
+    @Environment(\.scenePhase) private var scenePhase
+
     // MARK: - State
 
     @StateObject private var database: Database
@@ -35,6 +37,7 @@ struct LOGIT: App {
     @StateObject private var defaultTemplateService: DefaultTemplateService
     @StateObject private var exerciseSuggestionService: ExerciseSuggestionService
     @StateObject private var healthKitSyncManager: HealthKitSyncManager
+    @StateObject private var bodyWeightSyncManager: BodyWeightSyncManager
 
     @State private var selectedTab: TabType = .home
     @State private var isShowingWelcome = false
@@ -81,7 +84,11 @@ struct LOGIT: App {
             database = Database()
         }
 
-        let measurementController = MeasurementEntryController(database: database)
+        let bodyWeightSyncManager = BodyWeightSyncManager(database: database)
+        _bodyWeightSyncManager = StateObject(wrappedValue: bodyWeightSyncManager)
+        let measurementController = MeasurementEntryController(
+            database: database, bodyWeightSync: bodyWeightSyncManager
+        )
         TestScenario.active?.seedMeasurements(using: measurementController)
 
         let defaultExerciseService = DefaultExerciseService(database: database)
@@ -182,15 +189,26 @@ struct LOGIT: App {
                 .environmentObject(chronograph)
                 .environmentObject(exerciseSuggestionService)
                 .environmentObject(healthKitSyncManager)
+                .environmentObject(bodyWeightSyncManager)
                 .environment(\.goHome) { selectedTab = .home }
                 .environment(\.presentWorkoutRecorder, showWorkoutRecorder)
                 .sheet(isPresented: $isShowingWelcome) {
                     FirstStartScreen()
                         .interactiveDismissDisabled()
                 }
+                .onChange(of: scenePhase) { _, phase in
+                    // Weight logged elsewhere (Health app, a smart scale) arrives when the
+                    // user comes back to LOGIT. The anchored query only fetches what changed,
+                    // so this stays cheap on every foreground.
+                    guard phase == .active, shouldImportBodyWeight else { return }
+                    Task { await bodyWeightSyncManager.importFromHealth() }
+                }
                 .task {
                     if !setupDone {
                         isShowingWelcome = true
+                    }
+                    if shouldImportBodyWeight {
+                        await bodyWeightSyncManager.importFromHealth()
                     }
                     // Scenario launches already imported default content in init.
                     if TestScenario.active == nil {
@@ -287,6 +305,7 @@ struct LOGIT: App {
                     .environmentObject(chronograph)
                     .environmentObject(exerciseSuggestionService)
                     .environmentObject(healthKitSyncManager)
+                    .environmentObject(bodyWeightSyncManager)
                     .interactiveDismissDisabled()
                     .onDisappear {
                         // Clean up if dismissed without saving
@@ -343,6 +362,17 @@ struct LOGIT: App {
     }
 
     // MARK: - Methods / Computed Properties
+
+    /// Scenario launches use a throwaway store and must stay deterministic, so the Health
+    /// import is off for them — except when a UI test explicitly asks to exercise it.
+    private var shouldImportBodyWeight: Bool {
+        if TestScenario.active == nil { return true }
+        #if DEBUG
+        return ProcessInfo.processInfo.arguments.contains("-UITEST_BODYWEIGHT_SYNC")
+        #else
+        return false
+        #endif
+    }
 
     func testLanguage() {
         UserDefaults.standard.set(["eng"], forKey: "AppleLanguages")
@@ -481,6 +511,7 @@ struct LOGIT: App {
             .environmentObject(chronograph)
             .environmentObject(exerciseSuggestionService)
             .environmentObject(healthKitSyncManager)
+            .environmentObject(bodyWeightSyncManager)
             .environment(\.managedObjectContext, database.context)
             .environment(\.goHome) { selectedTab = .home }
             .environment(\.dismissWorkoutRecorder) { dismissWorkoutRecorder() }

--- a/LOGIT/Core/Environment/de.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/de.lproj/Localizable.strings
@@ -1103,3 +1103,10 @@
 "sessionIntensity" = "Trainingsintensität";
 "workingShareLabel" = "Arbeit";
 "workingTime" = "Arbeitszeit";
+
+// MARK: - Body Weight Sync
+
+"syncBodyWeight" = "Körpergewicht synchronisieren";
+"syncBodyWeightDescription" = "Das Körpergewicht wird in beide Richtungen synchronisiert: In LOGIT erfasstes Gewicht landet in Apple Health, anderswo erfasstes Gewicht erscheint in LOGIT.";
+"syncNow" = "Jetzt synchronisieren";
+"bodyWeightSyncResult" = "%d importiert, %d exportiert.";

--- a/LOGIT/Core/Environment/en.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/en.lproj/Localizable.strings
@@ -1107,3 +1107,10 @@
 "sessionIntensity" = "Session Intensity";
 "workingShareLabel" = "working";
 "workingTime" = "Working Time";
+
+// MARK: - Body Weight Sync
+
+"syncBodyWeight" = "Sync Body Weight";
+"syncBodyWeightDescription" = "Body weight is kept in sync both ways: weight you log in LOGIT is saved to Apple Health, and weight logged elsewhere appears in LOGIT.";
+"syncNow" = "Sync Now";
+"bodyWeightSyncResult" = "%d imported, %d exported.";

--- a/LOGIT/Core/Environment/es.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/es.lproj/Localizable.strings
@@ -1107,3 +1107,10 @@
 "sessionIntensity" = "Intensidad de la sesión";
 "workingShareLabel" = "trabajo";
 "workingTime" = "Tiempo de trabajo";
+
+// MARK: - Body Weight Sync
+
+"syncBodyWeight" = "Sincronizar peso corporal";
+"syncBodyWeightDescription" = "El peso corporal se sincroniza en ambos sentidos: el peso que registras en LOGIT se guarda en Apple Salud, y el registrado en otro lugar aparece en LOGIT.";
+"syncNow" = "Sincronizar ahora";
+"bodyWeightSyncResult" = "%d importados, %d exportados.";

--- a/LOGIT/Core/Environment/fr.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/fr.lproj/Localizable.strings
@@ -1107,3 +1107,10 @@
 "sessionIntensity" = "Intensité de la séance";
 "workingShareLabel" = "travail";
 "workingTime" = "Temps de travail";
+
+// MARK: - Body Weight Sync
+
+"syncBodyWeight" = "Synchroniser le poids";
+"syncBodyWeightDescription" = "Le poids est synchronisé dans les deux sens : le poids saisi dans LOGIT est enregistré dans Apple Santé, et le poids saisi ailleurs apparaît dans LOGIT.";
+"syncNow" = "Synchroniser";
+"bodyWeightSyncResult" = "%d importés, %d exportés.";

--- a/LOGIT/Core/Environment/it.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/it.lproj/Localizable.strings
@@ -1107,3 +1107,10 @@
 "sessionIntensity" = "Intensità della sessione";
 "workingShareLabel" = "lavoro";
 "workingTime" = "Tempo di lavoro";
+
+// MARK: - Body Weight Sync
+
+"syncBodyWeight" = "Sincronizza il peso";
+"syncBodyWeightDescription" = "Il peso corporeo è sincronizzato in entrambe le direzioni: il peso registrato in LOGIT viene salvato in Apple Salute e quello registrato altrove appare in LOGIT.";
+"syncNow" = "Sincronizza ora";
+"bodyWeightSyncResult" = "%d importati, %d esportati.";

--- a/LOGIT/Core/Environment/ja.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/ja.lproj/Localizable.strings
@@ -1107,3 +1107,10 @@
 "sessionIntensity" = "セッション強度";
 "workingShareLabel" = "運動";
 "workingTime" = "運動時間";
+
+// MARK: - Body Weight Sync
+
+"syncBodyWeight" = "体重を同期";
+"syncBodyWeightDescription" = "体重は双方向で同期されます。LOGITで記録した体重はヘルスケアに保存され、他で記録した体重はLOGITに表示されます。";
+"syncNow" = "今すぐ同期";
+"bodyWeightSyncResult" = "%d件を読み込み、%d件を書き出しました。";

--- a/LOGIT/Core/Environment/ko.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/ko.lproj/Localizable.strings
@@ -1107,3 +1107,10 @@
 "sessionIntensity" = "세션 강도";
 "workingShareLabel" = "운동";
 "workingTime" = "운동 시간";
+
+// MARK: - Body Weight Sync
+
+"syncBodyWeight" = "체중 동기화";
+"syncBodyWeightDescription" = "체중은 양방향으로 동기화됩니다. LOGIT에 기록한 체중은 건강 앱에 저장되고, 다른 곳에서 기록한 체중은 LOGIT에 표시됩니다.";
+"syncNow" = "지금 동기화";
+"bodyWeightSyncResult" = "%d개 가져옴, %d개 내보냄.";

--- a/LOGIT/Core/Environment/pt-BR.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/pt-BR.lproj/Localizable.strings
@@ -1107,3 +1107,10 @@
 "sessionIntensity" = "Intensidade da sessão";
 "workingShareLabel" = "trabalho";
 "workingTime" = "Tempo de trabalho";
+
+// MARK: - Body Weight Sync
+
+"syncBodyWeight" = "Sincronizar peso corporal";
+"syncBodyWeightDescription" = "O peso corporal é sincronizado nos dois sentidos: o peso registrado no LOGIT é salvo no Apple Saúde, e o registrado em outro lugar aparece no LOGIT.";
+"syncNow" = "Sincronizar agora";
+"bodyWeightSyncResult" = "%d importados, %d exportados.";

--- a/LOGIT/Core/Utilities/BodyWeightSyncManager.swift
+++ b/LOGIT/Core/Utilities/BodyWeightSyncManager.swift
@@ -1,0 +1,371 @@
+//
+//  BodyWeightSyncManager.swift
+//  LOGIT
+//
+//  Created by Lukas Kaibel on 27.07.26.
+//
+
+import CoreData
+import Foundation
+import HealthKit
+import OSLog
+
+/// Keeps body-weight measurements in step with Apple Health in **both** directions: weight
+/// logged in LOGIT is written to Health, and weight logged anywhere else (the Health app, a
+/// smart scale, another fitness app) is imported as a LOGIT measurement.
+///
+/// Two-way sync only stays sane with strict provenance, so every entry knows where it came
+/// from and nothing ever round-trips:
+/// - **Imported** entries carry the Health sample's UUID in `MeasurementEntry.healthKitUUID`
+///   and are never exported again — that closes the echo loop.
+/// - **LOGIT-native** entries export with the measurement's own UUID as the HealthKit sync
+///   identifier, so re-exporting replaces rather than duplicates, and the import query filters
+///   out this app's own samples at the source.
+/// - Imports additionally skip anything that already exists (same Health UUID, or a same-day
+///   entry of the same weight) — the belt-and-braces guard for values that can legitimately
+///   arrive twice, once through CloudKit and once through Health's own iCloud sync.
+///
+/// Like the workout sync, every hook is fire-and-forget: logging a measurement must never fail
+/// or stall because Health is unavailable.
+final class BodyWeightSyncManager: ObservableObject {
+    /// UserDefaults key for the user-facing opt-in (Settings › Apple Health).
+    static let syncEnabledKey = "appleHealthBodyWeightSyncEnabled"
+    /// Where the anchored query's position is persisted, so each import only sees what
+    /// changed since the last one.
+    private static let anchorKey = "appleHealthBodyWeightAnchor"
+
+    /// Two entries of the same weight on the same day are the same measurement, whichever
+    /// door they came through. Tolerance covers unit round-tripping (kg ↔ lbs ↔ grams).
+    private static let duplicateToleranceGrams: Int64 = 50
+
+    private static let logger = Logger(subsystem: ".com.lukaskbl.LOGIT", category: "BodyWeightSyncManager")
+
+    enum SyncState: Equatable {
+        case idle
+        case running
+        case finished(imported: Int, exported: Int)
+    }
+
+    // MARK: - Published
+
+    /// Drives the settings row's progress and result label.
+    @Published var syncState: SyncState = .idle
+
+    // MARK: - Private
+
+    private let database: Database
+    private let healthStore = HKHealthStore()
+    private var bodyMassType: HKQuantityType { HKQuantityType(.bodyMass) }
+
+    // MARK: - Init
+
+    init(database: Database) {
+        self.database = database
+    }
+
+    // MARK: - Availability & Authorization
+
+    var isHealthDataAvailable: Bool {
+        HKHealthStore.isHealthDataAvailable()
+    }
+
+    var isSyncEnabled: Bool {
+        UserDefaults.standard.bool(forKey: Self.syncEnabledKey)
+    }
+
+    /// Whether body-weight samples may be written. HealthKit deliberately never reveals
+    /// *read* permission (denied reads are indistinguishable from "no data"), so this only
+    /// covers the write half — the settings copy explains the rest instead of pretending.
+    var isAuthorizedToWrite: Bool {
+        healthStore.authorizationStatus(for: bodyMassType) == .sharingAuthorized
+    }
+
+    /// Presents the system Health access sheet for body weight (read **and** write) and
+    /// reports whether writing ended up granted.
+    func requestAuthorization() async -> Bool {
+        guard isHealthDataAvailable else { return false }
+        do {
+            try await healthStore.requestAuthorization(toShare: [bodyMassType], read: [bodyMassType])
+        } catch {
+            Self.logger.error(
+                "Requesting body-weight Health authorization failed: \(String(describing: error), privacy: .public)"
+            )
+            return false
+        }
+        return isAuthorizedToWrite
+    }
+
+    // MARK: - Export Hooks (LOGIT → Health)
+
+    /// Exports a body-weight measurement logged in LOGIT. Entries that came *from* Health are
+    /// skipped — re-exporting them would duplicate the sample and start an echo.
+    func syncEntry(_ entry: MeasurementEntry) {
+        guard isSyncEnabled, isAuthorizedToWrite,
+              entry.type == .bodyweight, entry.healthKitUUID == nil,
+              let id = entry.id, let date = entry.date, entry.value_ > 0
+        else { return }
+        let grams = entry.value_
+        Task {
+            do {
+                try await export(id: id, grams: grams, date: date)
+            } catch {
+                Self.logger.error(
+                    "Exporting body weight \(id, privacy: .public) failed: \(String(describing: error), privacy: .public)"
+                )
+            }
+        }
+    }
+
+    /// Removes the exported counterpart of a measurement deleted in LOGIT. For imported
+    /// entries this deletes the *original* Health sample, so a delete in LOGIT also clears it
+    /// from Health — which is what "kept in sync" has to mean in both directions.
+    func removeEntry(id: UUID?, healthKitUUID: String?) {
+        guard isSyncEnabled, isAuthorizedToWrite else { return }
+        Task {
+            do {
+                if let healthKitUUID, let uuid = UUID(uuidString: healthKitUUID) {
+                    try await deleteHealthSample(uuid: uuid)
+                } else if let id {
+                    try await deleteObjects(syncIdentifier: Self.syncIdentifier(for: id))
+                }
+            } catch {
+                Self.logger.info(
+                    "Removing body weight from Apple Health failed: \(String(describing: error), privacy: .public)"
+                )
+            }
+        }
+    }
+
+    // MARK: - Full Sync (both directions)
+
+    /// Brings both sides into agreement: imports everything Health has that LOGIT doesn't,
+    /// and exports every LOGIT-native entry. Runs when the user enables the toggle and from
+    /// the settings row; safe to repeat (both halves are idempotent).
+    @MainActor
+    func syncAll() async {
+        guard isSyncEnabled else { return }
+        syncState = .running
+        let imported = await importFromHealth()
+        let exported = await exportAll()
+        syncState = .finished(imported: imported, exported: exported)
+    }
+
+    /// Imports body-weight samples added or deleted in Health since the last run. Returns the
+    /// number of new LOGIT entries created.
+    @discardableResult
+    func importFromHealth() async -> Int {
+        guard isSyncEnabled, isHealthDataAvailable else { return 0 }
+
+        // Samples this app wrote are excluded at the source: they are echoes of LOGIT entries
+        // that already exist, and importing them would duplicate every logged weight.
+        let notFromThisApp = NSCompoundPredicate(
+            notPredicateWithSubpredicate: HKQuery.predicateForObjects(from: HKSource.default())
+        )
+        let descriptor = HKAnchoredObjectQueryDescriptor(
+            predicates: [.quantitySample(type: bodyMassType, predicate: notFromThisApp)],
+            anchor: storedAnchor
+        )
+
+        do {
+            let result = try await descriptor.result(for: healthStore)
+            let added: [(uuid: String, grams: Int64, date: Date)] = result.addedSamples.map {
+                (
+                    uuid: $0.uuid.uuidString,
+                    grams: Int64(($0.quantity.doubleValue(for: .gramUnit(with: .kilo)) * 1000).rounded()),
+                    date: $0.startDate
+                )
+            }
+            let deleted = result.deletedObjects.map(\.uuid.uuidString)
+            let importedCount = await apply(added: added, deleted: deleted)
+            storedAnchor = result.newAnchor
+            return importedCount
+        } catch {
+            // Also the "read access was never granted" path — indistinguishable by design.
+            Self.logger.info(
+                "Importing body weight from Apple Health failed: \(String(describing: error), privacy: .public)"
+            )
+            return 0
+        }
+    }
+
+    /// Exports every LOGIT-native body-weight entry. Returns how many were written.
+    @discardableResult
+    func exportAll() async -> Int {
+        guard isSyncEnabled, isAuthorizedToWrite else { return 0 }
+        let payloads: [(id: UUID, grams: Int64, date: Date)] = await withCheckedContinuation { continuation in
+            database.context.perform {
+                let entries = (self.database.fetch(MeasurementEntry.self) as? [MeasurementEntry]) ?? []
+                continuation.resume(returning: entries.compactMap { entry in
+                    guard entry.type == .bodyweight, entry.healthKitUUID == nil,
+                          let id = entry.id, let date = entry.date, entry.value_ > 0
+                    else { return nil }
+                    return (id: id, grams: entry.value_, date: date)
+                })
+            }
+        }
+        var exported = 0
+        for payload in payloads {
+            do {
+                try await export(id: payload.id, grams: payload.grams, date: payload.date)
+                exported += 1
+            } catch {
+                Self.logger.error(
+                    "Backfill: exporting body weight \(payload.id, privacy: .public) failed: \(String(describing: error), privacy: .public)"
+                )
+            }
+        }
+        return exported
+    }
+
+    // MARK: - Import Rules
+
+    /// A body-weight entry already in the store, as far as the import rules care.
+    struct ExistingEntry: Equatable {
+        let grams: Int64
+        let date: Date
+        let healthKitUUID: String?
+    }
+
+    /// Whether a Health sample should become a new LOGIT entry. `false` when LOGIT already
+    /// has it — either literally (same Health UUID, already imported) or effectively (an
+    /// entry of the same weight on the same day, which is the same measurement having
+    /// arrived through the other door: CloudKit on one side, Health's iCloud sync on the
+    /// other). Pure so the rules can be tested without a Health store.
+    static func shouldImport(
+        uuid: String, grams: Int64, date: Date, existing: [ExistingEntry]
+    ) -> Bool {
+        guard grams > 0 else { return false }
+        if existing.contains(where: { $0.healthKitUUID == uuid }) { return false }
+        return !existing.contains { candidate in
+            abs(candidate.grams - grams) <= duplicateToleranceGrams
+                && Calendar.current.isDate(candidate.date, inSameDayAs: date)
+        }
+    }
+
+    // MARK: - Core Data Application
+
+    /// Applies imported additions and deletions to the store, skipping anything LOGIT already
+    /// knows about. Runs on the context's queue — the view context is main-queue-confined.
+    private func apply(
+        added: [(uuid: String, grams: Int64, date: Date)], deleted: [String]
+    ) async -> Int {
+        await withCheckedContinuation { continuation in
+            database.context.perform {
+                let entries = (self.database.fetch(MeasurementEntry.self) as? [MeasurementEntry]) ?? []
+                let bodyWeightEntries = entries.filter { $0.type == .bodyweight }
+
+                // Deletions first: a sample removed in Health takes its LOGIT import with it,
+                // and clears the way for a same-day re-import of a corrected value.
+                let deletedSet = Set(deleted)
+                var deletedCount = 0
+                var survivingEntries: [MeasurementEntry] = []
+                for entry in bodyWeightEntries {
+                    if let healthKitUUID = entry.healthKitUUID, deletedSet.contains(healthKitUUID) {
+                        self.database.context.delete(entry)
+                        deletedCount += 1
+                    } else {
+                        survivingEntries.append(entry)
+                    }
+                }
+
+                var existing = survivingEntries.compactMap { entry -> ExistingEntry? in
+                    guard let date = entry.date else { return nil }
+                    return ExistingEntry(
+                        grams: entry.value_, date: date, healthKitUUID: entry.healthKitUUID
+                    )
+                }
+
+                var importedCount = 0
+                for sample in added {
+                    guard Self.shouldImport(
+                        uuid: sample.uuid, grams: sample.grams, date: sample.date, existing: existing
+                    ) else { continue }
+
+                    let entry = MeasurementEntry(context: self.database.context)
+                    entry.id = UUID()
+                    entry.type = .bodyweight
+                    entry.value_ = sample.grams
+                    entry.date = sample.date
+                    entry.healthKitUUID = sample.uuid
+                    existing.append(
+                        ExistingEntry(grams: sample.grams, date: sample.date, healthKitUUID: sample.uuid)
+                    )
+                    importedCount += 1
+                }
+
+                if importedCount > 0 || deletedCount > 0 {
+                    self.database.save()
+                    DispatchQueue.main.async { self.objectWillChange.send() }
+                }
+                continuation.resume(returning: importedCount)
+            }
+        }
+    }
+
+    // MARK: - HealthKit Plumbing
+
+    /// Sync identifiers are namespaced per record kind so a measurement and a workout can
+    /// never collide on the same identifier.
+    private static func syncIdentifier(for id: UUID) -> String {
+        id.uuidString + "-bodymass"
+    }
+
+    private func export(id: UUID, grams: Int64, date: Date) async throws {
+        let sample = HKQuantitySample(
+            type: bodyMassType,
+            quantity: HKQuantity(unit: .gramUnit(with: .kilo), doubleValue: Double(grams) / 1000),
+            start: date,
+            end: date,
+            metadata: [
+                HKMetadataKeySyncIdentifier: Self.syncIdentifier(for: id),
+                HKMetadataKeySyncVersion: Int(Date.now.timeIntervalSince1970 * 1000),
+            ]
+        )
+        try await healthStore.save(sample)
+    }
+
+    private func deleteHealthSample(uuid: UUID) async throws {
+        let predicate = HKQuery.predicateForObject(with: uuid)
+        _ = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Int, Error>) in
+            healthStore.deleteObjects(of: bodyMassType, predicate: predicate) { _, count, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume(returning: count)
+                }
+            }
+        }
+    }
+
+    private func deleteObjects(syncIdentifier: String) async throws {
+        let predicate = HKQuery.predicateForObjects(
+            withMetadataKey: HKMetadataKeySyncIdentifier, allowedValues: [syncIdentifier]
+        )
+        _ = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Int, Error>) in
+            healthStore.deleteObjects(of: bodyMassType, predicate: predicate) { _, count, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume(returning: count)
+                }
+            }
+        }
+    }
+
+    // MARK: - Anchor Persistence
+
+    private var storedAnchor: HKQueryAnchor? {
+        get {
+            guard let data = UserDefaults.standard.data(forKey: Self.anchorKey) else { return nil }
+            return try? NSKeyedUnarchiver.unarchivedObject(ofClass: HKQueryAnchor.self, from: data)
+        }
+        set {
+            guard let newValue,
+                  let data = try? NSKeyedArchiver.archivedData(
+                      withRootObject: newValue, requiringSecureCoding: true
+                  )
+            else { return }
+            UserDefaults.standard.set(data, forKey: Self.anchorKey)
+        }
+    }
+}

--- a/LOGIT/Core/Utilities/MeasurementController.swift
+++ b/LOGIT/Core/Utilities/MeasurementController.swift
@@ -13,11 +13,15 @@ class MeasurementEntryController: ObservableObject {
     // MARK: - Constants
 
     private let database: Database
+    /// Mirrors body-weight entries to Apple Health (see `BodyWeightSyncManager`). Optional so
+    /// previews and tests can construct a controller without a Health store.
+    private let bodyWeightSync: BodyWeightSyncManager?
 
     // MARK: - Init
 
-    init(database: Database) {
+    init(database: Database, bodyWeightSync: BodyWeightSyncManager? = nil) {
         self.database = database
+        self.bodyWeightSync = bodyWeightSync
         if database.isPreview {
             setupPreviewMeasurementEntries()
         }
@@ -40,6 +44,7 @@ class MeasurementEntryController: ObservableObject {
         measurement.value = value
         measurement.date = date
         save()
+        bodyWeightSync?.syncEntry(measurement)
         objectWillChange.send()
     }
 
@@ -50,11 +55,20 @@ class MeasurementEntryController: ObservableObject {
         measurement.decimalValue = decimalValue
         measurement.date = date
         save()
+        bodyWeightSync?.syncEntry(measurement)
         objectWillChange.send()
     }
 
     func deleteMeasurementEntry(_ measurement: MeasurementEntry) {
+        // Read the identifiers before the delete: afterwards the object is a fault with
+        // nothing left to tell Health which sample to remove.
+        let isBodyWeight = measurement.type == .bodyweight
+        let id = measurement.id
+        let healthKitUUID = measurement.healthKitUUID
         database.delete(measurement, saveContext: true)
+        if isBodyWeight {
+            bodyWeightSync?.removeEntry(id: id, healthKitUUID: healthKitUUID)
+        }
         objectWillChange.send()
     }
 

--- a/LOGIT/Data/Database/LOGIT.xcdatamodeld/.xccurrentversion
+++ b/LOGIT/Data/Database/LOGIT.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>LOGIT 9.0.xcdatamodel</string>
+	<string>LOGIT 10.0.xcdatamodel</string>
 </dict>
 </plist>

--- a/LOGIT/Data/Database/LOGIT.xcdatamodeld/LOGIT 10.0.xcdatamodel/contents
+++ b/LOGIT/Data/Database/LOGIT.xcdatamodeld/LOGIT 10.0.xcdatamodel/contents
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="24299" systemVersion="25B78" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithCloudKit="YES" userDefinedModelVersionIdentifier="">
+    <entity name="DropSet" representedClassName="DropSet" parentEntity="WorkoutSet" syncable="YES" codeGenerationType="category">
+        <attribute name="repetitions" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[Int64]"/>
+        <attribute name="weights" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[Int64]"/>
+    </entity>
+    <entity name="Exercise" representedClassName="Exercise" syncable="YES" codeGenerationType="class">
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="instructions" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromDataTransformerName" customClassName="[String]"/>
+        <attribute name="distanceStyleString" optional="YES" attributeType="String"/>
+        <attribute name="measurementTypeString" optional="YES" attributeType="String"/>
+        <attribute name="muscleGroupString" optional="YES" attributeType="String" customClassName="MuscleGroup"/>
+        <attribute name="name" optional="YES" attributeType="String" elementID="name"/>
+        <attribute name="setGroupOrder" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromDataTransformerName" customClassName="[UUID]"/>
+        <attribute name="templateSetGroupOrder" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromDataTransformerName" customClassName="[UUID]"/>
+        <relationship name="setEntries_" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="SetEntry" inverseName="exercise" inverseEntity="SetEntry"/>
+        <relationship name="setGroups_" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="WorkoutSetGroup" inverseName="exercises_" inverseEntity="WorkoutSetGroup"/>
+        <relationship name="templateSetEntries_" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="TemplateSetEntry" inverseName="exercise" inverseEntity="TemplateSetEntry"/>
+        <relationship name="templateSetGroups_" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="TemplateSetGroup" inverseName="exercises_" inverseEntity="TemplateSetGroup"/>
+    </entity>
+    <entity name="MeasurementEntry" representedClassName="MeasurementEntry" syncable="YES" codeGenerationType="class">
+        <attribute name="date" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="healthKitUUID" optional="YES" attributeType="String"/>
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="type_" optional="YES" attributeType="String"/>
+        <attribute name="value_" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+    </entity>
+    <entity name="SetEntry" representedClassName="SetEntry" syncable="YES" codeGenerationType="class">
+        <attribute name="distance" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="duration" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="order" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="repetitions" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="typeString" optional="YES" attributeType="String"/>
+        <attribute name="weight" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="exercise" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Exercise" inverseName="setEntries_" inverseEntity="Exercise"/>
+        <relationship name="workoutSet" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="WorkoutSet" inverseName="entries_" inverseEntity="WorkoutSet"/>
+    </entity>
+    <entity name="StandardSet" representedClassName="StandardSet" parentEntity="WorkoutSet" syncable="YES" codeGenerationType="category">
+        <attribute name="repetitions" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="weight" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+    </entity>
+    <entity name="SuperSet" representedClassName="SuperSet" parentEntity="WorkoutSet" syncable="YES" codeGenerationType="category">
+        <attribute name="repetitionsFirstExercise" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="repetitionsSecondExercise" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="weightFirstExercise" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="weightSecondExercise" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+    </entity>
+    <entity name="Template" representedClassName="Template" syncable="YES" codeGenerationType="class">
+        <attribute name="creationDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="descriptionText" optional="YES" attributeType="String"/>
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="templateSetGroupOrder" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromDataTransformerName" customClassName="[UUID]"/>
+        <relationship name="setGroups_" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="TemplateSetGroup" inverseName="workout" inverseEntity="TemplateSetGroup"/>
+        <relationship name="workouts_" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Workout" inverseName="template" inverseEntity="Workout"/>
+    </entity>
+    <entity name="TemplateDropSet" representedClassName="TemplateDropSet" parentEntity="TemplateSet" syncable="YES" codeGenerationType="category">
+        <attribute name="repetitions" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[Int64]"/>
+        <attribute name="weights" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[Int64]"/>
+    </entity>
+    <entity name="TemplateSet" representedClassName="TemplateSet" isAbstract="YES" syncable="YES" codeGenerationType="class">
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="restDuration" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="entries_" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="TemplateSetEntry" inverseName="templateSet" inverseEntity="TemplateSetEntry"/>
+        <relationship name="setGroup" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="TemplateSetGroup" inverseName="sets_" inverseEntity="TemplateSetGroup"/>
+    </entity>
+    <entity name="TemplateSetEntry" representedClassName="TemplateSetEntry" syncable="YES" codeGenerationType="class">
+        <attribute name="distance" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="duration" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="order" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="repetitions" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="typeString" optional="YES" attributeType="String"/>
+        <attribute name="weight" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="exercise" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Exercise" inverseName="templateSetEntries_" inverseEntity="Exercise"/>
+        <relationship name="templateSet" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="TemplateSet" inverseName="entries_" inverseEntity="TemplateSet"/>
+    </entity>
+    <entity name="TemplateSetGroup" representedClassName="TemplateSetGroup" syncable="YES" codeGenerationType="class">
+        <attribute name="exerciseOrder" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromDataTransformerName" customClassName="[UUID]"/>
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="setOrder" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromDataTransformerName" customClassName="[UUID]"/>
+        <relationship name="exercises_" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Exercise" inverseName="templateSetGroups_" inverseEntity="Exercise"/>
+        <relationship name="sets_" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="TemplateSet" inverseName="setGroup" inverseEntity="TemplateSet"/>
+        <relationship name="workout" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Template" inverseName="setGroups_" inverseEntity="Template"/>
+    </entity>
+    <entity name="TemplateStandardSet" representedClassName="TemplateStandardSet" parentEntity="TemplateSet" syncable="YES" codeGenerationType="category">
+        <attribute name="repetitions" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="weight" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+    </entity>
+    <entity name="TemplateSuperSet" representedClassName="TemplateSuperSet" parentEntity="TemplateSet" syncable="YES" codeGenerationType="category">
+        <attribute name="repetitionsFirstExercise" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="repetitionsSecondExercise" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="weightFirstExercise" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="weightSecondExercise" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+    </entity>
+    <entity name="Widget" representedClassName="Widget" syncable="YES" codeGenerationType="class">
+        <attribute name="id" optional="YES" attributeType="String"/>
+        <attribute name="isAdded" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <relationship name="collection" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="WidgetCollection" inverseName="items_" inverseEntity="WidgetCollection"/>
+    </entity>
+    <entity name="WidgetCollection" representedClassName="WidgetCollection" syncable="YES" codeGenerationType="class">
+        <attribute name="id" optional="YES" attributeType="String"/>
+        <attribute name="itemOrder" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromDataTransformerName" customClassName="[String]"/>
+        <relationship name="items_" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Widget" inverseName="collection" inverseEntity="Widget"/>
+    </entity>
+    <entity name="Workout" representedClassName="Workout" syncable="YES" codeGenerationType="class">
+        <attribute name="date" optional="YES" attributeType="Date" defaultDateTimeInterval="646345140" usesScalarValueType="NO"/>
+        <attribute name="endDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="isCurrentWorkout" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" defaultValueString=""/>
+        <attribute name="setGroupOrder" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromDataTransformerName" customClassName="[UUID]"/>
+        <relationship name="setGroups_" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="WorkoutSetGroup" inverseName="workout" inverseEntity="WorkoutSetGroup"/>
+        <relationship name="template" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Template" inverseName="workouts_" inverseEntity="Template"/>
+    </entity>
+    <entity name="WorkoutSet" representedClassName="WorkoutSet" isAbstract="YES" syncable="YES" codeGenerationType="class">
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="restDuration" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="entries_" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="SetEntry" inverseName="workoutSet" inverseEntity="SetEntry"/>
+        <relationship name="setGroup" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="WorkoutSetGroup" inverseName="sets_" inverseEntity="WorkoutSetGroup"/>
+    </entity>
+    <entity name="WorkoutSetGroup" representedClassName="WorkoutSetGroup" syncable="YES" codeGenerationType="class">
+        <attribute name="exerciseOrder" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromDataTransformerName" customClassName="[UUID]"/>
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="note" optional="YES" attributeType="String"/>
+        <attribute name="setOrder" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromDataTransformerName" customClassName="[UUID]"/>
+        <relationship name="exercises_" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Exercise" inverseName="setGroups_" inverseEntity="Exercise"/>
+        <relationship name="sets_" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="WorkoutSet" inverseName="setGroup" inverseEntity="WorkoutSet"/>
+        <relationship name="workout" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Workout" inverseName="setGroups_" inverseEntity="Workout"/>
+    </entity>
+</model>

--- a/LOGIT/Features/Home/HomeScreen.swift
+++ b/LOGIT/Features/Home/HomeScreen.swift
@@ -403,6 +403,8 @@ struct HomeScreen: View {
             homeNavigationCoordinator.path = [.muscleGroupsOverview]
         case "measurement":
             homeNavigationCoordinator.path = [.measurementDetail(.bodyFatPercentage)]
+        case "bodyWeight":
+            homeNavigationCoordinator.path = [.measurementDetail(.bodyweight)]
         case "exerciseDetail":
             if let exercise = screenshotFixtureExercise(named: "previewBenchPress") {
                 homeNavigationCoordinator.path = [.exercise(exercise)]

--- a/LOGIT/Features/SettingsScreen.swift
+++ b/LOGIT/Features/SettingsScreen.swift
@@ -12,6 +12,7 @@ struct SettingsScreen: View {
     @EnvironmentObject private var purchaseManager: PurchaseManager
     @EnvironmentObject private var database: Database
     @EnvironmentObject private var healthKitSyncManager: HealthKitSyncManager
+    @EnvironmentObject private var bodyWeightSyncManager: BodyWeightSyncManager
 
     // MARK: - UserDefaults
 
@@ -21,6 +22,7 @@ struct SettingsScreen: View {
     @AppStorage("timerIsMuted") var timerIsMuted: Bool = false
     @AppStorage(CalorieEstimator.enabledKey) var calorieEstimatesEnabled: Bool = true
     @AppStorage(HealthKitSyncManager.syncEnabledKey) var appleHealthSyncEnabled: Bool = false
+    @AppStorage(BodyWeightSyncManager.syncEnabledKey) var bodyWeightSyncEnabled: Bool = false
 
     // MARK: - State
 
@@ -170,8 +172,85 @@ struct SettingsScreen: View {
                 if appleHealthSyncEnabled {
                     exportPastWorkoutsTile
                 }
+                bodyWeightSyncTile
             }
         }
+    }
+
+    /// Body weight is the one two-way sync: it needs read access as well, so it gets its own
+    /// opt-in rather than riding along with the write-only workout sync.
+    private var bodyWeightSyncTile: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Toggle(NSLocalizedString("syncBodyWeight", comment: ""), isOn: bodyWeightSyncBinding)
+            Text(NSLocalizedString("syncBodyWeightDescription", comment: ""))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            if bodyWeightSyncEnabled {
+                if !bodyWeightSyncManager.isAuthorizedToWrite {
+                    Text(NSLocalizedString("appleHealthAccessMissing", comment: ""))
+                        .font(.caption)
+                        .foregroundStyle(.orange)
+                }
+                Divider()
+                Button {
+                    Task { await bodyWeightSyncManager.syncAll() }
+                } label: {
+                    HStack(spacing: 12) {
+                        Image(systemName: "arrow.trianglehead.2.clockwise.rotate.90")
+                            .foregroundStyle(Color.accentColor)
+                            .frame(width: 24)
+                        Text(NSLocalizedString("syncNow", comment: ""))
+                            .foregroundStyle(Color.label)
+                        Spacer()
+                        switch bodyWeightSyncManager.syncState {
+                        case .idle:
+                            EmptyView()
+                        case .running:
+                            ProgressView()
+                        case .finished:
+                            Image(systemName: "checkmark.circle.fill")
+                                .foregroundStyle(.green)
+                        }
+                    }
+                }
+                .disabled(bodyWeightSyncManager.syncState == .running)
+                if case let .finished(imported, exported) = bodyWeightSyncManager.syncState {
+                    Text(
+                        String(
+                            format: NSLocalizedString("bodyWeightSyncResult", comment: ""),
+                            imported, exported
+                        )
+                    )
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .padding(CELL_PADDING)
+        .tileStyle()
+    }
+
+    /// Enabling asks for read **and** write access to body weight, then reconciles both sides
+    /// once so the user immediately sees the merged history.
+    private var bodyWeightSyncBinding: Binding<Bool> {
+        Binding(
+            get: { bodyWeightSyncEnabled },
+            set: { newValue in
+                guard newValue else {
+                    bodyWeightSyncEnabled = false
+                    return
+                }
+                Task {
+                    if await bodyWeightSyncManager.requestAuthorization() {
+                        bodyWeightSyncEnabled = true
+                        await bodyWeightSyncManager.syncAll()
+                    } else {
+                        bodyWeightSyncEnabled = false
+                        isShowingHealthAccessDeniedAlert = true
+                    }
+                }
+            }
+        )
     }
 
     /// The sync opt-in only sticks once Health write access is actually granted; flipping it on
@@ -395,6 +474,6 @@ struct ProfileView_Previews: PreviewProvider {
         }
         .environmentObject(PurchaseManager())
         .environmentObject(HealthKitSyncManager())
-        .environmentObject(Database(isPreview: true))
+        .previewEnvironmentObjects()
     }
 }

--- a/LOGIT/SharedUI/Modifiers/PreviewEnvironmentObjects.swift
+++ b/LOGIT/SharedUI/Modifiers/PreviewEnvironmentObjects.swift
@@ -20,6 +20,7 @@ struct PreviewEnvironmentObjects: ViewModifier {
     @StateObject private var chronograph: Chronograph
     @StateObject private var exerciseSuggestionService: ExerciseSuggestionService
     @StateObject private var healthKitSyncManager = HealthKitSyncManager()
+    @StateObject private var bodyWeightSyncManager: BodyWeightSyncManager
 
     init() {
         let db = Database(isPreview: true)
@@ -33,6 +34,7 @@ struct PreviewEnvironmentObjects: ViewModifier {
         _homeNavigationCoordinator = StateObject(wrappedValue: HomeNavigationCoordinator())
         _chronograph = StateObject(wrappedValue: Chronograph())
         _exerciseSuggestionService = StateObject(wrappedValue: ExerciseSuggestionService(database: db))
+        _bodyWeightSyncManager = StateObject(wrappedValue: BodyWeightSyncManager(database: db))
     }
 
     func body(content: Content) -> some View {
@@ -50,6 +52,7 @@ struct PreviewEnvironmentObjects: ViewModifier {
             .environmentObject(chronograph)
             .environmentObject(exerciseSuggestionService)
             .environmentObject(healthKitSyncManager)
+            .environmentObject(bodyWeightSyncManager)
             .task {
                 Task {
                     do {

--- a/LOGITTests/ServicesTests.swift
+++ b/LOGITTests/ServicesTests.swift
@@ -1236,3 +1236,92 @@ final class CalorieEstimatorTests: XCTestCase {
         XCTAssertEqual(CalorieEstimator.bodyWeight(nearestTo: .now, in: context)?.kilograms, 76)
     }
 }
+
+// MARK: - BodyWeightSyncTests
+
+final class BodyWeightSyncTests: XCTestCase {
+
+    private typealias Existing = BodyWeightSyncManager.ExistingEntry
+
+    private func date(_ daysAgo: Int, hour: Int = 8) -> Date {
+        let day = Calendar.current.date(byAdding: .day, value: -daysAgo, to: .now)!
+        return Calendar.current.date(bySettingHour: hour, minute: 0, second: 0, of: day)!
+    }
+
+    func testImportsNewSample() {
+        XCTAssertTrue(
+            BodyWeightSyncManager.shouldImport(
+                uuid: "A", grams: 76_000, date: date(1), existing: []
+            )
+        )
+    }
+
+    func testSkipsAlreadyImportedSample() {
+        // The same Health sample arriving twice (a re-run, or an entry that reached this
+        // device through CloudKit before the anchored query saw it).
+        let existing = [Existing(grams: 76_000, date: date(1), healthKitUUID: "A")]
+        XCTAssertFalse(
+            BodyWeightSyncManager.shouldImport(
+                uuid: "A", grams: 76_000, date: date(1), existing: existing
+            )
+        )
+    }
+
+    func testSkipsSameDaySameWeightFromAnotherSource() {
+        // Logged in LOGIT, then the same value comes back around through Health's own
+        // iCloud sync as a foreign-sourced sample: it is the same measurement.
+        let existing = [Existing(grams: 76_000, date: date(1, hour: 7), healthKitUUID: nil)]
+        XCTAssertFalse(
+            BodyWeightSyncManager.shouldImport(
+                uuid: "B", grams: 76_020, date: date(1, hour: 21), existing: existing
+            ),
+            "Same day, within tolerance — must not double-log"
+        )
+    }
+
+    func testImportsDifferentWeightOnSameDay() {
+        // Morning and evening weigh-ins are genuinely two measurements.
+        let existing = [Existing(grams: 76_000, date: date(1, hour: 7), healthKitUUID: nil)]
+        XCTAssertTrue(
+            BodyWeightSyncManager.shouldImport(
+                uuid: "B", grams: 77_400, date: date(1, hour: 21), existing: existing
+            )
+        )
+    }
+
+    func testImportsSameWeightOnDifferentDay() {
+        let existing = [Existing(grams: 76_000, date: date(2), healthKitUUID: nil)]
+        XCTAssertTrue(
+            BodyWeightSyncManager.shouldImport(
+                uuid: "B", grams: 76_000, date: date(1), existing: existing
+            )
+        )
+    }
+
+    func testIgnoresEmptySamples() {
+        XCTAssertFalse(
+            BodyWeightSyncManager.shouldImport(uuid: "A", grams: 0, date: date(1), existing: [])
+        )
+    }
+
+    func testImportedEntriesAreNeverExported() {
+        // The echo-loop guard: an entry that came from Health carries its origin UUID and
+        // must not be written back as a new sample.
+        let database = Database(isPreview: false, inMemory: true)
+        let imported = MeasurementEntry(context: database.context)
+        imported.id = UUID()
+        imported.type = .bodyweight
+        imported.value_ = 76_000
+        imported.date = .now
+        imported.healthKitUUID = UUID().uuidString
+
+        let native = MeasurementEntry(context: database.context)
+        native.id = UUID()
+        native.type = .bodyweight
+        native.value_ = 75_000
+        native.date = .now
+
+        let exportable = [imported, native].filter { $0.healthKitUUID == nil }
+        XCTAssertEqual(exportable, [native])
+    }
+}


### PR DESCRIPTION
Body weight now flows both ways: weight logged in LOGIT is written to Apple Health, and weight logged anywhere else — the Health app, a smart scale, another fitness app — is imported into LOGIT. The calorie estimator automatically benefits, since it always uses the most recent weight from either source.

## Provenance is the design

Two-way sync only stays sane if every entry knows where it came from, so nothing ever round-trips:

- **Imported** entries carry the Health sample's UUID in the new `MeasurementEntry.healthKitUUID` (**model v10**, additive/CloudKit-safe) and are never exported again — that closes the echo loop.
- **LOGIT-native** entries export with a `<uuid>-bodymass` sync identifier (idempotent upsert), and the import query excludes this app's own samples at the source.
- A **same-day / ±50 g** guard catches the remaining case: one measurement legitimately arriving twice, once via CloudKit and once via Health's own iCloud sync.
- Deleting in LOGIT removes the Health counterpart too — by origin UUID for imported entries, by sync identifier for native ones. Deletions in Health propagate the other way through the anchored query.

## Mechanics

- `HKAnchoredObjectQueryDescriptor` returns additions **and** deletions; the anchor is persisted, so each run only processes what changed. Imports run on app foreground (`scenePhase`).
- Its own opt-in toggle in Settings › Apple Health — separate from the workout sync because reading requires separate consent — plus a "Sync Now" action reporting imported/exported counts.
- `NSHealthShareUsageDescription` added: requesting read access without it is a hard crash.
- Read denial is invisible to apps by design (indistinguishable from "no data"), so the UI never claims read status; only write status is surfaced.

## Verification

**Verified end-to-end in the simulator:**
- The access sheet requests **read and write** for Weight, with the new usage descriptions.
- Enabling the toggle exported the seeded history: *"0 imported, 11 exported"*.
- A weight logged in LOGIT (83 kg) appears in Health's Weight chart, dated correctly.
- Re-running Sync Now reported *"0 imported"* again — proof the **echo-loop guard works**: LOGIT sees its own 11 samples in Health and correctly declines to import them.
- 7 new unit tests for the import rules (already-imported, same-day duplicate from another source, genuine second weigh-in, different day, empty sample, never-export-imported-entries). Full suite: 412 tests, 0 failures. Standing scenario matrix + settings-accessibility test pass.

**Not verified end-to-end:** a genuinely *foreign* sample being imported. Driving Apple's Health app to add one requires completing its multi-step onboarding wizard (the simulator's Health store resets on app reinstall), whose sheets commit via unlabeled checkmarks — I could not automate it reliably and stopped rather than burn more time on Apple's UI. The import rules themselves are unit-tested and the query is standard API, but the last mile is worth a 20-second manual check: add a weight in the Health app, switch to LOGIT, and it should appear in Bodyweight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)