### PR TITLE
Exercise editor: compose the measurement instead of picking a type

### DIFF
--- a/LOGIT/Core/Enums/SetMeasurementType.swift
+++ b/LOGIT/Core/Enums/SetMeasurementType.swift
@@ -78,3 +78,36 @@ enum SetMeasurementType: String, CaseIterable, Codable, Identifiable {
         NSLocalizedString("measurementType.\(rawValue)", comment: "")
     }
 }
+
+/// One value a set entry can record. The exercise editor lets the user compose a measurement
+/// type by toggling these instead of decoding combined names like "Weight & Distance".
+enum SetTrackedField: CaseIterable {
+    case repetitions, weight, duration, distance
+}
+
+extension SetMeasurementType {
+    /// The fields this type records, derived from the `uses*` flags so the two views of the
+    /// same fact can't drift apart.
+    var trackedFields: Set<SetTrackedField> {
+        var fields = Set<SetTrackedField>()
+        if usesRepetitions { fields.insert(.repetitions) }
+        if usesWeight { fields.insert(.weight) }
+        if usesDuration { fields.insert(.duration) }
+        if usesDistance { fields.insert(.distance) }
+        return fields
+    }
+
+    /// The type recording exactly `trackedFields`, or nil while a selection is incomplete —
+    /// weight on its own or nothing at all names no type.
+    init?(trackedFields: Set<SetTrackedField>) {
+        guard let match = Self.allCases.first(where: { $0.trackedFields == trackedFields })
+        else { return nil }
+        self = match
+    }
+
+    /// Whether `trackedFields` could still grow into a valid type — the exercise editor keeps
+    /// a field tappable only while adding it leaves at least one type reachable.
+    static func isSubsetOfAnyType(_ trackedFields: Set<SetTrackedField>) -> Bool {
+        allCases.contains { trackedFields.isSubset(of: $0.trackedFields) }
+    }
+}

--- a/LOGIT/Core/Environment/de.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/de.lproj/Localizable.strings
@@ -1112,3 +1112,15 @@
 "syncBodyWeightDescription" = "Das Körpergewicht wird in beide Richtungen synchronisiert: In LOGIT erfasstes Gewicht landet in Apple Health, anderswo erfasstes Gewicht erscheint in LOGIT.";
 "syncNow" = "Jetzt synchronisieren";
 "bodyWeightSyncResult" = "%d importiert, %d exportiert.";
+
+// Exercise editor — measurement builder
+"trackPerSet" = "Was trackst du pro Satz?";
+"trackingEmptyHint" = "Wähle mindestens einen Wert aus.";
+"trackingWeightAloneHint" = "Ergänze das Gewicht um Wiederholungen, Dauer oder Distanz.";
+"setPreviewCaption" = "So wird ein Satz aussehen";
+"progressMetricCaption" = "Wird beim Training auf dem Übungs-Badge angezeigt.";
+"progressMetricE1RMDescription" = "Geschätztes One-Rep-Max aus Gewicht und Wiederholungen";
+"progressMetricWeightDescription" = "Schwerstes Gewicht in einem Satz";
+"progressMetricRepetitionsDescription" = "Meiste Wiederholungen in einem Satz";
+"progressMetricDurationDescription" = "Längste Dauer in einem Satz";
+"progressMetricDistanceDescription" = "Weiteste Distanz in einem Satz";

--- a/LOGIT/Core/Environment/en.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/en.lproj/Localizable.strings
@@ -1116,3 +1116,15 @@
 "syncBodyWeightDescription" = "Body weight is kept in sync both ways: weight you log in LOGIT is saved to Apple Health, and weight logged elsewhere appears in LOGIT.";
 "syncNow" = "Sync Now";
 "bodyWeightSyncResult" = "%d imported, %d exported.";
+
+// Exercise editor — measurement builder
+"trackPerSet" = "What do you track per set?";
+"trackingEmptyHint" = "Pick at least one value to track.";
+"trackingWeightAloneHint" = "Add reps, a duration, or a distance to go with the weight.";
+"setPreviewCaption" = "One set will look like this";
+"progressMetricCaption" = "Shown on the exercise badge while you train.";
+"progressMetricE1RMDescription" = "Estimated one-rep max, from weight and reps";
+"progressMetricWeightDescription" = "Heaviest weight lifted in a set";
+"progressMetricRepetitionsDescription" = "Most reps in a single set";
+"progressMetricDurationDescription" = "Longest duration in a single set";
+"progressMetricDistanceDescription" = "Farthest distance in a single set";

--- a/LOGIT/Core/Environment/es.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/es.lproj/Localizable.strings
@@ -1116,3 +1116,15 @@
 "syncBodyWeightDescription" = "El peso corporal se sincroniza en ambos sentidos: el peso que registras en LOGIT se guarda en Apple Salud, y el registrado en otro lugar aparece en LOGIT.";
 "syncNow" = "Sincronizar ahora";
 "bodyWeightSyncResult" = "%d importados, %d exportados.";
+
+// Exercise editor — measurement builder
+"trackPerSet" = "¿Qué registras por serie?";
+"trackingEmptyHint" = "Elige al menos un valor para registrar.";
+"trackingWeightAloneHint" = "Añade repeticiones, duración o distancia al peso.";
+"setPreviewCaption" = "Así se verá una serie";
+"progressMetricCaption" = "Se muestra en la insignia del ejercicio mientras entrenas.";
+"progressMetricE1RMDescription" = "1RM estimado, a partir del peso y las repeticiones";
+"progressMetricWeightDescription" = "Mayor peso levantado en una serie";
+"progressMetricRepetitionsDescription" = "Más repeticiones en una sola serie";
+"progressMetricDurationDescription" = "Mayor duración en una sola serie";
+"progressMetricDistanceDescription" = "Mayor distancia en una sola serie";

--- a/LOGIT/Core/Environment/fr.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/fr.lproj/Localizable.strings
@@ -1116,3 +1116,15 @@
 "syncBodyWeightDescription" = "Le poids est synchronisé dans les deux sens : le poids saisi dans LOGIT est enregistré dans Apple Santé, et le poids saisi ailleurs apparaît dans LOGIT.";
 "syncNow" = "Synchroniser";
 "bodyWeightSyncResult" = "%d importés, %d exportés.";
+
+// Exercise editor — measurement builder
+"trackPerSet" = "Que suivez-vous par série ?";
+"trackingEmptyHint" = "Choisissez au moins une valeur à suivre.";
+"trackingWeightAloneHint" = "Ajoutez des répétitions, une durée ou une distance au poids.";
+"setPreviewCaption" = "Voici à quoi ressemblera une série";
+"progressMetricCaption" = "Affiché sur le badge de l'exercice pendant l'entraînement.";
+"progressMetricE1RMDescription" = "1RM estimé, à partir du poids et des répétitions";
+"progressMetricWeightDescription" = "Poids le plus lourd soulevé dans une série";
+"progressMetricRepetitionsDescription" = "Le plus de répétitions en une série";
+"progressMetricDurationDescription" = "La plus longue durée en une série";
+"progressMetricDistanceDescription" = "La plus grande distance en une série";

--- a/LOGIT/Core/Environment/it.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/it.lproj/Localizable.strings
@@ -1116,3 +1116,15 @@
 "syncBodyWeightDescription" = "Il peso corporeo è sincronizzato in entrambe le direzioni: il peso registrato in LOGIT viene salvato in Apple Salute e quello registrato altrove appare in LOGIT.";
 "syncNow" = "Sincronizza ora";
 "bodyWeightSyncResult" = "%d importati, %d esportati.";
+
+// Exercise editor — measurement builder
+"trackPerSet" = "Cosa registri per ogni serie?";
+"trackingEmptyHint" = "Scegli almeno un valore da registrare.";
+"trackingWeightAloneHint" = "Aggiungi ripetizioni, durata o distanza al peso.";
+"setPreviewCaption" = "Ecco come apparirà una serie";
+"progressMetricCaption" = "Mostrato sul badge dell'esercizio durante l'allenamento.";
+"progressMetricE1RMDescription" = "Massimale stimato (1RM) da peso e ripetizioni";
+"progressMetricWeightDescription" = "Peso più alto sollevato in una serie";
+"progressMetricRepetitionsDescription" = "Più ripetizioni in una singola serie";
+"progressMetricDurationDescription" = "Durata più lunga in una singola serie";
+"progressMetricDistanceDescription" = "Distanza più lunga in una singola serie";

--- a/LOGIT/Core/Environment/ja.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/ja.lproj/Localizable.strings
@@ -1116,3 +1116,15 @@
 "syncBodyWeightDescription" = "体重は双方向で同期されます。LOGITで記録した体重はヘルスケアに保存され、他で記録した体重はLOGITに表示されます。";
 "syncNow" = "今すぐ同期";
 "bodyWeightSyncResult" = "%d件を読み込み、%d件を書き出しました。";
+
+// Exercise editor — measurement builder
+"trackPerSet" = "セットごとに何を記録しますか?";
+"trackingEmptyHint" = "記録する値を1つ以上選んでください。";
+"trackingWeightAloneHint" = "重量に加えてレップ数・時間・距離のいずれかを選んでください。";
+"setPreviewCaption" = "セットはこのように表示されます";
+"progressMetricCaption" = "トレーニング中にエクササイズのバッジに表示されます。";
+"progressMetricE1RMDescription" = "重量とレップ数から推定した1RM";
+"progressMetricWeightDescription" = "1セットで挙げた最大重量";
+"progressMetricRepetitionsDescription" = "1セットの最多レップ数";
+"progressMetricDurationDescription" = "1セットの最長時間";
+"progressMetricDistanceDescription" = "1セットの最長距離";

--- a/LOGIT/Core/Environment/ko.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/ko.lproj/Localizable.strings
@@ -1116,3 +1116,15 @@
 "syncBodyWeightDescription" = "체중은 양방향으로 동기화됩니다. LOGIT에 기록한 체중은 건강 앱에 저장되고, 다른 곳에서 기록한 체중은 LOGIT에 표시됩니다.";
 "syncNow" = "지금 동기화";
 "bodyWeightSyncResult" = "%d개 가져옴, %d개 내보냄.";
+
+// Exercise editor — measurement builder
+"trackPerSet" = "세트마다 무엇을 기록하나요?";
+"trackingEmptyHint" = "기록할 값을 하나 이상 선택하세요.";
+"trackingWeightAloneHint" = "무게에 횟수, 시간 또는 거리를 추가하세요.";
+"setPreviewCaption" = "세트는 이렇게 표시됩니다";
+"progressMetricCaption" = "운동 중 배지에 표시됩니다.";
+"progressMetricE1RMDescription" = "무게와 횟수로 추정한 1RM";
+"progressMetricWeightDescription" = "한 세트에서 든 최대 무게";
+"progressMetricRepetitionsDescription" = "한 세트 최다 횟수";
+"progressMetricDurationDescription" = "한 세트 최장 시간";
+"progressMetricDistanceDescription" = "한 세트 최장 거리";

--- a/LOGIT/Core/Environment/pt-BR.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/pt-BR.lproj/Localizable.strings
@@ -1116,3 +1116,15 @@
 "syncBodyWeightDescription" = "O peso corporal é sincronizado nos dois sentidos: o peso registrado no LOGIT é salvo no Apple Saúde, e o registrado em outro lugar aparece no LOGIT.";
 "syncNow" = "Sincronizar agora";
 "bodyWeightSyncResult" = "%d importados, %d exportados.";
+
+// Exercise editor — measurement builder
+"trackPerSet" = "O que você registra por série?";
+"trackingEmptyHint" = "Escolha pelo menos um valor para registrar.";
+"trackingWeightAloneHint" = "Adicione repetições, duração ou distância ao peso.";
+"setPreviewCaption" = "Uma série ficará assim";
+"progressMetricCaption" = "Exibido no selo do exercício durante o treino.";
+"progressMetricE1RMDescription" = "1RM estimado, a partir do peso e das repetições";
+"progressMetricWeightDescription" = "Maior peso levantado em uma série";
+"progressMetricRepetitionsDescription" = "Mais repetições em uma única série";
+"progressMetricDurationDescription" = "Maior duração em uma única série";
+"progressMetricDistanceDescription" = "Maior distância em uma única série";

--- a/LOGIT/Data/EntityExtensions/Exercise+.swift
+++ b/LOGIT/Data/EntityExtensions/Exercise+.swift
@@ -249,6 +249,23 @@ enum ExercisePrimaryMetric: String, CaseIterable {
         }
     }
 
+    /// One-line explanation for the exercise editor's metric picker — "e1RM" alone doesn't
+    /// introduce itself.
+    var caption: String {
+        switch self {
+        case .estimatedOneRepMax:
+            return NSLocalizedString("progressMetricE1RMDescription", comment: "")
+        case .weight:
+            return NSLocalizedString("progressMetricWeightDescription", comment: "")
+        case .repetitions:
+            return NSLocalizedString("progressMetricRepetitionsDescription", comment: "")
+        case .duration:
+            return NSLocalizedString("progressMetricDurationDescription", comment: "")
+        case .distance:
+            return NSLocalizedString("progressMetricDistanceDescription", comment: "")
+        }
+    }
+
     /// The metric shown when the user hasn't chosen one for an exercise: e1RM for Pro users (the
     /// flagship metric), repetitions for free users — the one metric whose info panel is fully
     /// visible without Pro, so a default badge tap always lands on usable content. Upgrading flips

--- a/LOGIT/Features/Exercise/ExerciseDetail/ExerciseDetailScreen.swift
+++ b/LOGIT/Features/Exercise/ExerciseDetail/ExerciseDetailScreen.swift
@@ -169,6 +169,7 @@ struct ExerciseDetailScreen: View {
                         } label: {
                             Image(systemName: "ellipsis.circle")
                         }
+                        .accessibilityIdentifier("exerciseDetailMenu")
                         .confirmationDialog(
                             Text(NSLocalizedString("deleteExerciseConfirmation", comment: "")),
                             isPresented: $showDeletionAlert,

--- a/LOGIT/Features/Exercise/ExerciseEditScreen.swift
+++ b/LOGIT/Features/Exercise/ExerciseEditScreen.swift
@@ -17,7 +17,9 @@ struct ExerciseEditScreen: View {
 
     @State private var exerciseName: String
     @State private var muscleGroup: MuscleGroup
-    @State private var measurementType: SetMeasurementType
+    /// The builder's selection. The measurement type is derived from it: the user composes
+    /// "what do I type in per set" from four fields instead of decoding seven combined names.
+    @State private var trackedFields: Set<SetTrackedField>
     @State private var distanceStyle: SetMeasurementType.DistanceStyle
     @State private var primaryMetric: ExercisePrimaryMetric
     @State private var showingExerciseExistsAlert: Bool = false
@@ -31,6 +33,9 @@ struct ExerciseEditScreen: View {
     private let exerciseToEdit: Exercise?
     private let onEditFinished: ((_ exercise: Exercise) -> Void)?
 
+    /// Stable identity for the preview row's inert field indices.
+    private static let previewSetID = UUID()
+
     // MARK: - Init
 
     init(
@@ -41,13 +46,12 @@ struct ExerciseEditScreen: View {
     ) {
         self.exerciseToEdit = exerciseToEdit
         self.onEditFinished = onEditFinished
+        let initialType = exerciseToEdit?.measurementType ?? .repsAndWeight
         _exerciseName = State(initialValue: initialExerciseName ?? exerciseToEdit?.displayName ?? "")
         _muscleGroup = State(initialValue: exerciseToEdit?.muscleGroup ?? initialMuscleGroup)
-        _measurementType = State(initialValue: exerciseToEdit?.measurementType ?? .repsAndWeight)
+        _trackedFields = State(initialValue: initialType.trackedFields)
         _distanceStyle = State(
-            initialValue: exerciseToEdit?.distanceStyle
-                ?? (exerciseToEdit?.measurementType ?? .repsAndWeight).distanceStyle
-                ?? .long
+            initialValue: exerciseToEdit?.distanceStyle ?? initialType.distanceStyle ?? .long
         )
         _primaryMetric = State(initialValue: exerciseToEdit?.primaryMetric ?? .defaultMetric)
     }
@@ -56,98 +60,80 @@ struct ExerciseEditScreen: View {
 
     var body: some View {
         NavigationStack {
-            VStack(spacing: SECTION_SPACING) {
-                TextField(
-                    NSLocalizedString("exerciseName", comment: ""),
-                    text: $exerciseName
-                )
-                .focused($nameFieldIsFocused)
-                .font(.body.weight(.bold))
-                .padding(CELL_PADDING)
-                .tileStyle()
-                .padding(.horizontal)
-                .padding(.top, 30)
-
-                VStack(alignment: .leading) {
-                    Text(NSLocalizedString("selectMuscleGroup", comment: ""))
-                        .fontWeight(.semibold)
-                        .foregroundColor(.secondary)
-                        .padding(.horizontal)
-                    MuscleGroupSelector(
-                        selectedMuscleGroup: optionalMuscleGroupBinding,
-                        canBeNil: false
+            ScrollView {
+                VStack(alignment: .leading, spacing: SECTION_SPACING) {
+                    TextField(
+                        NSLocalizedString("exerciseName", comment: ""),
+                        text: $exerciseName
                     )
-                }
+                    .focused($nameFieldIsFocused)
+                    .font(.body.weight(.bold))
+                    .padding(CELL_PADDING)
+                    .tileStyle()
+                    .padding(.top, 30)
 
-                VStack(alignment: .leading) {
-                    Text(NSLocalizedString("measurementType", comment: ""))
-                        .fontWeight(.semibold)
-                        .foregroundColor(.secondary)
-                        .padding(.horizontal)
-                    Picker(NSLocalizedString("measurementType", comment: ""), selection: $measurementType) {
-                        ForEach(SetMeasurementType.allCases) { type in
-                            Text(type.title).tag(type)
-                        }
-                    }
-                    .pickerStyle(.menu)
-                    .padding(.horizontal)
-                    // Changing the type never rewrites history: recorded entries keep the
-                    // fields they were performed with; only new sets record the new fields.
-                    if exerciseToEdit != nil, measurementType != exerciseToEdit?.measurementType {
-                        Text(NSLocalizedString("measurementTypeChangeInfo", comment: ""))
-                            .font(.footnote)
-                            .foregroundStyle(.secondary)
-                            .padding(.horizontal)
-                    }
-                }
-
-                // Distance scale (km vs m, mi vs yd) — a display choice; distances are always
-                // stored in meters, so switching never touches recorded values.
-                if measurementType.usesDistance {
                     VStack(alignment: .leading) {
-                        Text(NSLocalizedString("distanceUnit", comment: ""))
+                        Text(NSLocalizedString("selectMuscleGroup", comment: ""))
                             .fontWeight(.semibold)
                             .foregroundColor(.secondary)
-                            .padding(.horizontal)
-                        Picker(NSLocalizedString("distanceUnit", comment: ""), selection: $distanceStyle) {
-                            ForEach(SetMeasurementType.DistanceStyle.allCases, id: \.self) { style in
-                                Text(distanceStyleTitle(for: style)).tag(style)
-                            }
-                        }
-                        .pickerStyle(.segmented)
-                        .padding(.horizontal)
-                        .onChange(of: measurementType) { _, newType in
-                            // A newly chosen measurement resets the scale to its natural
-                            // default — the user can still flip it right here.
-                            if let defaultStyle = newType.distanceStyle {
-                                distanceStyle = defaultStyle
-                            }
-                        }
+                        MuscleGroupSelector(
+                            selectedMuscleGroup: optionalMuscleGroupBinding,
+                            canBeNil: false,
+                            wraps: true
+                        )
                     }
-                }
 
-                VStack(alignment: .leading) {
-                    Text(NSLocalizedString("progressMetric", comment: ""))
-                        .fontWeight(.semibold)
-                        .foregroundColor(.secondary)
-                        .padding(.horizontal)
-                    // Only metrics that fit the chosen measurement — a plank never offers e1RM.
-                    let allowedMetrics = ExercisePrimaryMetric.allowed(for: measurementType)
-                    Picker(NSLocalizedString("progressMetric", comment: ""), selection: $primaryMetric) {
-                        ForEach(allowedMetrics, id: \.self) { metric in
-                            Text(metric.title).tag(metric)
+                    VStack(alignment: .leading, spacing: 10) {
+                        Text(NSLocalizedString("trackPerSet", comment: ""))
+                            .fontWeight(.semibold)
+                            .foregroundColor(.secondary)
+                        LazyVGrid(
+                            columns: [GridItem(.flexible()), GridItem(.flexible())],
+                            spacing: 8
+                        ) {
+                            ForEach(SetTrackedField.allCases, id: \.self) { field in
+                                trackedFieldChip(for: field)
+                            }
+                        }
+                        .animation(.easeInOut(duration: 0.2), value: muscleGroup)
+                        if let hint = selectionHint {
+                            Text(hint)
+                                .font(.footnote)
+                                .foregroundStyle(.secondary)
+                                .padding(.horizontal, 4)
                         }
                     }
-                    .pickerStyle(.segmented)
-                    .padding(.horizontal)
-                    .onChange(of: measurementType) { _, newType in
-                        let allowed = ExercisePrimaryMetric.allowed(for: newType)
-                        if !allowed.contains(primaryMetric) {
-                            primaryMetric = allowed.contains(.defaultMetric) ? .defaultMetric : allowed[0]
+
+                    if let measurementType {
+                        setPreview(for: measurementType)
+
+                        // Changing the type never rewrites history: recorded entries keep the
+                        // fields they were performed with; only new sets record the new fields.
+                        if exerciseToEdit != nil, measurementType != exerciseToEdit?.measurementType {
+                            Text(NSLocalizedString("measurementTypeChangeInfo", comment: ""))
+                                .font(.footnote)
+                                .foregroundStyle(.secondary)
+                                .padding(.horizontal, 4)
+                                .padding(.top, -SECTION_SPACING + 10)
                         }
+
+                        metricSection(for: measurementType)
                     }
                 }
-                Spacer()
+                .padding(.horizontal)
+                .padding(.bottom, 30)
+            }
+            .onChange(of: measurementType) { _, newType in
+                guard let newType else { return }
+                // A newly composed measurement resets the distance scale to its natural
+                // default — the user can still flip it right in the preview.
+                if let defaultStyle = newType.distanceStyle {
+                    distanceStyle = defaultStyle
+                }
+                let allowed = ExercisePrimaryMetric.allowed(for: newType)
+                if !allowed.contains(primaryMetric) {
+                    primaryMetric = allowed.contains(.defaultMetric) ? .defaultMetric : allowed[0]
+                }
             }
             .navigationTitle(
                 exerciseToEdit != nil
@@ -164,7 +150,7 @@ struct ExerciseEditScreen: View {
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button(NSLocalizedString("save", comment: "")) {
                         let trimmedName = exerciseName.trimmingCharacters(in: .whitespaces)
-                        
+
                         if trimmedName.isEmpty {
                             showingExerciseNameEmptyAlert = true
                         } else if trimmedName.hasPrefix("_default") {
@@ -186,6 +172,7 @@ struct ExerciseEditScreen: View {
                         }
                     }
                     .font(.body.weight(.semibold))
+                    .disabled(measurementType == nil)
                 }
             }
             .alert(
@@ -214,13 +201,308 @@ struct ExerciseEditScreen: View {
             }
         }
         .onAppear {
-            nameFieldIsFocused = true
+            // Autofocus only for a brand-new exercise — when editing, the user usually came
+            // for the measurement or muscle group, and the keyboard would bury both.
+            if exerciseToEdit == nil {
+                nameFieldIsFocused = true
+            }
+        }
+    }
+
+    // MARK: - Tracked Field Chips
+
+    private func trackedFieldChip(for field: SetTrackedField) -> some View {
+        let isSelected = trackedFields.contains(field)
+        // A field stays addable only while some measurement type contains the grown selection —
+        // this is where the two-field cap and the invalid pairings (reps+time) surface.
+        let isEnabled = isSelected
+            || SetMeasurementType.isSubsetOfAnyType(trackedFields.union([field]))
+        return Button {
+            UISelectionFeedbackGenerator().selectionChanged()
+            withAnimation(.snappy(duration: 0.25)) {
+                if isSelected {
+                    trackedFields.remove(field)
+                } else {
+                    trackedFields.insert(field)
+                }
+            }
+        } label: {
+            HStack(spacing: 10) {
+                Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                    .font(.title3)
+                    .foregroundStyle(isSelected ? selectionColor : Color.secondaryLabel)
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(title(for: field))
+                        .font(.callout.weight(.semibold))
+                        .foregroundStyle(Color.label)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.7)
+                    Text(unitHint(for: field))
+                        .font(.footnote)
+                        .foregroundStyle(Color.secondaryLabel)
+                        .lineLimit(1)
+                }
+                Spacer(minLength: 0)
+            }
+            .padding(CELL_PADDING)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                isSelected
+                    ? selectionColor.secondaryTranslucentBackground
+                    : Color.secondaryBackground
+            )
+            .cornerRadius(16)
+            .overlay(
+                RoundedRectangle(cornerRadius: 16)
+                    .strokeBorder(isSelected ? selectionColor : .clear, lineWidth: 1.5)
+            )
+        }
+        .buttonStyle(.plain)
+        .disabled(!isEnabled)
+        .opacity(isEnabled ? 1.0 : 0.4)
+        .accessibilityIdentifier("trackedFieldChip_\(field)")
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+    }
+
+    private func title(for field: SetTrackedField) -> String {
+        switch field {
+        case .repetitions: return NSLocalizedString("repetitions", comment: "")
+        case .weight: return NSLocalizedString("weight", comment: "")
+        case .duration: return NSLocalizedString("measurementType.duration", comment: "")
+        case .distance: return NSLocalizedString("measurementType.distance", comment: "")
+        }
+    }
+
+    /// The unit the recorder's field will carry — the caption explains a chip in the same
+    /// vocabulary the set row will use. Reps use the human-readable short form ("Reps"),
+    /// not the field's terse "rps".
+    private func unitHint(for field: SetTrackedField) -> String {
+        switch field {
+        case .repetitions: return NSLocalizedString("repsShort", comment: "")
+        case .weight: return WeightUnit.used.rawValue
+        case .duration: return NSLocalizedString("sec", comment: "")
+        case .distance: return "\(DistanceUnit.used.shortUnit) / \(DistanceUnit.used.rawValue)"
+        }
+    }
+
+    /// Only two incomplete selections are reachable (adding is capped to subsets of real
+    /// types): nothing at all, or weight without a partner.
+    private var selectionHint: String? {
+        guard measurementType == nil else { return nil }
+        return trackedFields.isEmpty
+            ? NSLocalizedString("trackingEmptyHint", comment: "")
+            : NSLocalizedString("trackingWeightAloneHint", comment: "")
+    }
+
+    // MARK: - Set Preview
+
+    /// A live render of one set row exactly as the recorder will show it — real field
+    /// components in their read-only mode, recessed on the same tile the set cells sit on.
+    private func setPreview(for measurementType: SetMeasurementType) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text(NSLocalizedString("setPreviewCaption", comment: ""))
+                .font(.footnote.weight(.medium))
+                .foregroundStyle(.secondary)
+            HStack {
+                Text("1")
+                    .fontWeight(.bold)
+                    .fontDesign(.rounded)
+                    .foregroundStyle(.secondary)
+                Spacer()
+                previewFields(for: measurementType)
+            }
+            .padding(.horizontal, CELL_PADDING)
+            .padding(.vertical, 10)
+            .secondaryTileStyle(insetShadow: true)
+            .canEdit(false)
+            if measurementType.usesDistance {
+                HStack {
+                    Text(NSLocalizedString("distanceUnit", comment: ""))
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                    Picker(
+                        NSLocalizedString("distanceUnit", comment: ""),
+                        selection: $distanceStyle
+                    ) {
+                        ForEach(SetMeasurementType.DistanceStyle.allCases, id: \.self) { style in
+                            Text(unitLabel(for: style)).tag(style)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                    .frame(maxWidth: 140)
+                    .accessibilityIdentifier("distanceStylePicker")
+                }
+                .font(.callout)
+            }
+        }
+        .padding(CELL_PADDING)
+        .tileStyle()
+        .accessibilityIdentifier("setPreviewTile")
+    }
+
+    /// Mirrors `SetEntryFieldsRow.fields`' order for each type, with sample values in the
+    /// read-only rendering the workout detail uses.
+    @ViewBuilder
+    private func previewFields(for measurementType: SetMeasurementType) -> some View {
+        switch measurementType {
+        case .repsAndWeight:
+            previewRepetitionsField(tertiary: 0)
+            previewWeightField(tertiary: 1)
+        case .repsOnly:
+            previewRepetitionsField(tertiary: 0)
+        case .duration:
+            previewDurationField(tertiary: 0)
+        case .weightAndDuration:
+            previewWeightField(tertiary: 0)
+            previewDurationField(tertiary: 1)
+        case .distance:
+            previewDistanceField(tertiary: 0)
+        case .distanceAndDuration:
+            previewDistanceField(tertiary: 0)
+            previewDurationField(tertiary: 1)
+        case .weightAndDistance:
+            previewWeightField(tertiary: 0)
+            previewDistanceField(tertiary: 1)
+        }
+    }
+
+    private func previewIndex(_ tertiary: Int) -> IntegerField.Index {
+        IntegerField.Index(setID: Self.previewSetID, secondary: 0, tertiary: tertiary)
+    }
+
+    private func previewRepetitionsField(tertiary: Int) -> some View {
+        IntegerField(
+            placeholder: 0,
+            value: .constant(12),
+            maxDigits: 4,
+            index: previewIndex(tertiary),
+            focusedIntegerFieldIndex: .constant(nil),
+            unit: NSLocalizedString("reps", comment: "")
+        )
+    }
+
+    private func previewWeightField(tertiary: Int) -> some View {
+        DecimalField(
+            placeholder: 0,
+            value: .constant(WeightUnit.used == .kg ? 60 : 135),
+            maxDigits: 4,
+            decimalPlaces: WeightUnit.used == .kg ? 3 : 2,
+            index: previewIndex(tertiary),
+            focusedIntegerFieldIndex: .constant(nil),
+            unit: WeightUnit.used.rawValue
+        )
+    }
+
+    private func previewDurationField(tertiary: Int) -> some View {
+        IntegerField(
+            placeholder: 0,
+            value: .constant(45),
+            maxDigits: 4,
+            index: previewIndex(tertiary),
+            focusedIntegerFieldIndex: .constant(nil),
+            unit: NSLocalizedString("sec", comment: "")
+        )
+    }
+
+    @ViewBuilder
+    private func previewDistanceField(tertiary: Int) -> some View {
+        switch distanceStyle {
+        case .long:
+            DecimalField(
+                placeholder: 0,
+                value: .constant(5),
+                maxDigits: 4,
+                decimalPlaces: 2,
+                index: previewIndex(tertiary),
+                focusedIntegerFieldIndex: .constant(nil),
+                unit: DistanceUnit.used.rawValue
+            )
+        case .short:
+            IntegerField(
+                placeholder: 0,
+                value: .constant(40),
+                maxDigits: 5,
+                index: previewIndex(tertiary),
+                focusedIntegerFieldIndex: .constant(nil),
+                unit: DistanceUnit.used.shortUnit
+            )
+        }
+    }
+
+    /// Compact segment label — "km" / "m" (or "mi" / "yd"), matching the preview's own unit.
+    private func unitLabel(for style: SetMeasurementType.DistanceStyle) -> String {
+        switch style {
+        case .long: return DistanceUnit.used.rawValue
+        case .short: return DistanceUnit.used.shortUnit
+        }
+    }
+
+    // MARK: - Progress Metric
+
+    private func metricSection(for measurementType: SetMeasurementType) -> some View {
+        // Only metrics that fit the chosen measurement — a plank never offers e1RM.
+        let allowedMetrics = ExercisePrimaryMetric.allowed(for: measurementType)
+        return VStack(alignment: .leading, spacing: 4) {
+            Text(NSLocalizedString("progressMetric", comment: ""))
+                .fontWeight(.semibold)
+                .foregroundColor(.secondary)
+            Text(NSLocalizedString("progressMetricCaption", comment: ""))
+                .font(.footnote)
+                .foregroundStyle(.tertiary)
+            VStack(spacing: 0) {
+                ForEach(allowedMetrics, id: \.self) { metric in
+                    Button {
+                        UISelectionFeedbackGenerator().selectionChanged()
+                        primaryMetric = metric
+                    } label: {
+                        HStack(spacing: 12) {
+                            Image(systemName: primaryMetric == metric ? "circle.inset.filled" : "circle")
+                                .font(.title3)
+                                .foregroundStyle(
+                                    primaryMetric == metric ? selectionColor : Color.secondaryLabel
+                                )
+                            VStack(alignment: .leading, spacing: 1) {
+                                Text(metric.title)
+                                    .font(.body.weight(.medium))
+                                    .foregroundStyle(Color.label)
+                                Text(metric.caption)
+                                    .font(.footnote)
+                                    .foregroundStyle(Color.secondaryLabel)
+                                    .multilineTextAlignment(.leading)
+                            }
+                            Spacer(minLength: 0)
+                        }
+                        .padding(CELL_PADDING)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityIdentifier("progressMetricOption_\(metric.rawValue)")
+                    .accessibilityAddTraits(primaryMetric == metric ? .isSelected : [])
+                    if metric != allowedMetrics.last {
+                        Divider()
+                            .padding(.leading, CELL_PADDING + 32)
+                    }
+                }
+            }
+            .tileStyle()
+            .padding(.top, 6)
+            .animation(.easeInOut(duration: 0.2), value: muscleGroup)
         }
     }
 
     // MARK: - Computed Properties
 
+    /// Selection controls wear the chosen muscle group's color, so the whole sheet reads as
+    /// one exercise rather than the muscle capsules disagreeing with a lime accent below.
+    private var selectionColor: Color {
+        muscleGroup.color
+    }
+
+    private var measurementType: SetMeasurementType? {
+        SetMeasurementType(trackedFields: trackedFields)
+    }
+
     private func saveExercise() {
+        guard let measurementType else { return }
         let exercise: Exercise
         if let exerciseToEdit = exerciseToEdit {
             exerciseToEdit.name = exerciseName.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/LOGIT/Features/Exercise/ExerciseListScreen.swift
+++ b/LOGIT/Features/Exercise/ExerciseListScreen.swift
@@ -119,6 +119,7 @@ struct ExerciseListScreen: View {
                     Button(action: { showingAddExercise.toggle() }) {
                         Image(systemName: "plus")
                     }
+                    .accessibilityIdentifier("addExerciseButton")
                 }
             }
             .sheet(isPresented: $showingAddExercise) {

--- a/LOGIT/SharedUI/Styles/ButtonStyle.swift
+++ b/LOGIT/SharedUI/Styles/ButtonStyle.swift
@@ -91,17 +91,21 @@ struct SelectionButtonStyle: ButtonStyle {
 struct CapsuleButtonStyle: ButtonStyle {
     let color: Color?
     let isSelected: Bool
+    /// Trims the horizontal padding for capsules that must wrap into rows rather than scroll —
+    /// all eight muscle groups only settle into two rows on a phone at the tighter inset.
+    let compact: Bool
 
-    init(color: Color? = nil, isSelected: Bool = true) {
+    init(color: Color? = nil, isSelected: Bool = true, compact: Bool = false) {
         self.color = color
         self.isSelected = isSelected
+        self.compact = compact
     }
 
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
-            .font(.system(.headline, design: .rounded, weight: .semibold))
-            .padding(.vertical, 8)
-            .padding(.horizontal, 15)
+            .font(.system(compact ? .subheadline : .headline, design: .rounded, weight: .semibold))
+            .padding(.vertical, compact ? 7 : 8)
+            .padding(.horizontal, compact ? 13 : 15)
             .foregroundStyle(
                 (isSelected ? Color.background : (color ?? .label)).gradient
             )

--- a/LOGIT/SharedUI/Views/MuscleGroupSelector.swift
+++ b/LOGIT/SharedUI/Views/MuscleGroupSelector.swift
@@ -12,54 +12,195 @@ struct MuscleGroupSelector: View {
     let muscleGroups: [MuscleGroup]
     let canBeNil: Bool
     let animation: Bool
+    /// Wrapped capsules show every group at once — the exercise editor uses this so no option
+    /// hides off-screen. The default stays the single scrolling row used by the filter bars.
+    let wraps: Bool
 
     init(
         selectedMuscleGroup: Binding<MuscleGroup?>,
         from muscleGroups: [MuscleGroup] = MuscleGroup.allCases,
         canBeNil: Bool = true,
-        withAnimation: Bool = false
+        withAnimation: Bool = false,
+        wraps: Bool = false
     ) {
         _selectedMuscleGroup = selectedMuscleGroup
         self.muscleGroups = muscleGroups
         self.canBeNil = canBeNil
         animation = withAnimation
+        self.wraps = wraps
     }
 
     var body: some View {
-        ScrollView(.horizontal, showsIndicators: false) {
-            HStack {
-                if canBeNil {
-                    Button(NSLocalizedString("all", comment: "")) {
-                        if animation {
-                            withAnimation {
-                                selectedMuscleGroup = nil
-                            }
-                        } else {
-                            selectedMuscleGroup = nil
-                        }
-                    }
-                    .buttonStyle(CapsuleButtonStyle(isSelected: selectedMuscleGroup == nil))
+        if wraps {
+            FlowLayout {
+                capsules
+            }
+        } else {
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack {
+                    capsules
                 }
-                ForEach(muscleGroups) { muscleGroup in
-                    Button(muscleGroup.description) {
-                        if animation {
-                            withAnimation {
-                                selectedMuscleGroup = muscleGroup
-                            }
-                        } else {
-                            selectedMuscleGroup = muscleGroup
-                        }
+                .padding(.horizontal)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var capsules: some View {
+        if canBeNil {
+            Button(NSLocalizedString("all", comment: "")) {
+                if animation {
+                    withAnimation {
+                        selectedMuscleGroup = nil
                     }
-                    .buttonStyle(
-                        CapsuleButtonStyle(
-                            color: muscleGroup.color,
-                            isSelected: selectedMuscleGroup == muscleGroup
-                        )
-                    )
+                } else {
+                    selectedMuscleGroup = nil
                 }
             }
-            .padding(.horizontal)
+            .buttonStyle(CapsuleButtonStyle(isSelected: selectedMuscleGroup == nil, compact: wraps))
         }
+        ForEach(muscleGroups) { muscleGroup in
+            Button(muscleGroup.description) {
+                if animation {
+                    withAnimation {
+                        selectedMuscleGroup = muscleGroup
+                    }
+                } else {
+                    selectedMuscleGroup = muscleGroup
+                }
+            }
+            .buttonStyle(
+                CapsuleButtonStyle(
+                    color: muscleGroup.color,
+                    isSelected: selectedMuscleGroup == muscleGroup,
+                    compact: wraps
+                )
+            )
+        }
+    }
+}
+
+/// Line-wrapping layout for variable-width capsules. Two things separate it from a plain
+/// wrap: rows are *balanced*, so eight muscle names settle into two even rows instead of
+/// three ragged ones, and each row is *justified*, so the capsules spread across the width
+/// rather than cramming against the leading edge. Localized names never truncate.
+struct FlowLayout: Layout {
+    /// The tightest gap between two capsules; justification only ever widens it.
+    var minSpacing: CGFloat = 8
+    /// How far a justified gap may open before the row is left-aligned instead — without a
+    /// ceiling, a short row would drift apart into disconnected islands.
+    var maxSpacing: CGFloat = 26
+    var rowSpacing: CGFloat = 8
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+        let sizes = subviews.map { $0.sizeThatFits(.unspecified) }
+        let maxWidth = proposal.width ?? .infinity
+        let rows = balancedRows(sizes: sizes, maxWidth: maxWidth)
+        let height = rows.reduce(0) { $0 + rowHeight($1, sizes: sizes) }
+            + rowSpacing * CGFloat(max(rows.count - 1, 0))
+        let widest = rows.map { rowWidth($0, sizes: sizes) }.max() ?? 0
+        return CGSize(width: proposal.width ?? widest, height: height)
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
+        let sizes = subviews.map { $0.sizeThatFits(.unspecified) }
+        let rows = balancedRows(sizes: sizes, maxWidth: bounds.width)
+        // One gap for the whole block, not per row: rows of different total width would
+        // otherwise each get their own rhythm, which reads as an accident rather than a grid.
+        let spacing = uniformSpacing(rows: rows, sizes: sizes, maxWidth: bounds.width)
+        var y = bounds.minY
+        for row in rows {
+            let height = rowHeight(row, sizes: sizes)
+            let width = row.reduce(0) { $0 + sizes[$1].width }
+                + spacing * CGFloat(max(row.count - 1, 0))
+            // Centered, so the leftover on a shorter row splits evenly instead of stranding
+            // the whole remainder on the trailing edge.
+            var x = bounds.minX + max(bounds.width - width, 0) / 2
+            for index in row {
+                let size = sizes[index]
+                subviews[index].place(
+                    at: CGPoint(x: x, y: y + (height - size.height) / 2),
+                    proposal: ProposedViewSize(size)
+                )
+                x += size.width + spacing
+            }
+            y += height + rowSpacing
+        }
+    }
+
+    /// The widest gap every row can afford — the fullest row sets the limit, so no row
+    /// overflows and all of them breathe alike.
+    private func uniformSpacing(rows: [[Int]], sizes: [CGSize], maxWidth: CGFloat) -> CGFloat {
+        let affordable = rows.compactMap { row -> CGFloat? in
+            let gaps = row.count - 1
+            guard gaps > 0 else { return nil }
+            let slack = maxWidth - row.reduce(0) { $0 + sizes[$1].width }
+            return slack / CGFloat(gaps)
+        }
+        guard let tightest = affordable.min() else { return minSpacing }
+        return min(max(tightest, minSpacing), maxSpacing)
+    }
+
+    // MARK: - Row Building
+
+    private func rowWidth(_ row: [Int], sizes: [CGSize]) -> CGFloat {
+        row.reduce(0) { $0 + sizes[$1].width } + minSpacing * CGFloat(max(row.count - 1, 0))
+    }
+
+    private func rowHeight(_ row: [Int], sizes: [CGSize]) -> CGFloat {
+        row.map { sizes[$0].height }.max() ?? 0
+    }
+
+    /// Packs into the fewest rows the width allows, then evens those rows out: the narrowest
+    /// row limit that still fits in that many rows is the balanced one, found by bisection.
+    /// Without this, greedy packing leaves the remainder stranded alone on a last line.
+    private func balancedRows(sizes: [CGSize], maxWidth: CGFloat) -> [[Int]] {
+        guard !sizes.isEmpty, maxWidth.isFinite, maxWidth > 0 else {
+            return sizes.isEmpty ? [] : [Array(sizes.indices)]
+        }
+        let greedy = pack(sizes: sizes, limit: maxWidth)
+        guard greedy.count > 1 else { return greedy }
+
+        var low = sizes.map(\.width).max() ?? 0
+        var high = maxWidth
+        var balanced = greedy
+        while high - low > 0.5 {
+            let mid = (low + high) / 2
+            let candidate = pack(sizes: sizes, limit: mid)
+            if candidate.count <= greedy.count {
+                balanced = candidate
+                high = mid
+            } else {
+                low = mid
+            }
+        }
+        return balanced
+    }
+
+    private func pack(sizes: [CGSize], limit: CGFloat) -> [[Int]] {
+        var rows: [[Int]] = []
+        var current: [Int] = []
+        var width: CGFloat = 0
+        for (index, size) in sizes.enumerated() {
+            if current.isEmpty {
+                current = [index]
+                width = size.width
+                continue
+            }
+            let grown = width + minSpacing + size.width
+            if grown > limit {
+                rows.append(current)
+                current = [index]
+                width = size.width
+            } else {
+                current.append(index)
+                width = grown
+            }
+        }
+        if !current.isEmpty {
+            rows.append(current)
+        }
+        return rows
     }
 }
 
@@ -68,5 +209,7 @@ struct MuscleGroupSelector_Previews: PreviewProvider {
         MuscleGroupSelector(selectedMuscleGroup: .constant(.chest))
         MuscleGroupSelector(selectedMuscleGroup: .constant(.chest), from: [.chest, .back])
         MuscleGroupSelector(selectedMuscleGroup: .constant(.chest), from: [])
+        MuscleGroupSelector(selectedMuscleGroup: .constant(.chest), canBeNil: false, wraps: true)
+            .padding()
     }
 }

--- a/LOGITUITests/ScenarioScreenshots.swift
+++ b/LOGITUITests/ScenarioScreenshots.swift
@@ -1003,6 +1003,183 @@ final class ScenarioScreenshots: XCTestCase {
         attach(app, "\(prefix)_02_summary_scrolled")
     }
 
+    // MARK: - Exercise editor (measurement builder)
+
+    /// The redesigned exercise editor: measurement type is composed from four tracked-field
+    /// chips with a live set preview, instead of the old seven-option dropdown. Drives the
+    /// full chip state machine — the two-field cap disabling chips, the only two reachable
+    /// incomplete selections (nothing, weight alone) disabling Save with a hint — then saves
+    /// a weight+distance exercise and confirms it landed in the list.
+    func testExerciseBuilderCreateFlow() {
+        let app = launchApp(scenario: "many")
+
+        let tabBar = app.tabBars.firstMatch
+        XCTAssertTrue(tabBar.waitForExistence(timeout: 30), "Tab bar never appeared")
+        waitABit(1)
+        tapTab(app, at: 3)
+        waitABit(1)
+
+        let exercisesRow = app.staticTexts["Exercises"].firstMatch
+        XCTAssertTrue(exercisesRow.waitForExistence(timeout: 5), "Exercises row missing on the Search tab")
+        exercisesRow.tap()
+        waitABit(1)
+
+        app.buttons["addExerciseButton"].firstMatch.tap()
+
+        let repsChip = app.buttons["trackedFieldChip_repetitions"]
+        let weightChip = app.buttons["trackedFieldChip_weight"]
+        let durationChip = app.buttons["trackedFieldChip_duration"]
+        let distanceChip = app.buttons["trackedFieldChip_distance"]
+        XCTAssertTrue(repsChip.waitForExistence(timeout: 5), "Builder chips missing on the editor")
+
+        // The name field autofocuses; name the exercise and dismiss the keyboard via return
+        // so the lower chips and preview stay hittable.
+        app.typeText("UITest Carry\n")
+        waitABit(1)
+        attach(app, "exercise_builder_new_default")
+
+        // Default Reps & Weight: the two-field cap disables the other chips.
+        XCTAssertFalse(durationChip.isEnabled, "Duration chip enabled despite two fields selected")
+        XCTAssertFalse(distanceChip.isEnabled, "Distance chip enabled despite two fields selected")
+        XCTAssertTrue(
+            app.descendants(matching: .any)["setPreviewTile"].exists,
+            "Set preview missing for a valid selection"
+        )
+
+        let saveButton = app.buttons["Save"].firstMatch
+
+        // Reps alone is a valid type; duration cannot join reps.
+        weightChip.tap()
+        waitABit(1)
+        XCTAssertFalse(durationChip.isEnabled, "Duration chip must not pair with reps")
+        XCTAssertTrue(saveButton.isEnabled, "Reps-only must be saveable")
+
+        // Empty selection: Save disabled, hint shown.
+        repsChip.tap()
+        waitABit(1)
+        XCTAssertFalse(saveButton.isEnabled, "Save enabled with nothing selected")
+        attach(app, "exercise_builder_empty_hint")
+
+        // Weight alone is incomplete: still no Save, partner hint shown.
+        weightChip.tap()
+        waitABit(1)
+        XCTAssertFalse(saveButton.isEnabled, "Save enabled with weight alone")
+
+        // Weight + distance: valid again — preview with the distance unit switch appears.
+        distanceChip.tap()
+        waitABit(1)
+        XCTAssertTrue(saveButton.isEnabled, "Save disabled for weight + distance")
+        // The segmented control swallows its SwiftUI identifier, so assert via its segments.
+        XCTAssertTrue(
+            app.buttons["km"].waitForExistence(timeout: 3) && app.buttons["m"].exists,
+            "Distance unit switch missing for a distance type"
+        )
+        attach(app, "exercise_builder_weight_distance")
+
+        saveButton.tap()
+        waitABit(2)
+
+        // The alphabetical list is lazy and huge — reach the U-named row through search;
+        // repeated snapshot-and-swipe loops time out the accessibility queries here.
+        let searchField = app.searchFields.firstMatch
+        if !searchField.waitForExistence(timeout: 3) {
+            app.buttons["Search"].firstMatch.tap()
+            XCTAssertTrue(searchField.waitForExistence(timeout: 5), "Exercise list search never opened")
+        }
+        searchField.tap()
+        app.typeText("UITest Carry")
+        waitABit(2)
+        XCTAssertTrue(
+            app.staticTexts["UITest Carry"].firstMatch.waitForExistence(timeout: 5),
+            "Saved exercise not in the list"
+        )
+        attach(app, "exercise_builder_saved_in_list")
+    }
+
+    /// Editing an existing exercise: the builder must arrive prefilled from the exercise's
+    /// measurement type, and changing the type must surface the history-safety footnote.
+    /// Default exercises can't be edited, so the flow first creates a duration-only exercise,
+    /// then reopens it through detail → menu → Edit.
+    func testExerciseBuilderEditExistingFlow() {
+        let app = launchApp(scenario: "many")
+
+        let tabBar = app.tabBars.firstMatch
+        XCTAssertTrue(tabBar.waitForExistence(timeout: 30), "Tab bar never appeared")
+        waitABit(1)
+        tapTab(app, at: 3)
+        waitABit(1)
+
+        let exercisesRow = app.staticTexts["Exercises"].firstMatch
+        XCTAssertTrue(exercisesRow.waitForExistence(timeout: 5), "Exercises row missing on the Search tab")
+        exercisesRow.tap()
+        waitABit(1)
+
+        app.buttons["addExerciseButton"].firstMatch.tap()
+
+        let repsChip = app.buttons["trackedFieldChip_repetitions"]
+        let weightChip = app.buttons["trackedFieldChip_weight"]
+        let durationChip = app.buttons["trackedFieldChip_duration"]
+        XCTAssertTrue(repsChip.waitForExistence(timeout: 5), "Builder chips missing on the editor")
+
+        // Compose a duration-only exercise: drop reps and weight, add duration.
+        app.typeText("UITest Plank\n")
+        waitABit(1)
+        repsChip.tap()
+        weightChip.tap()
+        durationChip.tap()
+        waitABit(1)
+        app.buttons["Save"].firstMatch.tap()
+        waitABit(2)
+
+        // Reach the new exercise through search — repeatedly snapshotting the full
+        // alphabetical list while swiping times out the accessibility queries.
+        let searchField = app.searchFields.firstMatch
+        if !searchField.waitForExistence(timeout: 3) {
+            app.buttons["Search"].firstMatch.tap()
+            XCTAssertTrue(searchField.waitForExistence(timeout: 5), "Exercise list search never opened")
+        }
+        searchField.tap()
+        app.typeText("UITest Plank")
+        waitABit(2)
+
+        let savedRow = app.staticTexts["UITest Plank"].firstMatch
+        XCTAssertTrue(savedRow.waitForExistence(timeout: 5), "Created exercise not found via search")
+        savedRow.tap()
+        waitABit(3) // charts on the detail screen need a moment before heavy queries
+
+        let detailMenu = app.buttons["exerciseDetailMenu"].firstMatch
+        XCTAssertTrue(detailMenu.waitForExistence(timeout: 10), "Detail screen never opened")
+        detailMenu.tap()
+        let editItem = app.buttons["Edit"].firstMatch
+        XCTAssertTrue(editItem.waitForExistence(timeout: 3), "Edit item missing from the detail menu")
+        editItem.tap()
+        waitABit(1)
+
+        // The builder arrives prefilled: duration on, reps unpairable, weight addable.
+        XCTAssertTrue(durationChip.waitForExistence(timeout: 5), "Builder chips missing when editing")
+        XCTAssertTrue(durationChip.isSelected, "Duration chip not prefilled from the exercise")
+        XCTAssertFalse(repsChip.isEnabled, "Reps chip must not pair with duration")
+        XCTAssertTrue(weightChip.isEnabled, "Weight chip must be addable to duration")
+        attach(app, "exercise_builder_edit_prefilled")
+
+        // Changing the type shows the history-safety footnote.
+        weightChip.tap()
+        waitABit(1)
+        XCTAssertTrue(
+            app.staticTexts["Existing sets keep the values they were recorded with. Only new sets use the new measurement."]
+                .waitForExistence(timeout: 3),
+            "Type-change footnote missing after changing the measurement"
+        )
+        attach(app, "exercise_builder_edit_type_changed")
+
+        app.buttons["Save"].firstMatch.tap()
+        waitABit(2)
+        XCTAssertTrue(
+            app.staticTexts["UITest Plank"].firstMatch.waitForExistence(timeout: 5),
+            "Detail screen not visible after saving the edit"
+        )
+    }
+
     // MARK: - Helpers
 
     private func launchApp(scenario: String, extraArguments: [String] = []) -> XCUIApplication {


### PR DESCRIPTION
The edit-exercise screen asked its most consequential question through a bare dropdown of seven schema-flavored names — "Weight & Duration" vs. "Distance & Duration" — with nothing to show what a set would actually ask for. It now asks the question lifters answer anyway: **what do you write down per set?**

Four toggle chips (Reps, Weight, Duration, Distance) over a **live preview of one set row**.

## How it maps onto the model

`SetMeasurementType` is untouched. It gains a `trackedFields` derivation (built from its existing `uses*` flags, so the two views of the same fact can't drift) plus `init?(trackedFields:)`. A chip stays tappable only while the grown selection is still a subset of some real type — so the two-field cap and the invalid pairings (reps + duration names no type) fall out of the model instead of hand-written rules.

That leaves exactly two reachable incomplete states — nothing selected, and weight alone — each showing a hint and disabling Save.

## The preview is the description

It renders the recorder's own `IntegerField` / `DecimalField` in their read-only mode, on the set cell's recessed tile, in the same field order `SetEntryFieldsRow` uses per type. No hand-drawn replica to fall out of date.

The distance unit switch moved inside that tile — it used to appear and disappear as its own section, reflowing the form under your thumb.

## Alongside

- **Selection wears the chosen muscle group's color**, so the sheet reads as one exercise rather than lime chips arguing with colored capsules.
- **Muscle capsules wrap into two balanced, evenly gapped rows** (new `FlowLayout` + a compact `CapsuleButtonStyle` inset) instead of scrolling half the groups off the right edge. Checked in English and German; the scrolling filter bars elsewhere are unchanged.
- **Progress Metric became captioned radio rows** — "e1RM" now introduces itself, and a caption says where the choice actually shows up.
- The name field only autofocuses when creating; when editing, the keyboard no longer buries the controls you came for.
- Changing an existing exercise's type still surfaces the history-safety footnote — recorded sets keep their values.

Ten new strings across all eight locales.

## Verification

Two new UI tests in `ScenarioScreenshots`, both green on the iOS 26.4 simulator:

- `testExerciseBuilderCreateFlow` — drives the full chip state machine (two-field cap disabling chips, both incomplete states disabling Save), saves a weight+distance exercise, confirms it lands in the list.
- `testExerciseBuilderEditExistingFlow` — chips arrive prefilled from an existing exercise's measurement type; changing it surfaces the footnote.

Design exploration and annotated before/after captures: https://claude.ai/code/artifact/0f832089-05d0-4fc6-9e98-20859922e978

🤖 Generated with [Claude Code](https://claude.com/claude-code)
