### PR TITLE
Summary Progress tab: Strength Progress on top, Highlights carousel, duration formatting

### DIFF
--- a/LOGIT.xcodeproj/project.pbxproj
+++ b/LOGIT.xcodeproj/project.pbxproj
@@ -18,7 +18,9 @@
 		28E43ABE4881F802FBBACCE9 /* RangePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F685CCE0EE8FE86E8E0135C /* RangePicker.swift */; };
 		2A384BE3816900000002 /* ExerciseSuggestionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54EE2592821500000001 /* ExerciseSuggestionService.swift */; };
 		2BD2E4720FB2C657F8CA372B /* CompletionRing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C72085C4C10146858277690 /* CompletionRing.swift */; };
+		341961F0E25343384F192151 /* ProgressHighlights.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FF2AD8F630BC39E7A090D62 /* ProgressHighlights.swift */; };
 		34ED649B10150341352AE3D1 /* StatPeriodTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F8CD271000D75928FAE0887 /* StatPeriodTests.swift */; };
+		37D658746432D205B9A100B7 /* DurationFormatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E5AE5DB723E798F9B5C1B84 /* DurationFormatting.swift */; };
 		396ADE67CD8C1D14F7A8D82A /* LOGITWidgetExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3BDDD14FE5BF0C275AF30C5 /* LOGITWidgetExtension.swift */; };
 		435F070826CC8D1F8D7239B8 /* WorkoutDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4845CEF582EB23AB447C90B2 /* WorkoutDTO.swift */; };
 		53B547C48713887B1E5542EE /* MuscleBalanceCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0258213863A5C9812190A44D /* MuscleBalanceCalculator.swift */; };
@@ -300,6 +302,7 @@
 		E5F79A5B29FEF4F260749E66 /* LiveActivityShowcaseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A95CC85E7895692DD1082ACD /* LiveActivityShowcaseView.swift */; };
 		F344926EBBAE89A564139E06 /* MuscleTargetSplitStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DDAB0743896FB9245B6D5A9 /* MuscleTargetSplitStore.swift */; };
 		F83E8531DDDC8C271BDF20F1 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A72B470FE19DAE1E42233F7F /* Foundation.framework */; };
+		F9CE85436E7F6E6314F09662 /* ProgressHighlightCards.swift in Sources */ = {isa = PBXBuildFile; fileRef = 391121B40138EB15F263AD08 /* ProgressHighlightCards.swift */; };
 		FAC9CFA615E04E86BD814205 /* OneRepMaxCalculating.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6923C33A92504E5287236332 /* OneRepMaxCalculating.swift */; };
 		FE01CA11AB1E5077AE000002 /* SummaryProgressTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE01CA11AB1E5077AE000001 /* SummaryProgressTab.swift */; };
 		FF178CF5635C188320F0E7B4 /* WorkoutLiveActivityWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19AE937C7333501AE5BD9977 /* WorkoutLiveActivityWidget.swift */; };
@@ -367,15 +370,18 @@
 		19AE937C7333501AE5BD9977 /* WorkoutLiveActivityWidget.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkoutLiveActivityWidget.swift; sourceTree = "<group>"; };
 		1EB3B92BF7A5E9FE9E442716 /* WorkoutSharingService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkoutSharingService.swift; sourceTree = "<group>"; };
 		1F685CCE0EE8FE86E8E0135C /* RangePicker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RangePicker.swift; sourceTree = "<group>"; };
+		1FF2AD8F630BC39E7A090D62 /* ProgressHighlights.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ProgressHighlights.swift; sourceTree = "<group>"; };
 		22040B8B5D5971A78B9E3A04 /* Pods_LOGIT.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_LOGIT.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2B422D4E53B9396026019B50 /* SummaryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryViewModel.swift; sourceTree = "<group>"; };
 		3184F4CAAB24791B6F5AC79A /* SharedWithYouBanner.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SharedWithYouBanner.swift; sourceTree = "<group>"; };
 		336772BB4E860E3894BA7355 /* SummaryStatTiles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryStatTiles.swift; sourceTree = "<group>"; };
+		391121B40138EB15F263AD08 /* ProgressHighlightCards.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ProgressHighlightCards.swift; sourceTree = "<group>"; };
 		3C72085C4C10146858277690 /* CompletionRing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionRing.swift; sourceTree = "<group>"; };
 		3CDACB5BDD447438F8D60BAE /* LOGITScreenshots.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LOGITScreenshots.swift; sourceTree = "<group>"; };
 		4845CEF582EB23AB447C90B2 /* WorkoutDTO.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkoutDTO.swift; sourceTree = "<group>"; };
 		4B6F634C95B552C305EA0055 /* WorkoutLiveActivitySnapshotBuilder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkoutLiveActivitySnapshotBuilder.swift; sourceTree = "<group>"; };
 		4DDAB0743896FB9245B6D5A9 /* MuscleTargetSplitStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MuscleTargetSplitStore.swift; sourceTree = "<group>"; };
+		4E5AE5DB723E798F9B5C1B84 /* DurationFormatting.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DurationFormatting.swift; sourceTree = "<group>"; };
 		547CD2BA3A17B483651496C5 /* MuscleBalanceTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MuscleBalanceTile.swift; sourceTree = "<group>"; };
 		54EE2592821500000001 /* ExerciseSuggestionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseSuggestionService.swift; sourceTree = "<group>"; };
 		54FB7DD2DDA0DE70BD366F9C /* MuscleGroupsOverviewScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MuscleGroupsOverviewScreen.swift; sourceTree = "<group>"; };
@@ -560,8 +566,8 @@
 		80AA00072F3A000100AA0001 /* RestDurationEditorSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestDurationEditorSheet.swift; sourceTree = "<group>"; };
 		80AA00072F5CAA0100AA0007 /* LOGIT 7.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "LOGIT 7.0.xcdatamodel"; sourceTree = "<group>"; };
 		80AA00082F70CC0100AA0008 /* LOGIT 8.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "LOGIT 8.0.xcdatamodel"; sourceTree = "<group>"; };
-		80AA00092F84DD0100AA0009 /* LOGIT 9.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "LOGIT 9.0.xcdatamodel"; sourceTree = "<group>"; };
 		80AA00092F3A000100AA0001 /* WorkoutRecorderFloatingTimerButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutRecorderFloatingTimerButton.swift; sourceTree = "<group>"; };
+		80AA00092F84DD0100AA0009 /* LOGIT 9.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "LOGIT 9.0.xcdatamodel"; sourceTree = "<group>"; };
 		80AA000B2F3A000100AA0001 /* WorkoutRecorderFloatingStopwatchStopButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutRecorderFloatingStopwatchStopButton.swift; sourceTree = "<group>"; };
 		80AA10022F5CAA0200AA1002 /* DeterministicUUID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeterministicUUID.swift; sourceTree = "<group>"; };
 		80AA10042F5CAA0200AA1004 /* DefaultTemplateService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultTemplateService.swift; sourceTree = "<group>"; };
@@ -906,6 +912,7 @@
 				8E740E99321E2590B08B80A0 /* HealthKitSyncManager.swift */,
 				D6430636F05E66F518AE5872 /* CalorieEstimator.swift */,
 				0EC1A1AB3B397E77717694AF /* BodyWeightSyncManager.swift */,
+				4E5AE5DB723E798F9B5C1B84 /* DurationFormatting.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -1075,6 +1082,8 @@
 				DE557E27ADC9A2C02BE79DBE /* SummaryStatScreen.swift */,
 				2B422D4E53B9396026019B50 /* SummaryViewModel.swift */,
 				801BBD032DF7338A00CDB1FB /* TargetPerWeekDetailScreen.swift */,
+				1FF2AD8F630BC39E7A090D62 /* ProgressHighlights.swift */,
+				391121B40138EB15F263AD08 /* ProgressHighlightCards.swift */,
 			);
 			path = Home;
 			sourceTree = "<group>";
@@ -1875,6 +1884,9 @@
 				94B930251BE222630CF21349 /* CalorieEstimator.swift in Sources */,
 				8628A1F9D2552C1D90998743 /* WorkoutCalorieRow.swift in Sources */,
 				5FA589471AAA718BF29F5E04 /* BodyWeightSyncManager.swift in Sources */,
+				341961F0E25343384F192151 /* ProgressHighlights.swift in Sources */,
+				F9CE85436E7F6E6314F09662 /* ProgressHighlightCards.swift in Sources */,
+				37D658746432D205B9A100B7 /* DurationFormatting.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/LOGIT/Core/Environment/de.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/de.lproj/Localizable.strings
@@ -1018,13 +1018,30 @@
 
 
 /* Progress tab — overall progress trend */
-"overallProgress" = "Gesamtfortschritt";
+"strengthProgress" = "Kraftfortschritt";
 "trendingUp" = "Aufwärtstrend";
 "trendingSteady" = "Stabil";
 "trendingDown" = "Abwärtstrend";
 "byMuscleGroup" = "Nach Muskelgruppe";
-"overallProgressBasis" = "Geschätztes 1RM · letzte 8 Wochen vs. die 8 davor";
-"overallProgressEmpty" = "Logge weiter Workouts, um deinen Gesamttrend zu sehen.";
+"strengthProgressBasis" = "Geschätztes 1RM · letzte 8 Wochen vs. die 8 davor";
+"strengthProgressEmpty" = "Logge weiter Workouts, um deinen Krafttrend zu sehen.";
+
+// Progress highlights (carousel cards)
+"firstTimePast" = "Erstmals über %@";
+"trendMoreVolume" = "Mehr Volumen";
+"trendMoreSets" = "Mehr Sätze";
+"trendMoreWorkouts" = "Mehr Workouts";
+"trendMuscleSets" = "Mehr %@-Sätze";
+"trendExerciseVolume" = "%@-Volumen steigt";
+"allWorkouts" = "Alle Workouts";
+"trendWindowCaption" = "Letzte 4 Wochen vs. die 4 davor";
+"last4Weeks" = "Letzte 4 Wochen";
+"fourWeeksBefore" = "4 Wochen davor";
+"yearSoFar" = "%@ bisher";
+"yearCrossingHeadline" = "%@ hat %@ schon übertroffen";
+"monthsToSpare" = "mit %d Monaten Vorsprung";
+"monthToSpare" = "mit 1 Monat Vorsprung";
+"highlightsInfo" = "Meilensteine und Rekorde umfassen die letzten 4 Wochen. Trends vergleichen die letzten 4 Wochen mit den 4 davor.";
 "streak" = "Streak";
 
 // Timeframe unification: shared chart ranges + per-period muscle history

--- a/LOGIT/Core/Environment/en.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/en.lproj/Localizable.strings
@@ -1022,13 +1022,30 @@
 
 
 /* Progress tab — overall progress trend */
-"overallProgress" = "Overall Progress";
+"strengthProgress" = "Strength Progress";
 "trendingUp" = "Trending up";
 "trendingSteady" = "Holding steady";
 "trendingDown" = "Trending down";
 "byMuscleGroup" = "By muscle group";
-"overallProgressBasis" = "Estimated 1RM · last 8 weeks vs the 8 before";
-"overallProgressEmpty" = "Keep logging workouts to see your overall trend.";
+"strengthProgressBasis" = "Estimated 1RM · last 8 weeks vs the 8 before";
+"strengthProgressEmpty" = "Keep logging workouts to see your strength trend.";
+
+// Progress highlights (carousel cards)
+"firstTimePast" = "First time past %@";
+"trendMoreVolume" = "More volume";
+"trendMoreSets" = "More sets";
+"trendMoreWorkouts" = "More workouts";
+"trendMuscleSets" = "More %@ sets";
+"trendExerciseVolume" = "%@ volume is up";
+"allWorkouts" = "All workouts";
+"trendWindowCaption" = "Last 4 weeks vs the 4 before";
+"last4Weeks" = "Last 4 weeks";
+"fourWeeksBefore" = "4 weeks before";
+"yearSoFar" = "%@ so far";
+"yearCrossingHeadline" = "%@ already beat %@";
+"monthsToSpare" = "with %d months to spare";
+"monthToSpare" = "with 1 month to spare";
+"highlightsInfo" = "Milestones and records cover the last 4 weeks. Trends compare the last 4 weeks with the 4 before.";
 "streak" = "Streak";
 
 // Timeframe unification: shared chart ranges + per-period muscle history

--- a/LOGIT/Core/Environment/es.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/es.lproj/Localizable.strings
@@ -1022,13 +1022,30 @@
 
 
 /* Progress tab — overall progress trend */
-"overallProgress" = "Progreso general";
+"strengthProgress" = "Progreso de fuerza";
 "trendingUp" = "Tendencia al alza";
 "trendingSteady" = "Estable";
 "trendingDown" = "Tendencia a la baja";
 "byMuscleGroup" = "Por grupo muscular";
-"overallProgressBasis" = "1RM estimado · últimas 8 semanas vs. las 8 anteriores";
-"overallProgressEmpty" = "Sigue registrando entrenamientos para ver tu tendencia general.";
+"strengthProgressBasis" = "1RM estimado · últimas 8 semanas vs. las 8 anteriores";
+"strengthProgressEmpty" = "Sigue registrando entrenamientos para ver tu tendencia de fuerza.";
+
+// Progress highlights (carousel cards)
+"firstTimePast" = "Primera vez por encima de %@";
+"trendMoreVolume" = "Más volumen";
+"trendMoreSets" = "Más series";
+"trendMoreWorkouts" = "Más entrenamientos";
+"trendMuscleSets" = "Más series de %@";
+"trendExerciseVolume" = "Sube el volumen de %@";
+"allWorkouts" = "Todos los entrenamientos";
+"trendWindowCaption" = "Últimas 4 semanas vs. las 4 anteriores";
+"last4Weeks" = "Últimas 4 semanas";
+"fourWeeksBefore" = "4 semanas antes";
+"yearSoFar" = "%@ hasta ahora";
+"yearCrossingHeadline" = "%@ ya superó a %@";
+"monthsToSpare" = "con %d meses de margen";
+"monthToSpare" = "con 1 mes de margen";
+"highlightsInfo" = "Los hitos y récords cubren las últimas 4 semanas. Las tendencias comparan las últimas 4 semanas con las 4 anteriores.";
 "streak" = "Racha";
 
 // Timeframe unification: shared chart ranges + per-period muscle history

--- a/LOGIT/Core/Environment/fr.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/fr.lproj/Localizable.strings
@@ -1022,13 +1022,30 @@
 
 
 /* Progress tab — overall progress trend */
-"overallProgress" = "Progression globale";
+"strengthProgress" = "Progression en force";
 "trendingUp" = "En hausse";
 "trendingSteady" = "Stable";
 "trendingDown" = "En baisse";
 "byMuscleGroup" = "Par groupe musculaire";
-"overallProgressBasis" = "1RM estimé · 8 dernières semaines vs les 8 précédentes";
-"overallProgressEmpty" = "Continuez à enregistrer des séances pour voir votre tendance globale.";
+"strengthProgressBasis" = "1RM estimé · 8 dernières semaines vs les 8 précédentes";
+"strengthProgressEmpty" = "Continuez à enregistrer des séances pour voir votre tendance de force.";
+
+// Progress highlights (carousel cards)
+"firstTimePast" = "Première fois au-dessus de %@";
+"trendMoreVolume" = "Plus de volume";
+"trendMoreSets" = "Plus de séries";
+"trendMoreWorkouts" = "Plus de séances";
+"trendMuscleSets" = "Plus de séries pour %@";
+"trendExerciseVolume" = "Volume de %@ en hausse";
+"allWorkouts" = "Toutes les séances";
+"trendWindowCaption" = "4 dernières semaines vs les 4 précédentes";
+"last4Weeks" = "4 dernières semaines";
+"fourWeeksBefore" = "4 semaines avant";
+"yearSoFar" = "%@ jusqu'ici";
+"yearCrossingHeadline" = "%@ a déjà dépassé %@";
+"monthsToSpare" = "avec %d mois d'avance";
+"monthToSpare" = "avec 1 mois d'avance";
+"highlightsInfo" = "Les jalons et records couvrent les 4 dernières semaines. Les tendances comparent les 4 dernières semaines aux 4 précédentes.";
 "streak" = "Série";
 
 // Timeframe unification: shared chart ranges + per-period muscle history

--- a/LOGIT/Core/Environment/it.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/it.lproj/Localizable.strings
@@ -1022,13 +1022,30 @@
 
 
 /* Progress tab — overall progress trend */
-"overallProgress" = "Progresso generale";
+"strengthProgress" = "Progresso di forza";
 "trendingUp" = "In crescita";
 "trendingSteady" = "Stabile";
 "trendingDown" = "In calo";
 "byMuscleGroup" = "Per gruppo muscolare";
-"overallProgressBasis" = "1RM stimato · ultime 8 settimane vs le 8 precedenti";
-"overallProgressEmpty" = "Continua a registrare allenamenti per vedere il tuo andamento generale.";
+"strengthProgressBasis" = "1RM stimato · ultime 8 settimane vs le 8 precedenti";
+"strengthProgressEmpty" = "Continua a registrare allenamenti per vedere il tuo andamento di forza.";
+
+// Progress highlights (carousel cards)
+"firstTimePast" = "Prima volta oltre %@";
+"trendMoreVolume" = "Più volume";
+"trendMoreSets" = "Più serie";
+"trendMoreWorkouts" = "Più allenamenti";
+"trendMuscleSets" = "Più serie per %@";
+"trendExerciseVolume" = "Volume di %@ in crescita";
+"allWorkouts" = "Tutti gli allenamenti";
+"trendWindowCaption" = "Ultime 4 settimane vs le 4 precedenti";
+"last4Weeks" = "Ultime 4 settimane";
+"fourWeeksBefore" = "4 settimane prima";
+"yearSoFar" = "%@ finora";
+"yearCrossingHeadline" = "%@ ha già superato %@";
+"monthsToSpare" = "con %d mesi di anticipo";
+"monthToSpare" = "con 1 mese di anticipo";
+"highlightsInfo" = "Traguardi e record coprono le ultime 4 settimane. Le tendenze confrontano le ultime 4 settimane con le 4 precedenti.";
 "streak" = "Serie";
 
 // Timeframe unification: shared chart ranges + per-period muscle history

--- a/LOGIT/Core/Environment/ja.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/ja.lproj/Localizable.strings
@@ -1022,13 +1022,30 @@
 
 
 /* Progress tab — overall progress trend */
-"overallProgress" = "全体の進捗";
+"strengthProgress" = "筋力の進捗";
 "trendingUp" = "上昇傾向";
 "trendingSteady" = "横ばい";
 "trendingDown" = "下降傾向";
 "byMuscleGroup" = "筋群別";
-"overallProgressBasis" = "推定1RM · 直近8週間 vs その前の8週間";
-"overallProgressEmpty" = "ワークアウトを記録すると全体の傾向が表示されます。";
+"strengthProgressBasis" = "推定1RM · 直近8週間 vs その前の8週間";
+"strengthProgressEmpty" = "ワークアウトを記録すると筋力の傾向が表示されます。";
+
+// Progress highlights (carousel cards)
+"firstTimePast" = "初めて%@を突破";
+"trendMoreVolume" = "ボリューム増加";
+"trendMoreSets" = "セット数増加";
+"trendMoreWorkouts" = "ワークアウト増加";
+"trendMuscleSets" = "%@のセット数が増加";
+"trendExerciseVolume" = "%@のボリューム上昇";
+"allWorkouts" = "すべてのワークアウト";
+"trendWindowCaption" = "直近4週間 vs その前の4週間";
+"last4Weeks" = "直近4週間";
+"fourWeeksBefore" = "その前の4週間";
+"yearSoFar" = "%@年 これまで";
+"yearCrossingHeadline" = "%@年が%@年をすでに上回りました";
+"monthsToSpare" = "%dか月を残して";
+"monthToSpare" = "1か月を残して";
+"highlightsInfo" = "マイルストーンと記録は直近4週間が対象です。トレンドは直近4週間とその前の4週間を比較します。";
 "streak" = "連続記録";
 
 // Timeframe unification: shared chart ranges + per-period muscle history

--- a/LOGIT/Core/Environment/ko.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/ko.lproj/Localizable.strings
@@ -1022,13 +1022,30 @@
 
 
 /* Progress tab — overall progress trend */
-"overallProgress" = "전체 진행 상황";
+"strengthProgress" = "근력 진행 상황";
 "trendingUp" = "상승세";
 "trendingSteady" = "유지";
 "trendingDown" = "하락세";
 "byMuscleGroup" = "근육군별";
-"overallProgressBasis" = "추정 1RM · 최근 8주 vs 이전 8주";
-"overallProgressEmpty" = "운동을 계속 기록하면 전체 추세를 볼 수 있습니다.";
+"strengthProgressBasis" = "추정 1RM · 최근 8주 vs 이전 8주";
+"strengthProgressEmpty" = "운동을 계속 기록하면 근력 추세를 볼 수 있습니다.";
+
+// Progress highlights (carousel cards)
+"firstTimePast" = "처음으로 %@ 돌파";
+"trendMoreVolume" = "볼륨 증가";
+"trendMoreSets" = "세트 증가";
+"trendMoreWorkouts" = "운동 횟수 증가";
+"trendMuscleSets" = "%@ 세트 증가";
+"trendExerciseVolume" = "%@ 볼륨 상승";
+"allWorkouts" = "모든 운동";
+"trendWindowCaption" = "최근 4주 vs 이전 4주";
+"last4Weeks" = "최근 4주";
+"fourWeeksBefore" = "이전 4주";
+"yearSoFar" = "%@년 현재까지";
+"yearCrossingHeadline" = "%@년이 벌써 %@년을 넘어섰어요";
+"monthsToSpare" = "%d개월 남기고";
+"monthToSpare" = "1개월 남기고";
+"highlightsInfo" = "마일스톤과 기록은 최근 4주를 다룹니다. 추세는 최근 4주와 이전 4주를 비교합니다.";
 "streak" = "연속 기록";
 
 // Timeframe unification: shared chart ranges + per-period muscle history

--- a/LOGIT/Core/Environment/pt-BR.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/pt-BR.lproj/Localizable.strings
@@ -1022,13 +1022,30 @@
 
 
 /* Progress tab — overall progress trend */
-"overallProgress" = "Progresso geral";
+"strengthProgress" = "Progresso de força";
 "trendingUp" = "Em alta";
 "trendingSteady" = "Estável";
 "trendingDown" = "Em queda";
 "byMuscleGroup" = "Por grupo muscular";
-"overallProgressBasis" = "1RM estimado · últimas 8 semanas vs. as 8 anteriores";
-"overallProgressEmpty" = "Continue registrando treinos para ver sua tendência geral.";
+"strengthProgressBasis" = "1RM estimado · últimas 8 semanas vs. as 8 anteriores";
+"strengthProgressEmpty" = "Continue registrando treinos para ver sua tendência de força.";
+
+// Progress highlights (carousel cards)
+"firstTimePast" = "Primeira vez acima de %@";
+"trendMoreVolume" = "Mais volume";
+"trendMoreSets" = "Mais séries";
+"trendMoreWorkouts" = "Mais treinos";
+"trendMuscleSets" = "Mais séries de %@";
+"trendExerciseVolume" = "Volume de %@ subindo";
+"allWorkouts" = "Todos os treinos";
+"trendWindowCaption" = "Últimas 4 semanas vs. as 4 anteriores";
+"last4Weeks" = "Últimas 4 semanas";
+"fourWeeksBefore" = "4 semanas antes";
+"yearSoFar" = "%@ até agora";
+"yearCrossingHeadline" = "%@ já superou %@";
+"monthsToSpare" = "com %d meses de sobra";
+"monthToSpare" = "com 1 mês de sobra";
+"highlightsInfo" = "Marcos e recordes cobrem as últimas 4 semanas. As tendências comparam as últimas 4 semanas com as 4 anteriores.";
 "streak" = "Sequência";
 
 // Timeframe unification: shared chart ranges + per-period muscle history

--- a/LOGIT/Core/Utilities/DurationFormatting.swift
+++ b/LOGIT/Core/Utilities/DurationFormatting.swift
@@ -1,0 +1,38 @@
+//
+//  DurationFormatting.swift
+//  LOGIT
+//
+//  Created by Lukas Kaibel on 27.07.26.
+//
+
+import Foundation
+
+/// How a recorded duration (a held plank, a treadmill run — stored as whole seconds) is written
+/// wherever it is *displayed* rather than edited: the digital reading the rest timer and stopwatch
+/// already use, so a 90-second hold and a 90-second rest are spelled the same way.
+///
+/// "0:45", "1:30", "21:20", and "1:01:40" once past an hour. The string carries its own separators,
+/// so callers pass an **empty unit** instead of "sec" — a bare seconds count ("1280 SEC") is
+/// unreadable at a glance and can't be compared against another at a glance either.
+///
+/// The set-entry fields are deliberately not on this path: they are two separate minute and second
+/// fields, and a combined string is not editable.
+public func formatDurationForDisplay(_ seconds: Int) -> String {
+    let total = max(seconds, 0)
+    let hours = total / 3600
+    let minutes = (total % 3600) / 60
+    let secondsPart = total % 60
+    if hours > 0 {
+        return String(format: "%d:%02d:%02d", hours, minutes, secondsPart)
+    }
+    return String(format: "%d:%02d", minutes, secondsPart)
+}
+
+/// The same duration spelled out for VoiceOver — "21 minutes, 20 seconds" — because the digital
+/// reading is spoken as a pair of bare numbers ("twenty-one twenty"). Zero-valued units drop out,
+/// so a sub-minute hold reads simply as "45 seconds".
+public func accessibleDurationForDisplay(_ seconds: Int) -> String {
+    Duration.seconds(max(seconds, 0)).formatted(
+        .units(allowed: [.hours, .minutes, .seconds], width: .wide, zeroValueUnits: .hide)
+    )
+}

--- a/LOGIT/Core/Utilities/VolumeCalculating.swift
+++ b/LOGIT/Core/Utilities/VolumeCalculating.swift
@@ -61,3 +61,16 @@ public func getVolume(of groupedSets: [[WorkoutSet]]) -> [(Date, Int)] {
             .map { convertWeightForDisplaying($0) }
     ))
 }
+
+/// Compact volume for recap lines and highlight cards: "22k" past a thousand (one decimal below ten
+/// thousand), the plain number under it. Takes a *display-unit* value; keeps tight spots short where
+/// the full grouped figure would crowd the line — exact totals live on the volume screens.
+public func abbreviatedVolume(_ value: Int) -> String {
+    guard value >= 1000 else { return "\(value)" }
+    let thousands = Double(value) / 1000
+    if thousands >= 10 {
+        return "\(Int(thousands.rounded()))k"
+    }
+    let formatted = String(format: "%.1f", thousands)
+    return (formatted.hasSuffix(".0") ? String(formatted.dropLast(2)) : formatted) + "k"
+}

--- a/LOGIT/Features/Exercise/ExerciseDetail/ExerciseAttemptCell.swift
+++ b/LOGIT/Features/Exercise/ExerciseDetail/ExerciseAttemptCell.swift
@@ -188,8 +188,8 @@ private struct EntryValueColumns: View {
             }
             if value.type.usesDuration {
                 UnitView(
-                    value: "\(value.duration)",
-                    unit: NSLocalizedString("sec", comment: ""),
+                    value: formatDurationForDisplay(Int(value.duration)),
+                    unit: "",
                     configuration: .normal,
                     unitColor: .secondaryLabel
                 )

--- a/LOGIT/Features/Exercise/ExerciseDetail/ExerciseDurationScreen.swift
+++ b/LOGIT/Features/Exercise/ExerciseDetail/ExerciseDurationScreen.swift
@@ -36,7 +36,9 @@ struct ExerciseDurationScreen: View {
                 date: set.workout?.date ?? .now,
                 value: Double(raw),
                 raw: raw,
-                formatted: String(raw)
+                // The selection tooltip renders this string beside the (now empty) unit, so it
+                // has to carry the same digital reading as the header.
+                formatted: formatDurationForDisplay(raw)
             )
         }
         let pr = daily.map { $0.maximum(.duration, for: exercise) }.max() ?? 0
@@ -53,9 +55,12 @@ struct ExerciseDurationScreen: View {
                     bestAnchor: bestAnchor,
                     yScaleMax: yScaleMax,
                     color: exerciseMuscleGroupColor,
-                    unit: NSLocalizedString("sec", comment: ""),
+                    unit: "",
                     valueLabel: NSLocalizedString("measurementType.duration", comment: ""),
-                    formatValue: { String($0) }
+                    formatValue: { formatDurationForDisplay($0) },
+                    // Durations are stored and plotted in the same unit (seconds), so the axis
+                    // takes the same reading as the header.
+                    formatAxisValue: { formatDurationForDisplay($0) }
                 )
             }
             .padding(.top)

--- a/LOGIT/Features/Exercise/ExerciseDetail/Tiles/ExerciseDurationTile.swift
+++ b/LOGIT/Features/Exercise/ExerciseDetail/Tiles/ExerciseDurationTile.swift
@@ -18,10 +18,10 @@ struct ExerciseDurationTile: View {
             exercise: exercise,
             workoutSets: workoutSets,
             title: ExercisePrimaryMetric.duration.shortTitle,
-            unit: NSLocalizedString("sec", comment: ""),
+            unit: "",
             showsExerciseName: showsExerciseName,
             metricValue: { $0.maximum(.duration, for: exercise) },
-            formattedValue: { String($0) },
+            formattedValue: { formatDurationForDisplay($0) },
             chartValue: { Double($0) }
         )
     }

--- a/LOGIT/Features/Home/HomeNavigationCoordinator.swift
+++ b/LOGIT/Features/Home/HomeNavigationCoordinator.swift
@@ -17,7 +17,7 @@ enum HomeNavigationDestinationType: Hashable, Identifiable, Equatable {
         switch self {
         case let .exercise(exercise): return "exercise\(String(describing: exercise.id))"
         case let .measurementDetail(type): return "measurementDetail\(type.rawValue)"
-        case let .summaryStat(metric): return "summaryStat\(metric.rawValue)"
+        case let .summaryStat(metric, period): return "summaryStat\(metric.rawValue)\(period?.rawValue ?? "")"
         case let .muscleGroupDetail(group, period): return "muscleGroupDetail\(group.rawValue)\(period.rawValue)"
         case let .summaryRecords(period): return "summaryRecords\(period.rawValue)"
         case let .template(template): return "template\(String(describing: template.id))"
@@ -33,7 +33,10 @@ enum HomeNavigationDestinationType: Hashable, Identifiable, Equatable {
          muscleGroupsOverview,
          muscleGroupDetail(MuscleGroup, StatPeriod),
          muscleTargetSplit,
-         summaryStat(WorkoutStatMetric),
+         progressHighlights,
+         // The optional period pins the stat screen to a window (highlight cards open the chart
+         // they compare over); nil keeps the Summary's currently selected period.
+         summaryStat(WorkoutStatMetric, StatPeriod?),
          summaryRecords(StatPeriod),
          targetPerWeek,
          weeklyGoal,

--- a/LOGIT/Features/Home/HomeScreen.swift
+++ b/LOGIT/Features/Home/HomeScreen.swift
@@ -139,7 +139,7 @@ struct HomeScreen: View {
                                         viewModel: summaryViewModel,
                                         workouts: workouts,
                                         onOpenDetail: { metric in
-                                            homeNavigationCoordinator.path.append(.summaryStat(metric))
+                                            homeNavigationCoordinator.path.append(.summaryStat(metric, nil))
                                         }
                                     )
                                     Button {
@@ -253,12 +253,14 @@ struct HomeScreen: View {
                         MuscleTargetSplitScreen()
                     case let .muscleGroupDetail(group, initialPeriod):
                         MuscleGroupDetailScreen(muscleGroup: group, initialPeriod: initialPeriod)
-                    case let .summaryStat(metric):
+                    case let .summaryStat(metric, period):
                         SummaryStatScreen(
                             metric: metric,
                             workouts: workouts,
-                            initialPeriod: summaryViewModel.selectedPeriod
+                            initialPeriod: period ?? summaryViewModel.selectedPeriod
                         )
+                    case .progressHighlights:
+                        ProgressHighlightsScreen(workouts: workouts)
                     case let .summaryRecords(period):
                         SummaryRecordsScreen(
                             workouts: summaryViewModel.filtered(workouts, to: period),

--- a/LOGIT/Features/Home/ProgressHighlightCards.swift
+++ b/LOGIT/Features/Home/ProgressHighlightCards.swift
@@ -1,0 +1,496 @@
+//
+//  ProgressHighlightCards.swift
+//  LOGIT
+//
+//  Created by Lukas Kaibel on 24.07.26.
+//
+
+import SwiftUI
+
+// MARK: - Shared card metrics
+
+/// Every highlight card is exactly this tall, whatever its content — a uniform carousel scrolls as
+/// one calm strip instead of a skyline.
+let HIGHLIGHT_CARD_HEIGHT: CGFloat = 200
+/// Carousel card width; the remainder of the screen peeks the next card as the scroll affordance.
+let HIGHLIGHT_CARD_WIDTH: CGFloat = 300
+
+// MARK: - Carousel
+
+/// The Highlights carousel on the Progress tab: uniform-height cards, view-aligned paging, the next
+/// card peeking. Clipping is disabled so cards sweep the full screen width while scrolling even
+/// though the carousel sits inside the screen's horizontal padding.
+struct ProgressHighlightsCarousel: View {
+    let items: [ProgressHighlight]
+
+    var body: some View {
+        ScrollView(.horizontal) {
+            LazyHStack(spacing: 8) {
+                ForEach(items) { item in
+                    ProgressHighlightCardView(item: item, width: HIGHLIGHT_CARD_WIDTH)
+                }
+            }
+            .scrollTargetLayout()
+        }
+        .scrollTargetBehavior(.viewAligned)
+        .scrollIndicators(.hidden)
+        .scrollClipDisabled()
+    }
+}
+
+// MARK: - Card dispatch
+
+/// One highlight as a tappable card: dispatches to the best-card or comparison-card face and pushes
+/// the screen that proves the highlight — an exercise detail, a stat chart, the goal screen.
+struct ProgressHighlightCardView: View {
+    let item: ProgressHighlight
+    /// Fixed width in the carousel; nil fills the available width (the See-All list).
+    var width: CGFloat? = nil
+
+    @EnvironmentObject private var homeNavigationCoordinator: HomeNavigationCoordinator
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
+    var body: some View {
+        Button {
+            homeNavigationCoordinator.path.append(destination)
+        } label: {
+            card
+                .frame(width: width)
+                // Uniform height is what makes the carousel scroll as one calm strip — but at
+                // accessibility text sizes the content no longer fits it, so the cards size to
+                // their content instead (uneven, and legible) the way `MetricTile` does.
+                .frame(height: dynamicTypeSize.isAccessibilitySize ? nil : HIGHLIGHT_CARD_HEIGHT)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(TileButtonStyle())
+    }
+
+    @ViewBuilder
+    private var card: some View {
+        switch item {
+        case let .record(records):
+            HighlightBestCard(
+                records: records, subject: records.lead,
+                milestoneStepBaseValue: nil, isCompact: isCompact
+            )
+        case let .milestone(records, subject, step):
+            HighlightBestCard(
+                records: records, subject: subject,
+                milestoneStepBaseValue: step, isCompact: isCompact
+            )
+        case let .trend(trend):
+            HighlightComparisonCard(content: .init(trend: trend))
+        case let .yearCrossing(crossing):
+            HighlightComparisonCard(content: .init(crossing: crossing))
+        }
+    }
+
+    /// A fixed width means the carousel, where the scoreboard has to shrink; full width is the
+    /// See-All list, where it wears the record card's own size.
+    private var isCompact: Bool { width != nil }
+
+    /// Where the card taps through to — always the screen where the highlight's chart lives.
+    private var destination: HomeNavigationDestinationType {
+        switch item {
+        case let .record(records):
+            return .exercise(records.exercise)
+        case let .milestone(records, _, _):
+            return .exercise(records.exercise)
+        case let .trend(trend):
+            switch trend.kind {
+            case .volume: return .summaryStat(.volume, .month)
+            case .sets: return .summaryStat(.sets, .month)
+            case .workouts: return .weeklyGoal
+            case .muscleGroupSets: return .muscleGroupDetail(trend.muscleGroup ?? .chest, .month)
+            case .exerciseVolume:
+                if let exercise = trend.exercise { return .exercise(exercise) }
+                return .summaryStat(.volume, .month)
+            }
+        case .yearCrossing:
+            return .summaryStat(.volume, .year)
+        }
+    }
+}
+
+// MARK: - Best card (record / milestone)
+
+/// A recent best, wearing the personal-record card's anatomy so the same event reads the same way
+/// wherever it appears: the muscle-tinted trophy badge leading the exercise and metric, the dated
+/// previous-best → new-record scoreboard (`MetricComparisonView`, the shared shape the chart headers
+/// use) with the gain pill between them, over the exercise's all-time line for that metric bleeding
+/// out the bottom. Differences from `WorkoutPersonalRecordCard`, both forced by the carousel: a
+/// chevron (these cards navigate; that one doesn't) and a `.normal` scoreboard value so two
+/// spelled-out numbers plus the pill fit a card narrower than the screen.
+private struct HighlightBestCard: View {
+    /// The exercise's records for this window — one card per exercise, matching the record cards.
+    let records: WorkoutProgressReport.ExerciseRecords
+    /// The record the card is about: the lead metric normally, the metric that crossed a ladder step
+    /// on a milestone.
+    let subject: WorkoutProgressReport.PRRecord
+    /// Non-nil turns the card into a milestone: the subtitle names the crossed ladder step, and the
+    /// scoreboard below tells the same before/after story a plain record's does.
+    let milestoneStepBaseValue: Int?
+    /// In the carousel the scoreboard drops to `.normal` values so two spelled-out numbers plus the
+    /// pill fit a 300pt card; at full width it wears the record card's own `.large`.
+    var isCompact: Bool = false
+
+    var body: some View {
+        let color = records.exercise.muscleGroup?.color ?? .accentColor
+        VStack(alignment: .leading, spacing: 0) {
+            VStack(alignment: .leading, spacing: 12) {
+                header(color: color)
+                comparison(color: color)
+            }
+            .padding([.horizontal, .top], CELL_PADDING)
+            ExerciseTileSparkline(points: sparklinePoints, color: color, window: .allTime, bleeds: true)
+                .padding(.top, 4)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .tileStyle()
+    }
+
+    private func header(color: Color) -> some View {
+        HStack(spacing: 12) {
+            ZStack {
+                Circle()
+                    .fill(color.opacity(0.15))
+                    .frame(width: 38, height: 38)
+                Image(systemName: "trophy.fill")
+                    .font(.subheadline)
+                    .foregroundStyle(color.gradient)
+            }
+            VStack(alignment: .leading, spacing: 1) {
+                Text(records.exercise.displayName)
+                    .font(.body.weight(.semibold))
+                    .foregroundStyle(Color.label)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.8)
+                Text(subtitle)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.8)
+            }
+            Spacer(minLength: 4)
+            NavigationChevron()
+                .foregroundStyle(Color.secondaryLabel)
+        }
+    }
+
+    /// The record card's scoreboard verbatim — dated previous best, gain pill, dated new record —
+    /// only at the carousel's smaller value size.
+    private func comparison(color: Color) -> some View {
+        let previous = personalRecordDisplay(subject.previousBest, metric: subject.metric, exercise: subject.exercise)
+        let current = personalRecordDisplay(subject.value, metric: subject.metric, exercise: subject.exercise)
+        let percentChange = subject.previousBest > 0
+            ? (Double(subject.value) - Double(subject.previousBest)) / Double(subject.previousBest) * 100
+            : nil
+        return MetricComparisonView(
+            leading: .init(
+                label: NSLocalizedString("previousBest", comment: ""),
+                value: previous.value,
+                unit: previous.unit,
+                caption: dateCaption(subject.previousBestDate)
+            ),
+            trailing: .init(
+                label: NSLocalizedString("newRecord", comment: ""),
+                value: current.value,
+                unit: current.unit,
+                caption: dateCaption(subject.date)
+            ),
+            trailingValueStyle: AnyShapeStyle(color.gradient),
+            valueConfiguration: isCompact ? .normal : .large,
+            percentChange: percentChange,
+            positiveColor: color,
+            positiveStyle: AnyShapeStyle(color.gradient)
+        )
+    }
+
+    /// Metric name, and for a milestone the step it crossed — the one line that separates "you beat
+    /// your best" from "you went past a number that matters".
+    private var subtitle: String {
+        guard let milestoneStepBaseValue else {
+            // Every metric that set a record, the way the shared record rows list them.
+            return records.records.map(\.metric.title).joined(separator: " · ")
+        }
+        let step = personalRecordDisplay(milestoneStepBaseValue, metric: subject.metric, exercise: subject.exercise)
+        let milestone = String(
+            format: NSLocalizedString("firstTimePast", comment: ""),
+            "\(step.value) \(step.unit)"
+        )
+        return "\(subject.metric.title) · \(milestone)"
+    }
+
+    /// A scoreboard caption date — day and month, with the year only when it isn't the current one,
+    /// matching the record card's captions.
+    private func dateCaption(_ date: Date?) -> String? {
+        guard let date else { return nil }
+        return date.isInCurrentYear
+            ? date.formatted(.dateTime.day().month())
+            : date.formatted(.dateTime.day().month().year())
+    }
+
+    /// The exercise's daily best for this metric up to the record — the same series the records
+    /// screen charts under each record card.
+    private var sparklinePoints: [ExerciseTileSparkline.Point] {
+        let cutoff = subject.date ?? .now
+        let sets = records.exercise.sets.filter { ($0.workout?.date ?? .distantFuture) <= cutoff }
+        let grouped = Dictionary(grouping: sets) {
+            Calendar.current.startOfDay(for: $0.workout?.date ?? .now)
+        }
+        return grouped.compactMap { day, daySets -> ExerciseTileSparkline.Point? in
+            let best = daySets.map { metricValue($0) }.max() ?? 0
+            guard best > 0 else { return nil }
+            return ExerciseTileSparkline.Point(date: day, value: Double(best))
+        }
+        .sorted { $0.date < $1.date }
+    }
+
+    private func metricValue(_ workoutSet: WorkoutSet) -> Int {
+        switch subject.metric {
+        case .estimatedOneRepMax: return workoutSet.estimatedOneRepMax(for: records.exercise)
+        case .weight: return workoutSet.maximum(.weight, for: records.exercise)
+        case .repetitions: return workoutSet.maximum(.repetitions, for: records.exercise)
+        case .duration: return workoutSet.maximum(.duration, for: records.exercise)
+        case .distance: return workoutSet.maximum(.distance, for: records.exercise)
+        }
+    }
+}
+
+// MARK: - Comparison card (trend / year crossing)
+
+/// A now-vs-before comparison in the app's `ComparisonBar` language. Wears the same header as the
+/// best cards — a tinted glyph disc leading a headline and a scope · window caption — so the two
+/// card families read as one system in the carousel; below it, the current value over its tinted bar
+/// and the previous value over the gray one, each bar carrying its period label. Trends add the
+/// trend pill beside the current value; the year crossing lets the two bars speak for themselves.
+private struct HighlightComparisonCard: View {
+    /// Everything the card renders, prepared by the initializers so the view stays dumb.
+    struct Content {
+        let symbol: String
+        let headline: String
+        let caption: String
+        let currentValue: String
+        let previousValue: String
+        let unit: String
+        let currentLabel: String
+        let previousLabel: String
+        let currentNumeric: Double
+        let previousNumeric: Double
+        let percentChange: Double?
+        let tint: Color
+    }
+
+    let content: Content
+
+    var body: some View {
+        let maxValue = max(content.currentNumeric, content.previousNumeric, 1)
+        VStack(alignment: .leading, spacing: 8) {
+            header
+            VStack(alignment: .leading, spacing: 0) {
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                    UnitView(value: content.currentValue, unit: content.unit, unitColor: .secondaryLabel)
+                        .foregroundStyle(Color.label)
+                    if let percentChange = content.percentChange {
+                        TrendIndicatorView(percentChange: percentChange, positiveColor: content.tint)
+                    }
+                    Spacer(minLength: 0)
+                }
+                ComparisonBar(
+                    value: content.currentNumeric,
+                    maxValue: maxValue,
+                    tint: content.tint,
+                    label: content.currentLabel,
+                    labelColor: .black,
+                    trackColor: .tertiaryBackground
+                )
+                .frame(height: 24)
+                .padding(.top, 4)
+
+                UnitView(value: content.previousValue, unit: content.unit)
+                    .foregroundStyle(Color.secondaryLabel)
+                    .padding(.top, 8)
+                ComparisonBar(
+                    value: content.previousNumeric,
+                    maxValue: maxValue,
+                    tint: Color.gray.opacity(0.25),
+                    label: content.previousLabel,
+                    trackColor: .tertiaryBackground
+                )
+                .frame(height: 24)
+                .padding(.top, 4)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(CELL_PADDING)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .tileStyle()
+    }
+
+    private var header: some View {
+        HStack(spacing: 12) {
+            ZStack {
+                Circle()
+                    .fill(content.tint.opacity(0.15))
+                    .frame(width: 38, height: 38)
+                Image(systemName: content.symbol)
+                    .font(.subheadline)
+                    .foregroundStyle(content.tint.gradient)
+            }
+            VStack(alignment: .leading, spacing: 1) {
+                Text(content.headline)
+                    .font(.body.weight(.semibold))
+                    .foregroundStyle(Color.label)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.8)
+                Text(content.caption)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.8)
+            }
+            Spacer(minLength: 4)
+            NavigationChevron()
+                .foregroundStyle(Color.secondaryLabel)
+        }
+    }
+}
+
+extension HighlightComparisonCard.Content {
+    /// A rolling-window trend, worded and tinted by its scope. The headline states only *what* went
+    /// up — the caption below it owns the window, so the two can never contradict each other.
+    init(trend: ProgressTrend) {
+        symbol = "chart.line.uptrend.xyaxis"
+        let windowCaption = NSLocalizedString("trendWindowCaption", comment: "")
+        let scopeName: String
+        switch trend.kind {
+        case .volume, .sets, .workouts:
+            scopeName = NSLocalizedString("allWorkouts", comment: "")
+        case .muscleGroupSets:
+            scopeName = trend.muscleGroup?.description ?? ""
+        case .exerciseVolume:
+            scopeName = trend.exercise?.displayName ?? ""
+        }
+
+        switch trend.kind {
+        case .volume:
+            headline = NSLocalizedString("trendMoreVolume", comment: "")
+        case .sets:
+            headline = NSLocalizedString("trendMoreSets", comment: "")
+        case .workouts:
+            headline = NSLocalizedString("trendMoreWorkouts", comment: "")
+        case .muscleGroupSets:
+            headline = String(
+                format: NSLocalizedString("trendMuscleSets", comment: ""),
+                trend.muscleGroup?.description ?? ""
+            )
+        case .exerciseVolume:
+            headline = String(
+                format: NSLocalizedString("trendExerciseVolume", comment: ""),
+                trend.exercise?.displayName ?? ""
+            )
+        }
+        caption = "\(scopeName) · \(windowCaption)"
+
+        switch trend.kind {
+        case .volume, .exerciseVolume:
+            currentValue = abbreviatedVolume(convertWeightForDisplaying(trend.currentValue))
+            previousValue = abbreviatedVolume(convertWeightForDisplaying(trend.previousValue))
+            unit = WeightUnit.used.rawValue
+        case .sets, .muscleGroupSets:
+            currentValue = String(trend.currentValue)
+            previousValue = String(trend.previousValue)
+            unit = NSLocalizedString("sets", comment: "")
+        case .workouts:
+            currentValue = String(trend.currentValue)
+            previousValue = String(trend.previousValue)
+            unit = NSLocalizedString("workouts", comment: "")
+        }
+
+        currentLabel = NSLocalizedString("last4Weeks", comment: "")
+        previousLabel = NSLocalizedString("fourWeeksBefore", comment: "")
+        currentNumeric = Double(trend.currentValue)
+        previousNumeric = Double(trend.previousValue)
+        percentChange = Double(trend.displayedPercent)
+        switch trend.kind {
+        case .volume, .sets, .workouts:
+            tint = .accentColor
+        case .muscleGroupSets:
+            tint = trend.muscleGroup?.color ?? .accentColor
+        case .exerciseVolume:
+            tint = trend.exercise?.muscleGroup?.color ?? .accentColor
+        }
+    }
+
+    /// The year crossing — "2026 already beat 2025", the two year totals as bars.
+    init(crossing: ProgressYearCrossing) {
+        symbol = "calendar"
+        let year = String(crossing.year)
+        let previousYear = String(crossing.previousYear)
+        headline = String(format: NSLocalizedString("yearCrossingHeadline", comment: ""), year, previousYear)
+        let spare: String?
+        switch crossing.monthsToSpare {
+        case 0: spare = nil
+        case 1: spare = NSLocalizedString("monthToSpare", comment: "")
+        default: spare = String(format: NSLocalizedString("monthsToSpare", comment: ""), crossing.monthsToSpare)
+        }
+        let volumeTitle = NSLocalizedString("volume", comment: "")
+        caption = spare.map { "\(volumeTitle) · \($0)" } ?? volumeTitle
+        currentValue = abbreviatedVolume(convertWeightForDisplaying(crossing.currentVolume))
+        previousValue = abbreviatedVolume(convertWeightForDisplaying(crossing.previousVolume))
+        unit = WeightUnit.used.rawValue
+        currentLabel = String(format: NSLocalizedString("yearSoFar", comment: ""), year)
+        previousLabel = previousYear
+        currentNumeric = Double(crossing.currentVolume)
+        previousNumeric = Double(crossing.previousVolume)
+        percentChange = nil
+        tint = .accentColor
+    }
+}
+
+// MARK: - See-all screen
+
+/// Every current highlight as a vertical, priority-ordered list of the same cards — the overflow
+/// valve behind the carousel's "Show All" button.
+struct ProgressHighlightsScreen: View {
+    let workouts: [Workout]
+
+    @EnvironmentObject private var database: Database
+    @State private var items: [ProgressHighlight] = []
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 10) {
+                ForEach(items) { item in
+                    ProgressHighlightCardView(item: item)
+                }
+                footnote
+            }
+            .padding(.horizontal)
+            .padding(.top)
+            .padding(.bottom, SCROLLVIEW_BOTTOM_PADDING)
+        }
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .principal) {
+                Text(NSLocalizedString("highlights", comment: ""))
+                    .font(.headline)
+            }
+        }
+        .task(id: workouts.count) {
+            items = ProgressHighlights.compute(workouts: workouts, database: database)
+        }
+    }
+
+    private var footnote: some View {
+        HStack(alignment: .top, spacing: 6) {
+            Image(systemName: "info.circle")
+            Text(NSLocalizedString("highlightsInfo", comment: ""))
+        }
+        .font(.footnote)
+        .foregroundStyle(.secondary)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 4)
+        .padding(.top, 6)
+    }
+}

--- a/LOGIT/Features/Home/ProgressHighlights.swift
+++ b/LOGIT/Features/Home/ProgressHighlights.swift
@@ -1,0 +1,341 @@
+//
+//  ProgressHighlights.swift
+//  LOGIT
+//
+//  Created by Lukas Kaibel on 24.07.26.
+//
+
+import Foundation
+
+// MARK: - Highlight items
+
+/// One card in the Progress tab's Highlights carousel — a recent improvement the user would
+/// otherwise have to dig out of the detail charts. Ordered by `ProgressHighlights.compute`:
+/// milestones, then records, then the year crossing, then whole-training trends, then scoped
+/// (muscle-group / exercise) trends.
+enum ProgressHighlight: Identifiable {
+    /// An all-time best that crossed a ladder step ("first time past 160 kg"). Replaces the plain
+    /// record card for its exercise — it is the same event, dressed up. `subject` is the record that
+    /// did the crossing, which need not be the exercise's lead metric.
+    case milestone(
+        records: WorkoutProgressReport.ExerciseRecords,
+        subject: WorkoutProgressReport.PRRecord,
+        stepBaseValue: Int
+    )
+    /// One exercise's recent records (the existing `SummaryRecords` feed, grouped per exercise so an
+    /// exercise that set two records at once is one card rather than two).
+    case record(WorkoutProgressReport.ExerciseRecords)
+    /// This year's running volume total passed last year's full total.
+    case yearCrossing(ProgressYearCrossing)
+    /// A now-vs-before comparison over rolling 4-week windows.
+    case trend(ProgressTrend)
+
+    var id: String {
+        switch self {
+        case let .milestone(_, subject, step): return "milestone-\(subject.id)-\(step)"
+        case let .record(records): return "record-\(records.lead.id)"
+        case let .yearCrossing(crossing): return "year-\(crossing.year)"
+        case let .trend(trend): return "trend-\(trend.id)"
+        }
+    }
+}
+
+/// A rolling-window trend: the last 4 weeks against the 4 before, for one scope + metric family.
+/// Values are in base units (grams for volume, plain counts otherwise); the displayed percent is
+/// already rounded the way `TrendIndicatorView` rounds, so thresholds and the pill can't disagree.
+struct ProgressTrend: Identifiable {
+    enum Kind: String {
+        /// Whole-training volume.
+        case volume
+        /// Whole-training set count.
+        case sets
+        /// Whole-training workout count.
+        case workouts
+        /// One muscle group's set count.
+        case muscleGroupSets
+        /// One exercise's volume.
+        case exerciseVolume
+    }
+
+    let kind: Kind
+    /// Set for `muscleGroupSets` only.
+    var muscleGroup: MuscleGroup? = nil
+    /// Set for `exerciseVolume` only.
+    var exercise: Exercise? = nil
+    /// Base-unit totals of the recent and prior windows.
+    let currentValue: Int
+    let previousValue: Int
+
+    /// Rounded display percent (`TrendIndicatorView`'s rounding), guaranteed > 0 by construction.
+    var displayedPercent: Int {
+        guard previousValue > 0 else { return 0 }
+        let raw = (Double(currentValue) - Double(previousValue)) / Double(previousValue) * 100
+        return Int(min(abs(raw), 999).rounded()) * (raw < 0 ? -1 : 1)
+    }
+
+    var id: String {
+        "\(kind.rawValue)-\(muscleGroup?.rawValue ?? "")-\(exercise?.id?.uuidString ?? "")"
+    }
+}
+
+/// The one-time "this year already beat last year" event, in total volume. Only reported while its
+/// crossing date is recent (the highlights window), so it celebrates once and then retires without
+/// any persisted state.
+struct ProgressYearCrossing {
+    let year: Int
+    let previousYear: Int
+    /// Base-unit (gram) totals: this year to date, last year in full.
+    let currentVolume: Int
+    let previousVolume: Int
+    /// The date of the workout whose volume tipped the running total past last year.
+    let crossingDate: Date
+    /// Full calendar months left in the year after the crossing — "with 5 months to spare".
+    let monthsToSpare: Int
+}
+
+// MARK: - Milestone ladder
+
+/// The fixed ladder steps behind milestone detection, in the metric's base units. Weight ladders
+/// follow the *display* unit — a kg lifter crosses 100 kg, an lbs lifter crosses plate numbers like
+/// 225 lb — because thresholds are only meaningful in the unit you think in.
+enum MilestoneLadder {
+    /// Weight / e1RM steps in display units: kg every 10 to 100, then 20s to 200, then 25s;
+    /// lbs plate math, then 50s.
+    private static let kgSteps: [Int] = Array(stride(from: 10, through: 100, by: 10))
+        + Array(stride(from: 120, through: 200, by: 20))
+        + Array(stride(from: 225, through: 500, by: 25))
+    private static let lbsSteps: [Int] = [45, 95, 135, 185, 225, 275, 315, 365, 405, 455, 495]
+        + Array(stride(from: 545, through: 1000, by: 50))
+
+    private static let repsSteps = [10, 15, 20, 25, 30, 40, 50, 75, 100]
+    /// Seconds.
+    private static let durationSteps = [30, 60, 120, 180, 300, 600]
+    /// Meters — 1 k, 2.5 k, 5 k, 10 k, 15 k, half and full marathon.
+    private static let distanceSteps = [1000, 2500, 5000, 10000, 15000, 21098, 42195]
+
+    /// All ladder steps for a metric, converted to the metric's base units (grams for weights).
+    static func steps(for metric: ExercisePrimaryMetric) -> [Int] {
+        switch metric {
+        case .weight, .estimatedOneRepMax:
+            // `convertWeightForStoring` converts a display-unit value to grams using the same
+            // active unit that picked the step list.
+            let displaySteps = WeightUnit.used == .kg ? kgSteps : lbsSteps
+            return displaySteps.map { Int(convertWeightForStoring(Double($0))) }
+        case .repetitions: return repsSteps
+        case .duration: return durationSteps
+        case .distance: return distanceSteps
+        }
+    }
+
+    /// The highest ladder step a record crossed — `previousBest < step ≤ value` — or nil when none.
+    /// Because `previousBest` is the all-time best the record beat, a crossing can only happen once:
+    /// afterwards the all-time best sits at or above the step.
+    static func highestStep(crossedFrom previousBest: Int, to value: Int, metric: ExercisePrimaryMetric) -> Int? {
+        steps(for: metric).filter { previousBest < $0 && $0 <= value }.max()
+    }
+}
+
+// MARK: - Computation
+
+/// Assembles the Highlights feed from the already-fetched workouts — no new Core Data fetches, the
+/// same deal as the rest of the Progress tab. All windows anchor to the start of today so the feed
+/// is stable within a day.
+enum ProgressHighlights {
+
+    /// Rolling window length used by all trends: 4 weeks, the app's standard recent window.
+    private static let windowDays = 28
+
+    /// Noise floors: a trend must clear its relative threshold AND its absolute delta, with enough
+    /// training in both windows, so "up 50%" can never come from 2 sets becoming 3.
+    private static let wholePercentFloor = 10
+    private static let scopedPercentFloor = 15
+    private static let volumeDeltaFloorGrams = 500_000 // 500 kg
+    private static let setsDeltaFloor = 5
+    private static let workoutsDeltaFloor = 2
+    private static let wholeMinWorkoutsPerWindow = 3
+    private static let muscleMinSetsPerWindow = 6
+    private static let exerciseMinSessionsPerWindow = 2
+    /// A year crossing is only impressive against a real year of training.
+    private static let yearCrossingMinPreviousWorkouts = 20
+
+    /// How many cards the carousel shows; the See-All screen lists everything.
+    static let carouselLimit = 5
+
+    static func compute(
+        workouts: [Workout],
+        database: Database,
+        reference: Date = .now
+    ) -> [ProgressHighlight] {
+        let calendar = Calendar.current
+        // Exclude the workout currently being recorded everywhere — highlights tell the standing
+        // before this session, the way the exercise tiles do.
+        let finished = workouts.filter { !$0.isEmpty && !$0.isCurrentWorkout }
+
+        // Bests: the existing records feed over the recent window, split into milestones + records.
+        let windowStart = Exercise.currentBestWindowStart
+        let recentWorkouts = finished.filter { ($0.date ?? .distantPast) >= windowStart }
+        let records = SummaryRecords.records(in: recentWorkouts, database: database)
+        var milestones: [ProgressHighlight] = []
+        var plainRecords: [ProgressHighlight] = []
+        for group in records {
+            // A milestone can sit on any of the exercise's records, not only the lead one: crossing
+            // 100 kg on the estimated 1RM is the story even when the lifted weight leads the card.
+            // `records` is already in lead priority, so the first crossing found is the most
+            // tangible one.
+            let crossing = group.records.lazy.compactMap { record in
+                MilestoneLadder
+                    .highestStep(crossedFrom: record.previousBest, to: record.value, metric: record.metric)
+                    .map { (record, $0) }
+            }.first
+            if let (subject, step) = crossing {
+                milestones.append(.milestone(records: group, subject: subject, stepBaseValue: step))
+            } else {
+                plainRecords.append(.record(group))
+            }
+        }
+
+        // Rolling windows: [end-28d, end) vs [end-56d, end-28d), end = start of tomorrow so today
+        // counts fully.
+        let end = calendar.date(byAdding: .day, value: 1, to: calendar.startOfDay(for: reference)) ?? reference
+        guard
+            let currentStart = calendar.date(byAdding: .day, value: -windowDays, to: end),
+            let priorStart = calendar.date(byAdding: .day, value: -2 * windowDays, to: end)
+        else { return milestones + plainRecords }
+
+        let currentWorkouts = finished.filter { ($0.date ?? .distantPast) >= currentStart && ($0.date ?? .distantPast) < end }
+        let priorWorkouts = finished.filter { ($0.date ?? .distantPast) >= priorStart && ($0.date ?? .distantPast) < currentStart }
+        let currentSets = currentWorkouts.flatMap { $0.sets }
+        let priorSets = priorWorkouts.flatMap { $0.sets }
+
+        var wholeTrends: [ProgressTrend] = []
+        var scopedTrends: [ProgressTrend] = []
+
+        let enoughWorkouts = currentWorkouts.count >= wholeMinWorkoutsPerWindow
+            && priorWorkouts.count >= wholeMinWorkoutsPerWindow
+
+        // Whole-training volume.
+        let currentVolume = getVolume(of: currentSets)
+        let priorVolume = getVolume(of: priorSets)
+        let volumeTrend = ProgressTrend(kind: .volume, currentValue: currentVolume, previousValue: priorVolume)
+        let volumeFires = enoughWorkouts
+            && volumeTrend.displayedPercent >= wholePercentFloor
+            && currentVolume - priorVolume >= volumeDeltaFloorGrams
+        if volumeFires { wholeTrends.append(volumeTrend) }
+
+        // Whole-training sets.
+        let setsTrend = ProgressTrend(kind: .sets, currentValue: currentSets.count, previousValue: priorSets.count)
+        let setsFire = enoughWorkouts
+            && setsTrend.displayedPercent >= wholePercentFloor
+            && currentSets.count - priorSets.count >= setsDeltaFloor
+        if setsFire { wholeTrends.append(setsTrend) }
+
+        // Workout count.
+        let workoutsTrend = ProgressTrend(
+            kind: .workouts, currentValue: currentWorkouts.count, previousValue: priorWorkouts.count
+        )
+        if priorWorkouts.count >= wholeMinWorkoutsPerWindow,
+           workoutsTrend.displayedPercent >= wholePercentFloor,
+           currentWorkouts.count - priorWorkouts.count >= workoutsDeltaFloor {
+            wholeTrends.append(workoutsTrend)
+        }
+
+        // Muscle-group set trends — suppressed as a family when the whole-training sets card fires
+        // (one card per metric family per scope: the strongest single story wins).
+        if !setsFire {
+            let service = MuscleGroupService()
+            let currentByGroup = Dictionary(uniqueKeysWithValues: service.getMuscleGroupOccurances(in: currentSets))
+            let priorByGroup = Dictionary(uniqueKeysWithValues: service.getMuscleGroupOccurances(in: priorSets))
+            for group in MuscleGroup.allCases {
+                let current = currentByGroup[group] ?? 0
+                let prior = priorByGroup[group] ?? 0
+                guard current >= muscleMinSetsPerWindow, prior >= muscleMinSetsPerWindow else { continue }
+                let trend = ProgressTrend(kind: .muscleGroupSets, muscleGroup: group, currentValue: current, previousValue: prior)
+                guard trend.displayedPercent >= scopedPercentFloor,
+                      current - prior >= setsDeltaFloor else { continue }
+                scopedTrends.append(trend)
+            }
+        }
+
+        // Exercise volume trends — same family rule against the whole-training volume card.
+        if !volumeFires {
+            var exercises: [Exercise] = []
+            var seen = Set<Exercise>()
+            for workout in currentWorkouts {
+                for exercise in workout.exercises where !seen.contains(exercise) {
+                    seen.insert(exercise)
+                    exercises.append(exercise)
+                }
+            }
+            for exercise in exercises {
+                let currentSessions = currentWorkouts.filter { $0.exercises.contains(exercise) }
+                let priorSessions = priorWorkouts.filter { $0.exercises.contains(exercise) }
+                guard currentSessions.count >= exerciseMinSessionsPerWindow,
+                      priorSessions.count >= exerciseMinSessionsPerWindow else { continue }
+                let current = getVolume(of: currentSessions.flatMap { $0.sets }, for: exercise)
+                let prior = getVolume(of: priorSessions.flatMap { $0.sets }, for: exercise)
+                guard prior > 0 else { continue }
+                let trend = ProgressTrend(kind: .exerciseVolume, exercise: exercise, currentValue: current, previousValue: prior)
+                guard trend.displayedPercent >= scopedPercentFloor else { continue }
+                scopedTrends.append(trend)
+            }
+        }
+
+        wholeTrends.sort { $0.displayedPercent > $1.displayedPercent }
+        scopedTrends.sort { $0.displayedPercent > $1.displayedPercent }
+
+        // Year crossing — computed from full history, shown only while the crossing is recent.
+        var yearItems: [ProgressHighlight] = []
+        if let crossing = yearCrossing(in: finished, reference: reference, calendar: calendar),
+           crossing.crossingDate >= currentStart {
+            yearItems.append(.yearCrossing(crossing))
+        }
+
+        return milestones
+            + plainRecords
+            + yearItems
+            + wholeTrends.map { .trend($0) }
+            + scopedTrends.map { .trend($0) }
+    }
+
+    /// The day this year's running volume total passed last year's full total, or nil if it hasn't
+    /// (or last year holds too little training to make the comparison meaningful).
+    private static func yearCrossing(
+        in workouts: [Workout], reference: Date, calendar: Calendar
+    ) -> ProgressYearCrossing? {
+        let year = calendar.component(.year, from: reference)
+        let previousYear = year - 1
+        let previousYearWorkouts = workouts.filter {
+            guard let date = $0.date else { return false }
+            return calendar.component(.year, from: date) == previousYear
+        }
+        guard previousYearWorkouts.count >= yearCrossingMinPreviousWorkouts else { return nil }
+        let previousTotal = getVolume(of: previousYearWorkouts.flatMap { $0.sets })
+        guard previousTotal > 0 else { return nil }
+
+        let thisYearWorkouts = workouts
+            .filter {
+                guard let date = $0.date else { return false }
+                return calendar.component(.year, from: date) == year && date <= reference
+            }
+            .sorted { ($0.date ?? .distantPast) < ($1.date ?? .distantPast) }
+
+        var runningTotal = 0
+        var crossingDate: Date?
+        for workout in thisYearWorkouts {
+            runningTotal += getVolume(of: workout.sets)
+            if crossingDate == nil, runningTotal > previousTotal {
+                crossingDate = workout.date
+            }
+        }
+        guard let crossingDate else { return nil }
+        return ProgressYearCrossing(
+            year: year,
+            previousYear: previousYear,
+            // The card shows the full year-to-date total, not the total at the moment of crossing.
+            currentVolume: runningTotal,
+            previousVolume: previousTotal,
+            crossingDate: crossingDate,
+            monthsToSpare: 12 - calendar.component(.month, from: crossingDate)
+        )
+    }
+}

--- a/LOGIT/Features/Home/SummaryProgressTab.swift
+++ b/LOGIT/Features/Home/SummaryProgressTab.swift
@@ -43,34 +43,53 @@ struct SummaryTabPicker: View {
 
 // MARK: - Progress tab
 
-/// The `Progress` tab body: recent highlights on top, the overall strength-trend tile below. Computes
-/// both off the already-fetched `[Workout]` in a `.task` (no new Core Data fetches), the way the
-/// Summary's records tile does.
+/// The `Progress` tab body: the strength-trend tile leads as the tab's headline, the Highlights
+/// carousel below — recent bests, milestones, and trends as swipeable cards (see
+/// `ProgressHighlights`). Computes both off the already-fetched `[Workout]` in a `.task` (no new
+/// Core Data fetches), the way the Summary's records tile does.
 struct SummaryProgressTab: View {
     let workouts: [Workout]
 
     @EnvironmentObject private var database: Database
+    @EnvironmentObject private var homeNavigationCoordinator: HomeNavigationCoordinator
     @State private var overall: OverallProgress = .empty
-    @State private var highlights: [WorkoutProgressReport.ExerciseRecords] = []
+    @State private var highlights: [ProgressHighlight] = []
 
     var body: some View {
         VStack(spacing: 8) {
-            if !highlights.isEmpty {
-                ProgressHighlightsTile(records: highlights)
-            }
             OverallProgressTile(progress: overall)
+            if !highlights.isEmpty {
+                highlightsSection
+                    .padding(.top, 8)
+            }
         }
         .task(id: workouts.count) {
             overall = OverallProgress.compute(workouts: workouts)
-            highlights = SummaryRecords.records(in: recentWorkouts, database: database)
+            highlights = ProgressHighlights.compute(workouts: workouts, database: database)
         }
     }
 
-    /// Workouts of the last 4 weeks — the same rolling window "current best" uses everywhere, so the
-    /// highlights feed stays "recent" rather than all-time and matches the app's standard window.
-    private var recentWorkouts: [Workout] {
-        let cutoff = Exercise.currentBestWindowStart
-        return workouts.filter { !$0.isEmpty && ($0.date ?? .distantPast) >= cutoff }
+    /// Section header + carousel. The carousel shows the top few by priority; "Show All" appears
+    /// only once there is genuinely more than it shows.
+    private var highlightsSection: some View {
+        VStack(spacing: SECTION_HEADER_SPACING) {
+            HStack {
+                Text(NSLocalizedString("highlights", comment: ""))
+                    .sectionHeaderStyle2()
+                Spacer()
+                if highlights.count > ProgressHighlights.carouselLimit {
+                    Button {
+                        homeNavigationCoordinator.path.append(.progressHighlights)
+                    } label: {
+                        Text(NSLocalizedString("showAll", comment: ""))
+                    }
+                    .fontWeight(.semibold)
+                }
+            }
+            ProgressHighlightsCarousel(
+                items: Array(highlights.prefix(ProgressHighlights.carouselLimit))
+            )
+        }
     }
 }
 
@@ -210,7 +229,7 @@ struct OverallProgressTile: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            TileHeader(NSLocalizedString("overallProgress", comment: ""), showsChevron: false)
+            TileHeader(NSLocalizedString("strengthProgress", comment: ""), showsChevron: false)
                 .padding([.top, .horizontal], CELL_PADDING)
 
             if let overall = progress.overallPercentChange {
@@ -252,7 +271,7 @@ struct OverallProgressTile: View {
                     .font(.subheadline.weight(.semibold))
                     .foregroundStyle(Color.label)
                     .monospacedDigit()
-                Text(NSLocalizedString("overallProgressBasis", comment: ""))
+                Text(NSLocalizedString("strengthProgressBasis", comment: ""))
                     .font(.caption2)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
@@ -299,7 +318,7 @@ struct OverallProgressTile: View {
             Image(systemName: "chart.line.uptrend.xyaxis")
                 .font(.title3)
                 .foregroundStyle(.secondary)
-            Text(NSLocalizedString("overallProgressEmpty", comment: ""))
+            Text(NSLocalizedString("strengthProgressEmpty", comment: ""))
                 .font(.subheadline)
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
@@ -314,76 +333,5 @@ struct OverallProgressTile: View {
     }
 }
 
-// MARK: - Highlights tile
-
-/// The Progress tab's highlights: the most recent personal record as a prominent hero (exercise,
-/// metric, the new value and the gain over the old best), then up to a couple more recent records as
-/// the shared `PersonalBestRow`. Hidden entirely when there are no recent records — like the Summary
-/// records tile, an empty highlights tile would be worse than none.
-struct ProgressHighlightsTile: View {
-    /// Recent records (one entry per exercise, newest first) from `SummaryRecords.records`.
-    let records: [WorkoutProgressReport.ExerciseRecords]
-    var maxRows: Int = 3
-
-    var body: some View {
-        if let top = records.first {
-            VStack(alignment: .leading, spacing: 0) {
-                TileHeader(NSLocalizedString("highlights", comment: ""), showsChevron: false)
-                    .padding([.top, .horizontal], CELL_PADDING)
-                hero(top)
-                    .padding(.horizontal, CELL_PADDING)
-                    .padding(.top, 12)
-                let rest = Array(records.dropFirst().prefix(max(0, maxRows - 1)))
-                if !rest.isEmpty {
-                    VStack(spacing: 8) {
-                        ForEach(rest) { PersonalBestRow(records: $0) }
-                    }
-                    .padding(.horizontal, CELL_PADDING / 2)
-                    .padding(.top, 10)
-                }
-            }
-            .padding(.bottom, CELL_PADDING / 2)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .tileStyle()
-        }
-    }
-
-    private func hero(_ exerciseRecords: WorkoutProgressReport.ExerciseRecords) -> some View {
-        let record = exerciseRecords.lead
-        let color = exerciseRecords.exercise.muscleGroup?.color ?? .accentColor
-        let display = personalRecordDisplay(record.value, metric: record.metric, exercise: record.exercise)
-        let gain: Double? = record.previousBest > 0
-            ? (Double(record.value) - Double(record.previousBest)) / Double(record.previousBest) * 100
-            : nil
-        return HStack(spacing: 13) {
-            ZStack {
-                Circle().fill(color.opacity(0.15)).frame(width: 46, height: 46)
-                Image(systemName: "trophy.fill")
-                    .font(.title3)
-                    .foregroundStyle(color.gradient)
-            }
-            VStack(alignment: .leading, spacing: 3) {
-                Text(exerciseRecords.exercise.displayName)
-                    .font(.headline)
-                    .foregroundStyle(Color.label)
-                    .lineLimit(1)
-                Text("\(NSLocalizedString("newRecord", comment: "")) · \(exerciseRecords.records.map(\.metric.title).joined(separator: " · "))")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
-            }
-            Spacer(minLength: 8)
-            VStack(alignment: .trailing, spacing: 4) {
-                UnitView(value: display.value, unit: display.unit)
-                    .foregroundStyle(color.gradient)
-                if let gain {
-                    TrendIndicatorView(
-                        percentChange: gain,
-                        positiveColor: color,
-                        positiveStyle: AnyShapeStyle(color.gradient)
-                    )
-                }
-            }
-        }
-    }
-}
+// The old ProgressHighlightsTile (hero record + PersonalBestRow list) is superseded by the
+// Highlights carousel in ProgressHighlightCards.swift.

--- a/LOGIT/Features/Workout/Cells/WorkoutSetGroupCell.swift
+++ b/LOGIT/Features/Workout/Cells/WorkoutSetGroupCell.swift
@@ -1493,7 +1493,7 @@ private struct MetricBadgeView: View {
         case .repetitions:
             return UnitView(value: "\(value)", unit: NSLocalizedString("reps", comment: ""), configuration: .extraSmall)
         case .duration:
-            return UnitView(value: "\(value)", unit: NSLocalizedString("sec", comment: ""), configuration: .extraSmall)
+            return UnitView(value: formatDurationForDisplay(value), unit: "", configuration: .extraSmall)
         case .distance:
             return UnitView(
                 value: formatDistanceForDisplay(Int64(value), style: distanceStyle),
@@ -1565,7 +1565,9 @@ private struct MetricBadgeView: View {
         case .repetitions:
             return "\(value) \(NSLocalizedString("reps", comment: ""))"
         case .duration:
-            return "\(value) \(NSLocalizedString("sec", comment: ""))"
+            // Spoken in words ("1 minute, 30 seconds") — the digital reading would be read out as
+            // a pair of bare numbers.
+            return accessibleDurationForDisplay(value)
         case .distance:
             return "\(formatDistanceForDisplay(Int64(value), style: distanceStyle)) \(distanceUnitTitle(for: distanceStyle))"
         }
@@ -1913,7 +1915,8 @@ struct MetricInfoPanel: View {
         switch metric {
         case .estimatedOneRepMax: return formatEstimatedOneRepMax(value)
         case .weight: return formatWeightForDisplay(value)
-        case .repetitions, .duration: return String(value)
+        case .repetitions: return String(value)
+        case .duration: return formatDurationForDisplay(value)
         case .distance: return formatDistanceForDisplay(Int64(value), style: distanceStyle)
         }
     }
@@ -1922,7 +1925,7 @@ struct MetricInfoPanel: View {
         switch metric {
         case .estimatedOneRepMax, .weight: return WeightUnit.used.rawValue
         case .repetitions: return NSLocalizedString("reps", comment: "")
-        case .duration: return NSLocalizedString("sec", comment: "")
+        case .duration: return ""
         case .distance: return distanceUnitTitle(for: distanceStyle)
         }
     }

--- a/LOGIT/Features/Workout/LiveActivity/WorkoutLiveActivitySnapshotBuilder.swift
+++ b/LOGIT/Features/Workout/LiveActivity/WorkoutLiveActivitySnapshotBuilder.swift
@@ -227,24 +227,21 @@ enum WorkoutLiveActivitySnapshotBuilder {
         NSLocalizedString("reps", comment: "")
     }
 
-    private static var secondsLocalizedUnit: String {
-        NSLocalizedString("sec", comment: "")
-    }
-
     private static var liveActivityWeightUnit: String {
         WeightUnit.used.rawValue
     }
 
     /// The unit label for an entry's performance slot: reps for rep-based entries, the
     /// distance unit for distance-tracking ones (distance is their primary field on this
-    /// glanceable surface), seconds otherwise.
+    /// glanceable surface), and none for durations — those are written "1:30", which carries
+    /// its own separator.
     private static func performanceLocalizedUnit(for value: SetEntryValues?) -> String {
         guard let value else { return repsLocalizedUnit }
         if value.type.usesRepetitions { return repsLocalizedUnit }
         if let distanceStyle = value.type.distanceStyle(for: value.exercise) {
             return distanceUnitTitle(for: distanceStyle)
         }
-        return secondsLocalizedUnit
+        return ""
     }
 
     /// The values shown on the "current set" side: for compound sets the first exercise's
@@ -305,7 +302,7 @@ enum WorkoutLiveActivitySnapshotBuilder {
                 performancePlaceholders.append(value.distance == 0)
             } else if value.type.usesDuration {
                 let shown = value.duration > 0 ? value.duration : (template?.duration ?? 0)
-                performanceSegments.append(String(shown))
+                performanceSegments.append(formatDurationForDisplay(Int(shown)))
                 performancePlaceholders.append(value.duration == 0)
             }
             if value.type.usesWeight {
@@ -374,7 +371,7 @@ enum WorkoutLiveActivitySnapshotBuilder {
                     performanceSegments.append(formatDistanceForDisplay(value.distance, style: distanceStyle))
                 }
             } else if value.type.usesDuration, !value.type.usesRepetitions, value.duration > 0 {
-                performanceSegments.append(String(value.duration))
+                performanceSegments.append(formatDurationForDisplay(Int(value.duration)))
             }
             if value.type.usesWeight, value.weight > 0 {
                 weightSegments.append(formatWeightForDisplay(value.weight))

--- a/LOGIT/Features/Workout/WorkoutListScreen.swift
+++ b/LOGIT/Features/Workout/WorkoutListScreen.swift
@@ -322,19 +322,6 @@ private struct WorkoutHistorySectionHeader: View {
 
         return parts.joined(separator: " · ")
     }
-
-    /// Compact volume for the recap line: "22k" past a thousand (one decimal below ten thousand),
-    /// the plain number under it. Keeps the header short where the full grouped figure would crowd
-    /// the line — the exact totals live on the volume screens.
-    private func abbreviatedVolume(_ value: Int) -> String {
-        guard value >= 1000 else { return "\(value)" }
-        let thousands = Double(value) / 1000
-        if thousands >= 10 {
-            return "\(Int(thousands.rounded()))k"
-        }
-        let formatted = String(format: "%.1f", thousands)
-        return (formatted.hasSuffix(".0") ? String(formatted.dropLast(2)) : formatted) + "k"
-    }
 }
 
 // MARK: - Calendar header

--- a/LOGIT/SharedUI/Charts/CapabilityChartView.swift
+++ b/LOGIT/SharedUI/Charts/CapabilityChartView.swift
@@ -59,6 +59,10 @@ struct CapabilityChartView: View {
     /// Formats a raw metric (the header baseline and the anchor) into the screen's units — the same
     /// formatter the `Point.formatted` strings were built with.
     let formatValue: (Int) -> String
+    /// Formats a y-axis value, which is in **display** units — unlike `formatValue`, which takes a
+    /// raw one. Nil renders the plain number, right for kg / reps / volume. The duration screen
+    /// passes its digital reading so the axis can't disagree with the header above it.
+    var formatAxisValue: ((Int) -> String)? = nil
 
     @State private var chartRange: ChartRange = .threeMonths
     @State private var chartScrollPosition: Date = .now
@@ -203,7 +207,19 @@ struct CapabilityChartView: View {
                 chartRange.xAxisMarks(firstDataDate: firstDataDate)
             }
             .chartYAxis {
-                AxisMarks(values: [0, yScaleMax / 2, yScaleMax])
+                if let formatAxisValue {
+                    AxisMarks(values: [0, yScaleMax / 2, yScaleMax]) { value in
+                        AxisGridLine()
+                        AxisTick()
+                        AxisValueLabel {
+                            if let raw = value.as(Int.self) {
+                                Text(formatAxisValue(raw))
+                            }
+                        }
+                    }
+                } else {
+                    AxisMarks(values: [0, yScaleMax / 2, yScaleMax])
+                }
             }
             .emptyPlaceholder(points) {
                 Text(NSLocalizedString("noData", comment: ""))

--- a/LOGIT/SharedUI/Views/ComparisonBar.swift
+++ b/LOGIT/SharedUI/Views/ComparisonBar.swift
@@ -17,13 +17,25 @@ struct ComparisonBar: View {
     /// When set, the filled portion renders with this gradient instead of `tint` — used where the
     /// bar stands for a whole workout rather than a single metric (muscle-group themed bars).
     let gradient: LinearGradient?
+    /// Explicit label color, for tints the default rule can't judge — the pastel muscle colors are
+    /// light, so their labels need black like the accent's, but they aren't `.accentColor`.
+    let labelColor: Color?
+    /// The unfilled track. Defaults to the old `secondaryBackground`; a bar sitting ON a
+    /// `secondaryBackground` tile passes `.tertiaryBackground` so the track stays visible.
+    let trackColor: Color
 
-    init(value: Double, maxValue: Double, tint: Color, label: String = "", gradient: LinearGradient? = nil) {
+    init(
+        value: Double, maxValue: Double, tint: Color, label: String = "",
+        gradient: LinearGradient? = nil, labelColor: Color? = nil,
+        trackColor: Color = .secondaryBackground
+    ) {
         self.value = value
         self.maxValue = maxValue
         self.tint = tint
         self.label = label
         self.gradient = gradient
+        self.labelColor = labelColor
+        self.trackColor = trackColor
     }
 
     var body: some View {
@@ -32,7 +44,7 @@ struct ComparisonBar: View {
             let ratio = maxValue > 0 ? CGFloat(min(max(value / maxValue, 0), 1)) : 0
             ZStack(alignment: .leading) {
                 RoundedRectangle(cornerRadius: 10)
-                    .fill(Color.secondaryBackground)
+                    .fill(trackColor)
                 if let gradient {
                     RoundedRectangle(cornerRadius: 10)
                         .fill(gradient)
@@ -45,7 +57,7 @@ struct ComparisonBar: View {
                 if !label.isEmpty {
                     Text(label)
                         .font(.subheadline.weight(.semibold))
-                        .foregroundStyle(tint == .accentColor || gradient != nil ? .black : .primary)
+                        .foregroundStyle(labelColor ?? (tint == .accentColor || gradient != nil ? .black : .primary))
                         .padding(.horizontal, 10)
                 }
             }

--- a/LOGIT/SharedUI/Views/MetricComparisonView.swift
+++ b/LOGIT/SharedUI/Views/MetricComparisonView.swift
@@ -42,6 +42,10 @@ struct MetricComparisonView: View {
     /// Style of the trailing value. Defaults to the neutral label color; pass a muscle-group
     /// `color.gradient` to tint the subject (the popover's live "you, now" side).
     var trailingValueStyle: AnyShapeStyle = AnyShapeStyle(Color.label)
+    /// Size of both values. `.large` — the full-width headers this was built for — by default; the
+    /// Highlights carousel cards pass `.normal`, where two spelled-out values plus the pill have to
+    /// share a card barely wider than a phone's half screen.
+    var valueConfiguration: UnitViewConfiguration = .large
     /// Percent of trailing over leading. Nil omits the pill — nothing to compare.
     let percentChange: Double?
     var positiveColor: Color = .accentColor
@@ -72,7 +76,7 @@ struct MetricComparisonView: View {
                 .font(.footnote)
                 .fontWeight(.semibold)
                 .foregroundStyle(.secondary)
-            UnitView(value: side.value, unit: side.unit, configuration: .large)
+            UnitView(value: side.value, unit: side.unit, configuration: valueConfiguration)
                 // One continuous gradient across value + unit, not one restarting in each.
                 .continuousForegroundStyle(valueStyle)
             if let caption = side.caption {

--- a/LOGIT/SharedUI/Views/PersonalBestRow.swift
+++ b/LOGIT/SharedUI/Views/PersonalBestRow.swift
@@ -60,7 +60,9 @@ func personalRecordDisplay(
     case .estimatedOneRepMax: return (formatEstimatedOneRepMax(base), WeightUnit.used.rawValue)
     case .weight: return (formatWeightForDisplay(base), WeightUnit.used.rawValue)
     case .repetitions: return (String(base), NSLocalizedString("reps", comment: ""))
-    case .duration: return (String(base), NSLocalizedString("sec", comment: ""))
+    // The digital reading carries its own separators, so it takes no unit (see
+    // `formatDurationForDisplay`).
+    case .duration: return (formatDurationForDisplay(base), "")
     case .distance:
         let style = exercise?.distanceStyle ?? .long
         return (formatDistanceForDisplay(Int64(base), style: style), distanceUnitTitle(for: style))

--- a/LOGIT/SharedUI/Views/RestDurationPicker.swift
+++ b/LOGIT/SharedUI/Views/RestDurationPicker.swift
@@ -86,9 +86,8 @@ struct RestDurationLabel: View {
     }
 }
 
-/// Formats seconds into a compact rest time string (e.g. "1:30", "0:30", "3:00")
+/// Formats seconds into a compact rest time string (e.g. "1:30", "0:30", "3:00") — the same digital
+/// reading recorded set durations wear, so a rest interval and a held set are written alike.
 func restTimeString(seconds: Int) -> String {
-    let m = seconds / 60
-    let s = seconds % 60
-    return "\(m):\(String(format: "%02d", s))"
+    formatDurationForDisplay(seconds)
 }

--- a/LOGITTests/VolumeCalculatingTests.swift
+++ b/LOGITTests/VolumeCalculatingTests.swift
@@ -368,3 +368,123 @@ final class VolumeCalculatingTests: XCTestCase {
         XCTAssertEqual(volume, 1000 * 1000000, "Should handle large volume calculations")
     }
 }
+
+// MARK: - Milestone ladder
+
+/// The milestone detection behind the Highlights carousel: an all-time best crossing a fixed ladder
+/// step. Pure functions — no Core Data — so these run against the ladder itself. Weight ladders
+/// follow the display unit, so tests pin `weightUnit` explicitly and restore it.
+final class MilestoneLadderTests: XCTestCase {
+    private var originalWeightUnit: String?
+
+    override func setUp() {
+        super.setUp()
+        originalWeightUnit = UserDefaults.standard.string(forKey: "weightUnit")
+        UserDefaults.standard.set(WeightUnit.kg.rawValue, forKey: "weightUnit")
+    }
+
+    override func tearDown() {
+        if let originalWeightUnit {
+            UserDefaults.standard.set(originalWeightUnit, forKey: "weightUnit")
+        } else {
+            UserDefaults.standard.removeObject(forKey: "weightUnit")
+        }
+        super.tearDown()
+    }
+
+    func testWeightCrossingReturnsHighestStep() {
+        // 95 kg → 122.5 kg crosses 100 AND 120 — the highest crossed step wins.
+        let step = MilestoneLadder.highestStep(crossedFrom: 95_000, to: 122_500, metric: .weight)
+        XCTAssertEqual(step, 120_000)
+    }
+
+    func testNoCrossingBetweenSteps() {
+        // 92.5 kg → 97.5 kg improves without reaching the next step (100 kg).
+        XCTAssertNil(MilestoneLadder.highestStep(crossedFrom: 92_500, to: 97_500, metric: .weight))
+    }
+
+    func testExactStepCounts() {
+        // Landing exactly ON a step counts (previousBest < step ≤ value).
+        XCTAssertEqual(
+            MilestoneLadder.highestStep(crossedFrom: 97_500, to: 100_000, metric: .weight),
+            100_000
+        )
+    }
+
+    func testPreviousBestAtStepCannotRefire() {
+        // The all-time best already sits on the step — the same step can't fire again.
+        XCTAssertNil(MilestoneLadder.highestStep(crossedFrom: 100_000, to: 105_000, metric: .weight))
+    }
+
+    func testLbsLadderUsesPlateMath() {
+        UserDefaults.standard.set(WeightUnit.lbs.rawValue, forKey: "weightUnit")
+        // 220 lb → 230 lb crosses the 225 lb plate step (in grams).
+        let expected = Int(convertWeightForStoring(225.0))
+        let from = Int(convertWeightForStoring(220.0))
+        let to = Int(convertWeightForStoring(230.0))
+        XCTAssertEqual(MilestoneLadder.highestStep(crossedFrom: from, to: to, metric: .weight), expected)
+    }
+
+    func testRepetitionsLadder() {
+        XCTAssertEqual(MilestoneLadder.highestStep(crossedFrom: 8, to: 12, metric: .repetitions), 10)
+        XCTAssertNil(MilestoneLadder.highestStep(crossedFrom: 10, to: 12, metric: .repetitions))
+    }
+
+    func testDistanceLadderIncludesHalfMarathon() {
+        XCTAssertEqual(
+            MilestoneLadder.highestStep(crossedFrom: 15_000, to: 21_100, metric: .distance),
+            21_098
+        )
+    }
+}
+
+// MARK: - Duration formatting
+
+/// Recorded durations are stored as whole seconds but displayed as a digital reading, so a held
+/// plank and a treadmill run read the way a clock does rather than as a bare seconds count.
+final class DurationFormattingTests: XCTestCase {
+    func testSubMinuteKeepsLeadingZeroMinute() {
+        XCTAssertEqual(formatDurationForDisplay(45), "0:45")
+        XCTAssertEqual(formatDurationForDisplay(5), "0:05")
+    }
+
+    func testWholeMinute() {
+        XCTAssertEqual(formatDurationForDisplay(60), "1:00")
+        XCTAssertEqual(formatDurationForDisplay(90), "1:30")
+    }
+
+    func testManyMinutesPadsSecondsNotMinutes() {
+        // The reported case: a 1280-second run read as "1280 SEC".
+        XCTAssertEqual(formatDurationForDisplay(1280), "21:20")
+        XCTAssertEqual(formatDurationForDisplay(1320), "22:00")
+    }
+
+    func testHoursSplitOffAndPadMinutes() {
+        XCTAssertEqual(formatDurationForDisplay(3600), "1:00:00")
+        XCTAssertEqual(formatDurationForDisplay(3700), "1:01:40")
+        XCTAssertEqual(formatDurationForDisplay(7325), "2:02:05")
+    }
+
+    func testZeroAndNegativeAreSafe() {
+        XCTAssertEqual(formatDurationForDisplay(0), "0:00")
+        // Values can't be negative in the store, but the formatter must not produce "-1:-1".
+        XCTAssertEqual(formatDurationForDisplay(-30), "0:00")
+    }
+
+    /// The rest-duration picker delegates to the shared formatter — its output must not drift.
+    func testRestTimeStringMatchesSharedFormatter() {
+        for seconds in [30, 60, 90, 120, 180] {
+            XCTAssertEqual(restTimeString(seconds: seconds), formatDurationForDisplay(seconds))
+        }
+    }
+
+    /// VoiceOver gets words, not a pair of bare numbers.
+    func testAccessibleDurationSpellsUnitsAndHidesZeroes() {
+        let ninety = accessibleDurationForDisplay(90)
+        XCTAssertTrue(ninety.contains("1"), "Expected a minute component in \(ninety)")
+        XCTAssertTrue(ninety.contains("30"), "Expected a second component in \(ninety)")
+        // A sub-minute hold shouldn't announce "0 minutes".
+        let fortyFive = accessibleDurationForDisplay(45)
+        XCTAssertFalse(fortyFive.hasPrefix("0"), "Zero-valued units should be hidden: \(fortyFive)")
+    }
+}


### PR DESCRIPTION
## Strength Progress

The Progress tab's headline tile is renamed **Strength Progress** — it measures an estimated-1RM trend, which "Overall Progress" never said — and moves above the highlights. All 8 locales updated.

## Highlights → a carousel of moments

Highlights was a list of identical trophy rows that only ever showed personal records. It's now a swipeable carousel of uniform-height cards, widened to cover the improvements you'd otherwise have to dig out of the detail charts:

| Type | Fires when | Opens |
|---|---|---|
| Milestone | an all-time best crosses a ladder step ("first time past 100 kg") | exercise detail |
| Record | the existing recent-records feed | exercise detail |
| Year crossing | this year's running volume passes last year's full total | volume chart (year) |
| Trend | last 4 weeks beat the 4 before — volume / sets / workouts, whole-training or per muscle group / exercise | stat chart / muscle detail / exercise |

**Milestones** are detected purely from `previousBest < step ≤ value` on a record the app already computes, which makes them free of new state: a milestone is always also a record (its card replaces the record card), a first-ever entry can't fire one, and a step can't fire twice. Ladders follow the *display* unit — kg lifters cross 100 kg, lbs lifters cross plate numbers like 225.

**Trends** compare rolling 4-week windows, never partial calendar months (which would lie on the 10th), and sit behind both relative and absolute noise floors plus minimum training, so "up 50 %" can't come from 2 sets becoming 3.

Cards wear the personal-record card's own anatomy — trophy badge, the shared previous-best → new-record scoreboard, the bleeding all-time line — so the same event looks the same wherever it appears. Comparison cards revive `ComparisonBar`, orphaned since #51 removed `HighlightView`. **Show All** lists everything by priority once there's more than the carousel shows.

## Duration formatting

Durations rendered as raw seconds ("1280 SEC") everywhere they were *displayed* rather than edited. A shared `formatDurationForDisplay` now gives the digital reading the rest timer already uses (`0:45`, `21:20`, `1:01:40`), applied to records, the duration tile and chart (header, tooltip **and** axis), recent attempts, the in-workout badge and panel, and the Live Activity — whose own doc comment already claimed it showed "1:30". Editable min/sec entry fields are deliberately untouched. VoiceOver gets words rather than a pair of bare numbers.

## Verification

- 14 new unit tests (milestone ladder incl. lbs plate math and re-fire guard; duration formatting incl. hours, zero and negative)
- 14 existing Live Activity snapshot tests still pass
- Scenario captures on `one` / `many` / `free` / `stress`; carousel swipe, Show All and card tap-through driven end to end
- All four card faces rendered and inspected — the trend and year cards required temporarily dropping the noise floors, since fixture data never clears them

Cards yield their fixed height at accessibility Dynamic Type sizes, matching `MetricTile`, so uniform cards can't clip text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)