### PR TITLE
Localizations: remove duplicate keys across all 8 locales

### DIFF
--- a/LOGIT/Core/Environment/de.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/de.lproj/Localizable.strings
@@ -38,8 +38,8 @@
 "back" = "Rücken";
 "best" = "Max";
 "biceps" = "Bizeps";
-"bicepsLeft" = "Linker Bizeps";
-"bicepsRight" = "Rechter Bizeps";
+"bicepsLeft" = "Bizeps Links";
+"bicepsRight" = "Bizeps Rechts";
 "bodyFatPercentage" = "Körperfett";
 "bodyParts" = "Körperteile";
 "bodyweight" = "Körpergewicht";
@@ -102,7 +102,6 @@
 
 // MARK: - E
 
-"edit" = "Bearbeiten";
 "edit" = "Bearbeiten";
 "editDateTime" = "Datum / Zeit bearbeiten";
 "editNote" = "Notiz bearbeiten";
@@ -186,17 +185,13 @@
 
 "measurementBodyweight" = "Körpergewicht";
 "measurementCaloriesBurned" = "Verbrannte Kalorien";
-"chest" = "Brust";
-"measurementLengthHhmeasurementLengthBicepsLeft" = "Linker Bizeps";
 "calfLeft" = "Wade Links";
 "forearmLeft" = "Unterarm Links";
 "thighLeft" = "Oberschenkel Links";
 "neck" = "Hals";
-"bicepsRight" = "Bizeps Rechts";
 "calfRight" = "Wade Rechts";
 "forearmRight" = "Unterarm Rechts";
 "thighRight" = "Oberschenkel Rechts";
-"shoulders" = "Schultern";
 "waist" = "Taille";
 "measurements" = "Messungen";
 "measurementsPromotionDescription" = "Verfolge Körpergewicht, Körperfett und Körpermaße wie Arme, Brust und Taille, um deinen Fortschritt zu sehen.";
@@ -952,7 +947,6 @@
 "muscleBalanceLightYear" = "%@ dieses Jahr zu wenig";
 "muscleBalanceOnTarget" = "%d von 8 Gruppen im Ziel";
 "muscleBalanceBarA11y" = "%1$@: %2$d%% der Sätze, Ziel %3$d%%";
-"muscleBalanceOnTrack" = "Größtenteils im Plan";
 "muscleBalanceRoomToBalance" = "Noch Luft zum Ausgleich";
 "balanceVsTarget" = "Balance vs. Ziel";
 "adjustTargetSplit" = "Zielverteilung anpassen";
@@ -1032,14 +1026,6 @@
 "overallProgressBasis" = "Geschätztes 1RM · letzte 8 Wochen vs. die 8 davor";
 "overallProgressEmpty" = "Logge weiter Workouts, um deinen Gesamttrend zu sehen.";
 "streak" = "Streak";
-
-/* Muscle Balance — donut overview, sections & history chart */
-"muscleBalanceMore" = "+%d weitere";
-"muscleBalanceOverTime" = "Balance im Zeitverlauf";
-"muscleDetailEmptySubtitle" = "Du hast diese Muskelgruppe im gewählten Zeitraum nicht trainiert.";
-"muscleBalanceBelowTarget" = "Unter dem Ziel";
-"muscleBalanceAboveTarget" = "Über dem Ziel";
-"muscleBalanceOnTargetSection" = "Im Ziel";
 
 // Timeframe unification: shared chart ranges + per-period muscle history
 "range" = "Bereich";

--- a/LOGIT/Core/Environment/en.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/en.lproj/Localizable.strings
@@ -103,7 +103,6 @@
 // MARK: - E
 
 "edit" = "Edit";
-"edit" = "Edit";
 "editDateTime" = "Edit Date / Time";
 "editNote" = "Edit Note";
 "editTemplate" = "Edit Template";
@@ -191,17 +190,13 @@
 
 "measurementBodyweight" = "Bodyweight";
 "measurementCaloriesBurned" = "Calories Burned";
-"chest" = "Chest";
-"measurementLengthHhmeasurementLengthBicepsLeft" = "Biceps Left";
 "calfLeft" = "Calf Left";
 "forearmLeft" = "Forearm Left";
 "thighLeft" = "Thigh Left";
 "neck" = "Neck";
-"bicepsRight" = "Biceps Right";
 "calfRight" = "Calf Right";
 "forearmRight" = "Forearm Right";
 "thighRight" = "Thigh Right";
-"shoulders" = "Shoulders";
 "waist" = "Waist";
 "measurements" = "Measurements";
 "min" = "min";
@@ -956,7 +951,6 @@
 "muscleBalanceLightYear" = "%@ light this year";
 "muscleBalanceOnTarget" = "%d of 8 groups on target";
 "muscleBalanceBarA11y" = "%1$@: %2$d%% of sets, target %3$d%%";
-"muscleBalanceOnTrack" = "Mostly on track";
 "muscleBalanceRoomToBalance" = "Room to balance";
 "balanceVsTarget" = "Balance vs target";
 "adjustTargetSplit" = "Adjust target split";
@@ -1036,14 +1030,6 @@
 "overallProgressBasis" = "Estimated 1RM · last 8 weeks vs the 8 before";
 "overallProgressEmpty" = "Keep logging workouts to see your overall trend.";
 "streak" = "Streak";
-
-/* Muscle Balance — donut overview, sections & history chart */
-"muscleBalanceMore" = "+%d more";
-"muscleBalanceOverTime" = "Balance over time";
-"muscleDetailEmptySubtitle" = "You haven't trained this muscle in the selected period.";
-"muscleBalanceBelowTarget" = "Below target";
-"muscleBalanceAboveTarget" = "Above target";
-"muscleBalanceOnTargetSection" = "On target";
 
 // Timeframe unification: shared chart ranges + per-period muscle history
 "range" = "Range";

--- a/LOGIT/Core/Environment/es.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/es.lproj/Localizable.strings
@@ -103,7 +103,6 @@
 // MARK: - E
 
 "edit" = "Editar";
-"edit" = "Editar";
 "editDateTime" = "Editar fecha/hora";
 "editNote" = "Editar nota";
 "editTemplate" = "Editar plantilla";
@@ -191,17 +190,13 @@
 
 "measurementBodyweight" = "peso corporal";
 "measurementCaloriesBurned" = "Calorías quemadas";
-"chest" = "Pecho";
-"measurementLengthHhmeasurementLengthBicepsLeft" = "Bíceps Izquierdo";
 "calfLeft" = "Pantorrilla Izquierda";
 "forearmLeft" = "antebrazo izquierdo";
 "thighLeft" = "muslo izquierdo";
 "neck" = "Cuello";
-"bicepsRight" = "Bíceps derecho";
 "calfRight" = "Pantorrilla Derecha";
 "forearmRight" = "antebrazo derecho";
 "thighRight" = "Muslo Derecho";
-"shoulders" = "Hombros";
 "waist" = "Cintura";
 "measurements" = "Medidas";
 "min" = "mín.";
@@ -956,7 +951,6 @@
 "muscleBalanceLightYear" = "%@ flojo este año";
 "muscleBalanceOnTarget" = "%d de 8 grupos en objetivo";
 "muscleBalanceBarA11y" = "%1$@: %2$d%% de las series, objetivo %3$d%%";
-"muscleBalanceOnTrack" = "Casi en objetivo";
 "muscleBalanceRoomToBalance" = "Margen para equilibrar";
 "balanceVsTarget" = "Balance vs objetivo";
 "adjustTargetSplit" = "Ajustar reparto objetivo";
@@ -1036,14 +1030,6 @@
 "overallProgressBasis" = "1RM estimado · últimas 8 semanas vs. las 8 anteriores";
 "overallProgressEmpty" = "Sigue registrando entrenamientos para ver tu tendencia general.";
 "streak" = "Racha";
-
-/* Muscle Balance — donut overview, sections & history chart */
-"muscleBalanceMore" = "+%d más";
-"muscleBalanceOverTime" = "Equilibrio a lo largo del tiempo";
-"muscleDetailEmptySubtitle" = "No has entrenado este músculo en el periodo seleccionado.";
-"muscleBalanceBelowTarget" = "Bajo el objetivo";
-"muscleBalanceAboveTarget" = "Sobre el objetivo";
-"muscleBalanceOnTargetSection" = "En objetivo";
 
 // Timeframe unification: shared chart ranges + per-period muscle history
 "range" = "Rango";

--- a/LOGIT/Core/Environment/fr.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/fr.lproj/Localizable.strings
@@ -103,7 +103,6 @@
 // MARK: - E
 
 "edit" = "Modifier";
-"edit" = "Modifier";
 "editDateTime" = "Modifier la date/l'heure";
 "editNote" = "Modifier la note";
 "editTemplate" = "Modifier le modèle";
@@ -191,17 +190,13 @@
 
 "measurementBodyweight" = "Poids corporel";
 "measurementCaloriesBurned" = "Calories brûlées";
-"chest" = "Poitrine";
-"measurementLengthHhmeasurementLengthBicepsLeft" = "Biceps gauche";
 "calfLeft" = "Veau gauche";
 "forearmLeft" = "Avant-bras gauche";
 "thighLeft" = "Cuisse gauche";
 "neck" = "Cou";
-"bicepsRight" = "Biceps droit";
 "calfRight" = "Veau droit";
 "forearmRight" = "Avant-bras droit";
 "thighRight" = "Cuisse droite";
-"shoulders" = "Épaules";
 "waist" = "Taille";
 "measurements" = "Mesures";
 "min" = "min";
@@ -956,7 +951,6 @@
 "muscleBalanceLightYear" = "%@ faible cette année";
 "muscleBalanceOnTarget" = "%d des 8 groupes dans la cible";
 "muscleBalanceBarA11y" = "%1$@ : %2$d%% des séries, cible %3$d%%";
-"muscleBalanceOnTrack" = "Globalement sur la bonne voie";
 "muscleBalanceRoomToBalance" = "Marge d'équilibrage";
 "balanceVsTarget" = "Équilibre vs cible";
 "adjustTargetSplit" = "Ajuster la répartition cible";
@@ -1036,14 +1030,6 @@
 "overallProgressBasis" = "1RM estimé · 8 dernières semaines vs les 8 précédentes";
 "overallProgressEmpty" = "Continuez à enregistrer des séances pour voir votre tendance globale.";
 "streak" = "Série";
-
-/* Muscle Balance — donut overview, sections & history chart */
-"muscleBalanceMore" = "+%d de plus";
-"muscleBalanceOverTime" = "Équilibre dans le temps";
-"muscleDetailEmptySubtitle" = "Vous n'avez pas entraîné ce muscle sur la période sélectionnée.";
-"muscleBalanceBelowTarget" = "Sous la cible";
-"muscleBalanceAboveTarget" = "Au-dessus de la cible";
-"muscleBalanceOnTargetSection" = "Dans la cible";
 
 // Timeframe unification: shared chart ranges + per-period muscle history
 "range" = "Plage";

--- a/LOGIT/Core/Environment/it.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/it.lproj/Localizable.strings
@@ -103,7 +103,6 @@
 // MARK: - E
 
 "edit" = "Modificare";
-"edit" = "Modificare";
 "editDateTime" = "Modifica data/ora";
 "editNote" = "Modifica nota";
 "editTemplate" = "Modifica modello";
@@ -191,17 +190,13 @@
 
 "measurementBodyweight" = "Peso corporeo";
 "measurementCaloriesBurned" = "Calorie bruciate";
-"chest" = "Petto";
-"measurementLengthHhmeasurementLengthBicepsLeft" = "Bicipite sinistro";
 "calfLeft" = "Vitello a sinistra";
 "forearmLeft" = "Avambraccio sinistro";
 "thighLeft" = "Coscia sinistra";
 "neck" = "Collo";
-"bicepsRight" = "Bicipite destro";
 "calfRight" = "Vitello Giusto";
 "forearmRight" = "Avambraccio destro";
 "thighRight" = "Coscia destra";
-"shoulders" = "Spalle";
 "waist" = "Vita";
 "measurements" = "Misure";
 "min" = "min";
@@ -956,7 +951,6 @@
 "muscleBalanceLightYear" = "%@ scarso quest'anno";
 "muscleBalanceOnTarget" = "%d di 8 gruppi a target";
 "muscleBalanceBarA11y" = "%1$@: %2$d%% delle serie, target %3$d%%";
-"muscleBalanceOnTrack" = "Per lo più in linea";
 "muscleBalanceRoomToBalance" = "Spazio per bilanciare";
 "balanceVsTarget" = "Equilibrio vs target";
 "adjustTargetSplit" = "Regola la ripartizione target";
@@ -1036,14 +1030,6 @@
 "overallProgressBasis" = "1RM stimato · ultime 8 settimane vs le 8 precedenti";
 "overallProgressEmpty" = "Continua a registrare allenamenti per vedere il tuo andamento generale.";
 "streak" = "Serie";
-
-/* Muscle Balance — donut overview, sections & history chart */
-"muscleBalanceMore" = "+%d altri";
-"muscleBalanceOverTime" = "Equilibrio nel tempo";
-"muscleDetailEmptySubtitle" = "Non hai allenato questo muscolo nel periodo selezionato.";
-"muscleBalanceBelowTarget" = "Sotto il target";
-"muscleBalanceAboveTarget" = "Sopra il target";
-"muscleBalanceOnTargetSection" = "A target";
 
 // Timeframe unification: shared chart ranges + per-period muscle history
 "range" = "Intervallo";

--- a/LOGIT/Core/Environment/ja.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/ja.lproj/Localizable.strings
@@ -103,7 +103,6 @@
 // MARK: - E
 
 "edit" = "編集";
-"edit" = "編集";
 "editDateTime" = "日付/時刻の編集";
 "editNote" = "メモの編集";
 "editTemplate" = "テンプレートの編集";
@@ -191,17 +190,13 @@
 
 "measurementBodyweight" = "体重";
 "measurementCaloriesBurned" = "消費カロリー";
-"chest" = "胸";
-"measurementLengthHhmeasurementLengthBicepsLeft" = "左上腕二頭筋";
 "calfLeft" = "ふくらはぎ左";
 "forearmLeft" = "前腕左";
 "thighLeft" = "左腿";
 "neck" = "ネック";
-"bicepsRight" = "右上腕二頭筋";
 "calfRight" = "右ふくらはぎ";
 "forearmRight" = "右前腕";
 "thighRight" = "右もも";
-"shoulders" = "肩";
 "waist" = "ウエスト";
 "measurements" = "測定";
 "min" = "分";
@@ -956,7 +951,6 @@
 "muscleBalanceLightYear" = "今年は%@が少なめ";
 "muscleBalanceOnTarget" = "8グループ中%dが目標内";
 "muscleBalanceBarA11y" = "%1$@：セットの%2$d%%、目標%3$d%%";
-"muscleBalanceOnTrack" = "概ね順調";
 "muscleBalanceRoomToBalance" = "調整の余地あり";
 "balanceVsTarget" = "目標との比較";
 "adjustTargetSplit" = "目標配分を調整";
@@ -1036,14 +1030,6 @@
 "overallProgressBasis" = "推定1RM · 直近8週間 vs その前の8週間";
 "overallProgressEmpty" = "ワークアウトを記録すると全体の傾向が表示されます。";
 "streak" = "連続記録";
-
-/* Muscle Balance — donut overview, sections & history chart */
-"muscleBalanceMore" = "他%d件";
-"muscleBalanceOverTime" = "時間ごとのバランス";
-"muscleDetailEmptySubtitle" = "選択した期間にこの部位はトレーニングしていません。";
-"muscleBalanceBelowTarget" = "目標未満";
-"muscleBalanceAboveTarget" = "目標超過";
-"muscleBalanceOnTargetSection" = "目標どおり";
 
 // Timeframe unification: shared chart ranges + per-period muscle history
 "range" = "範囲";

--- a/LOGIT/Core/Environment/ko.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/ko.lproj/Localizable.strings
@@ -103,7 +103,6 @@
 // MARK: - E
 
 "edit" = "편집";
-"edit" = "편집";
 "editDateTime" = "날짜/시간 편집";
 "editNote" = "메모 편집";
 "editTemplate" = "템플릿 편집";
@@ -191,17 +190,13 @@
 
 "measurementBodyweight" = "체중";
 "measurementCaloriesBurned" = "칼로리 소모량";
-"chest" = "가슴";
-"measurementLengthHhmeasurementLengthBicepsLeft" = "왼쪽 팔뚝";
 "calfLeft" = "종아리 왼쪽";
 "forearmLeft" = "팔뚝 왼쪽";
 "thighLeft" = "허벅지 왼쪽";
 "neck" = "목";
-"bicepsRight" = "이두근 오른쪽";
 "calfRight" = "종아리 오른쪽";
 "forearmRight" = "팔뚝 오른쪽";
 "thighRight" = "허벅지 오른쪽";
-"shoulders" = "어깨";
 "waist" = "허리";
 "measurements" = "측정";
 "min" = "분";
@@ -956,7 +951,6 @@
 "muscleBalanceLightYear" = "올해 %@ 부족";
 "muscleBalanceOnTarget" = "8개 그룹 중 %d개 목표 달성";
 "muscleBalanceBarA11y" = "%1$@: 세트의 %2$d%%, 목표 %3$d%%";
-"muscleBalanceOnTrack" = "대체로 양호";
 "muscleBalanceRoomToBalance" = "균형 개선 여지";
 "balanceVsTarget" = "목표 대비 균형";
 "adjustTargetSplit" = "목표 배분 조정";
@@ -1036,14 +1030,6 @@
 "overallProgressBasis" = "추정 1RM · 최근 8주 vs 이전 8주";
 "overallProgressEmpty" = "운동을 계속 기록하면 전체 추세를 볼 수 있습니다.";
 "streak" = "연속 기록";
-
-/* Muscle Balance — donut overview, sections & history chart */
-"muscleBalanceMore" = "외 %d개";
-"muscleBalanceOverTime" = "기간별 균형";
-"muscleDetailEmptySubtitle" = "선택한 기간에 이 부위를 운동하지 않았습니다.";
-"muscleBalanceBelowTarget" = "목표 미만";
-"muscleBalanceAboveTarget" = "목표 초과";
-"muscleBalanceOnTargetSection" = "목표 달성";
 
 // Timeframe unification: shared chart ranges + per-period muscle history
 "range" = "범위";

--- a/LOGIT/Core/Environment/pt-BR.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/pt-BR.lproj/Localizable.strings
@@ -103,7 +103,6 @@
 // MARK: - E
 
 "edit" = "Editar";
-"edit" = "Editar";
 "editDateTime" = "Editar data/hora";
 "editNote" = "Editar nota";
 "editTemplate" = "Editar modelo";
@@ -191,17 +190,13 @@
 
 "measurementBodyweight" = "Peso corporal";
 "measurementCaloriesBurned" = "Calorias queimadas";
-"chest" = "Peito";
-"measurementLengthHhmeasurementLengthBicepsLeft" = "Bíceps Esquerdo";
 "calfLeft" = "Panturrilha Esquerda";
 "forearmLeft" = "Antebraço Esquerdo";
 "thighLeft" = "Coxa Esquerda";
 "neck" = "Pescoço";
-"bicepsRight" = "Bíceps direito";
 "calfRight" = "Panturrilha Direita";
 "forearmRight" = "Antebraço direito";
 "thighRight" = "Coxa Direita";
-"shoulders" = "Ombros";
 "waist" = "Cintura";
 "measurements" = "Medições";
 "min" = "min";
@@ -956,7 +951,6 @@
 "muscleBalanceLightYear" = "%@ fraco este ano";
 "muscleBalanceOnTarget" = "%d de 8 grupos na meta";
 "muscleBalanceBarA11y" = "%1$@: %2$d%% das séries, meta %3$d%%";
-"muscleBalanceOnTrack" = "Quase no alvo";
 "muscleBalanceRoomToBalance" = "Espaço para equilibrar";
 "balanceVsTarget" = "Equilíbrio vs meta";
 "adjustTargetSplit" = "Ajustar divisão da meta";
@@ -1036,14 +1030,6 @@
 "overallProgressBasis" = "1RM estimado · últimas 8 semanas vs. as 8 anteriores";
 "overallProgressEmpty" = "Continue registrando treinos para ver sua tendência geral.";
 "streak" = "Sequência";
-
-/* Muscle Balance — donut overview, sections & history chart */
-"muscleBalanceMore" = "+%d mais";
-"muscleBalanceOverTime" = "Equilíbrio ao longo do tempo";
-"muscleDetailEmptySubtitle" = "Você não treinou este músculo no período selecionado.";
-"muscleBalanceBelowTarget" = "Abaixo da meta";
-"muscleBalanceAboveTarget" = "Acima da meta";
-"muscleBalanceOnTargetSection" = "No alvo";
 
 // Timeframe unification: shared chart ranges + per-period muscle history
 "range" = "Intervalo";


### PR DESCRIPTION
Every locale's `Localizable.strings` defined the same 11 keys twice. Duplicates don't error in a `.strings` file — **the last definition silently wins** — so these were live landmines: editing the visible-looking entry would have had no effect on what ships.

Found with:

```bash
grep -o '^"[^"]*"' <file> | sort | uniq -d
```

## What the duplicates were

| Key(s) | Cause | Resolution |
|---|---|---|
| `chest`, `bicepsRight`, `shoulders` | e7aa9814's ancestor `4074198a` stripped the `measurementLength` prefix off the measurement block, colliding those keys with their alphabetical entries | Kept the alphabetical entry, dropped the measurement-block copy |
| `edit` | Two identical adjacent lines | Dropped the second |
| `muscleBalanceMore`, `muscleBalanceOverTime`, `muscleDetailEmptySubtitle`, `muscleBalanceBelowTarget`, `muscleBalanceAboveTarget`, `muscleBalanceOnTargetSection` | A trailing `/* Muscle Balance — donut overview… */` block re-declaring six already-defined keys verbatim | Deleted the whole block, comment included |
| `muscleBalanceOnTrack` | Two **different** values | Kept the later, already-winning one |

Only two keys had values that actually differed between their copies:

- **`muscleBalanceOnTrack`** — "Mostly on track" vs "On track" (and equivalents in all 8 locales). Kept the later wording, which is what was already rendering. It's a dead key besides: no Swift file references it.
- **`bicepsRight` (de only)** — `"Rechter Bizeps"` vs `"Bizeps Rechts"`. The winning value moved onto the canonical alphabetical entry, so the German string on screen is unchanged.

The dedup itself is provably a **no-op on rendered output**.

## Two adjacent cleanups

- Deleted `measurementLengthHhmeasurementLengthBicepsLeft`, a mangled leftover of that same rename, confirmed to have zero references outside the strings files.
- Fixed de's `bicepsLeft` → `"Bizeps Links"`, so the pair reads `Bizeps Links` / `Bizeps Rechts`, matching the six other left/right measurement labels (`Wade Links`, `Unterarm Rechts`, `Oberschenkel Links`…). `LengthMeasurementEntryType.rawValue` is localized directly, so this key backs both the measurement label and the muscle-group label.

## Verification

- No locale has duplicate keys (the `uniq -d` above returns empty for all 8)
- All 8 locales share an identical sorted key set
- `plutil -lint` passes on all 8
- `plutil -convert json` resolved maps diffed against the pre-change files show **exactly** the two intended value changes and nothing else. Since `plutil` resolves duplicates last-wins the same way the runtime does, this proves no other string changed — no screenshot run needed.

114 deletions, 2 insertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)