### PR TITLE
Summary: rebuild the Strength tile around the trend arrow, add its detail screen

### DIFF
--- a/LOGIT.xcodeproj/project.pbxproj
+++ b/LOGIT.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		5F6C92E180BAAEC435086790 /* PeriodHistoryChart.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3C48765200C9745764F2EAA /* PeriodHistoryChart.swift */; };
 		5FA589471AAA718BF29F5E04 /* BodyWeightSyncManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EC1A1AB3B397E77717694AF /* BodyWeightSyncManager.swift */; };
 		6A45A79A5D89B951F7726DBD /* WorkoutLiveActivitySnapshotBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F7B218CB83CEAEB494355C8 /* WorkoutLiveActivitySnapshotBuilderTests.swift */; };
+		71DC3DEF356C2667D7C796F8 /* TrendPlaceholder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72351631D9DB7A20F527F839 /* TrendPlaceholder.swift */; };
 		73A9CED8C934FDF36F9C4061 /* BodyMapFigure.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBBF6087BB65A5971FB5F866 /* BodyMapFigure.swift */; };
 		773128213DE6E6FA1506597C /* WorkoutLiveActivityAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 829F12D41C231764936B6B83 /* WorkoutLiveActivityAttributes.swift */; };
 		77B7E6990E4C00B75D9BC6ED /* PeriodPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA597E1519E8F6D2CBC8F9E /* PeriodPicker.swift */; };
@@ -392,6 +393,7 @@
 		62318B964175E7D02FE83914 /* MuscleTargetSplit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MuscleTargetSplit.swift; sourceTree = "<group>"; };
 		6923C33A92504E5287236332 /* OneRepMaxCalculating.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OneRepMaxCalculating.swift; sourceTree = "<group>"; };
 		6EC26E447A22B0B31E11DF31 /* StrengthProgress.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StrengthProgress.swift; sourceTree = "<group>"; };
+		72351631D9DB7A20F527F839 /* TrendPlaceholder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TrendPlaceholder.swift; sourceTree = "<group>"; };
 		7907FDE9289E99B1006AF271 /* CloudKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CloudKit.framework; path = System/Library/Frameworks/CloudKit.framework; sourceTree = SDKROOT; };
 		792A3FF22AB478F000C6A097 /* DatabaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseTests.swift; sourceTree = "<group>"; };
 		792D522B27F1160800B08813 /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
@@ -1321,6 +1323,7 @@
 				80NEWSHAR002 /* WorkoutActivityItemSource.swift */,
 				3184F4CAAB24791B6F5AC79A /* SharedWithYouBanner.swift */,
 				1F685CCE0EE8FE86E8E0135C /* RangePicker.swift */,
+				72351631D9DB7A20F527F839 /* TrendPlaceholder.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -1899,6 +1902,7 @@
 				CF922A65C4F78FA952E32E14 /* StrengthProgress.swift in Sources */,
 				5EB4C2E402AFA8F141A51F77 /* StrengthTile.swift in Sources */,
 				F7C76517E05AC18F16E4AC39 /* StrengthScreen.swift in Sources */,
+				71DC3DEF356C2667D7C796F8 /* TrendPlaceholder.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/LOGIT.xcodeproj/project.pbxproj
+++ b/LOGIT.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		53B547C48713887B1E5542EE /* MuscleBalanceCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0258213863A5C9812190A44D /* MuscleBalanceCalculator.swift */; };
 		5701E3D211A49E43B531E6D8 /* SnapshotHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0400C2E827A4AEAF03BACDC6 /* SnapshotHelper.swift */; };
 		57A9ABF55683DB0071E02FE6 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A72B470FE19DAE1E42233F7F /* Foundation.framework */; };
+		5EB4C2E402AFA8F141A51F77 /* StrengthTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B23FB52CA7FD72BF528A720 /* StrengthTile.swift */; };
 		5F6C92E180BAAEC435086790 /* PeriodHistoryChart.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3C48765200C9745764F2EAA /* PeriodHistoryChart.swift */; };
 		5FA589471AAA718BF29F5E04 /* BodyWeightSyncManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EC1A1AB3B397E77717694AF /* BodyWeightSyncManager.swift */; };
 		6A45A79A5D89B951F7726DBD /* WorkoutLiveActivitySnapshotBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F7B218CB83CEAEB494355C8 /* WorkoutLiveActivitySnapshotBuilderTests.swift */; };
@@ -166,7 +167,6 @@
 		801BBDE62DF7338A00CDB1FB /* ExerciseRepetitionsTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBCEA2DF7338A00CDB1FB /* ExerciseRepetitionsTile.swift */; };
 		801BBDE72DF7338A00CDB1FB /* UIConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBCAB2DF7338A00CDB1FB /* UIConstants.swift */; };
 		801BBDE82DF7338A00CDB1FB /* ExerciseHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBD4F2DF7338A00CDB1FB /* ExerciseHeader.swift */; };
-		80TH00022F80AA0100TH0002 /* SetGroupThread.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80TH00012F80AA0100TH0001 /* SetGroupThread.swift */; };
 		801BBDE92DF7338A00CDB1FB /* UIScreen+ScreenCorners.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBCB42DF7338A00CDB1FB /* UIScreen+ScreenCorners.swift */; };
 		801BBDEA2DF7338A00CDB1FB /* EnvironmentValues+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBCA72DF7338A00CDB1FB /* EnvironmentValues+.swift */; };
 		801BBDEB2DF7338A00CDB1FB /* WorkoutDetailScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801BBD272DF7338A00CDB1FB /* WorkoutDetailScreen.swift */; };
@@ -236,6 +236,7 @@
 		80SE000C2F70CC0100SE000C /* SetEntryMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80SE00092F70CC0100SE0009 /* SetEntryMigrationTests.swift */; };
 		80SE000D2F70CC0100SE000D /* LOGIT-v7-legacy.sqlite in Resources */ = {isa = PBXBuildFile; fileRef = 80SE000A2F70CC0100SE000A /* LOGIT-v7-legacy.sqlite */; };
 		80SE00112F70CC0100SE0011 /* SetEntryFieldsRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80SE00122F70CC0100SE0012 /* SetEntryFieldsRow.swift */; };
+		80TH00022F80AA0100TH0002 /* SetGroupThread.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80TH00012F80AA0100TH0001 /* SetGroupThread.swift */; };
 		85709CDA5A20D6B7D9C23487 /* ExerciseMergeServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF956F5D14BBB78133BD528A /* ExerciseMergeServiceTests.swift */; };
 		85D5027D8B1FA8DB36998EBC /* SummaryStatScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE557E27ADC9A2C02BE79DBE /* SummaryStatScreen.swift */; };
 		8628A1F9D2552C1D90998743 /* WorkoutCalorieRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 073E8CD784A7ED9A595CA5E2 /* WorkoutCalorieRow.swift */; };
@@ -279,6 +280,7 @@
 		BACD36D82914BE00C27FE040 /* MuscleTargetSplitScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80C7068F531DB65831E8FA8F /* MuscleTargetSplitScreen.swift */; };
 		BF2572963E23536237AA7662 /* MeasurementWatchlistRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE91C0394869857C0E932723 /* MeasurementWatchlistRow.swift */; };
 		C936BF70D80E3354D1D5BD21 /* SummaryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B422D4E53B9396026019B50 /* SummaryViewModel.swift */; };
+		CF922A65C4F78FA952E32E14 /* StrengthProgress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EC26E447A22B0B31E11DF31 /* StrengthProgress.swift */; };
 		CFBDBE49B12AA1C06C620875 /* ChartRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = C82BC4F48812B4D49D4E38E2 /* ChartRange.swift */; };
 		D0AF3C855D8D73E72DA7AF92 /* SummaryWelcomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E62F41D02C28CB089872E955 /* SummaryWelcomeView.swift */; };
 		D1D1D1000000000000000B01 /* MetricTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1D1D1000000000000000F01 /* MetricTile.swift */; };
@@ -301,6 +303,7 @@
 		E1E1E1000000000000000B16 /* PersonalBestRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1E1E1000000000000000F16 /* PersonalBestRow.swift */; };
 		E5F79A5B29FEF4F260749E66 /* LiveActivityShowcaseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A95CC85E7895692DD1082ACD /* LiveActivityShowcaseView.swift */; };
 		F344926EBBAE89A564139E06 /* MuscleTargetSplitStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DDAB0743896FB9245B6D5A9 /* MuscleTargetSplitStore.swift */; };
+		F7C76517E05AC18F16E4AC39 /* StrengthScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95BD1BA8A1474C3D38694723 /* StrengthScreen.swift */; };
 		F83E8531DDDC8C271BDF20F1 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A72B470FE19DAE1E42233F7F /* Foundation.framework */; };
 		F9CE85436E7F6E6314F09662 /* ProgressHighlightCards.swift in Sources */ = {isa = PBXBuildFile; fileRef = 391121B40138EB15F263AD08 /* ProgressHighlightCards.swift */; };
 		FAC9CFA615E04E86BD814205 /* OneRepMaxCalculating.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6923C33A92504E5287236332 /* OneRepMaxCalculating.swift */; };
@@ -388,6 +391,7 @@
 		5F7B218CB83CEAEB494355C8 /* WorkoutLiveActivitySnapshotBuilderTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkoutLiveActivitySnapshotBuilderTests.swift; sourceTree = "<group>"; };
 		62318B964175E7D02FE83914 /* MuscleTargetSplit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MuscleTargetSplit.swift; sourceTree = "<group>"; };
 		6923C33A92504E5287236332 /* OneRepMaxCalculating.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OneRepMaxCalculating.swift; sourceTree = "<group>"; };
+		6EC26E447A22B0B31E11DF31 /* StrengthProgress.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StrengthProgress.swift; sourceTree = "<group>"; };
 		7907FDE9289E99B1006AF271 /* CloudKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CloudKit.framework; path = System/Library/Frameworks/CloudKit.framework; sourceTree = SDKROOT; };
 		792A3FF22AB478F000C6A097 /* DatabaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseTests.swift; sourceTree = "<group>"; };
 		792D522B27F1160800B08813 /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
@@ -399,6 +403,7 @@
 		79E849072A7EA28000C0DF95 /* LOGITTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LOGITTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		79E849092A7EA28000C0DF95 /* ExerciseServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseServiceTests.swift; sourceTree = "<group>"; };
 		79EEE8722792E15D71C22DA3 /* SwipeableMonthView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwipeableMonthView.swift; sourceTree = "<group>"; };
+		7B23FB52CA7FD72BF528A720 /* StrengthTile.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StrengthTile.swift; sourceTree = "<group>"; };
 		7F8CD271000D75928FAE0887 /* StatPeriodTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatPeriodTests.swift; sourceTree = "<group>"; };
 		80036CDA2EFEF98C00B7C7B4 /* GlobalSearchScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalSearchScreen.swift; sourceTree = "<group>"; };
 		80036CDD2EFEF9CE00B7C7B4 /* FuzzySearchService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FuzzySearchService.swift; sourceTree = "<group>"; };
@@ -533,7 +538,6 @@
 		801BBD4C2DF7338A00CDB1FB /* TileStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TileStyle.swift; sourceTree = "<group>"; };
 		801BBD4E2DF7338A00CDB1FB /* CurrentWorkoutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentWorkoutView.swift; sourceTree = "<group>"; };
 		801BBD4F2DF7338A00CDB1FB /* ExerciseHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseHeader.swift; sourceTree = "<group>"; };
-		80TH00012F80AA0100TH0001 /* SetGroupThread.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetGroupThread.swift; sourceTree = "<group>"; };
 		801BBD502DF7338A00CDB1FB /* FlashView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlashView.swift; sourceTree = "<group>"; };
 		801BBD512DF7338A00CDB1FB /* InfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoView.swift; sourceTree = "<group>"; };
 		801BBD522DF7338A00CDB1FB /* IntegerField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegerField.swift; sourceTree = "<group>"; };
@@ -600,11 +604,13 @@
 		80SE000A2F70CC0100SE000A /* LOGIT-v7-legacy.sqlite */ = {isa = PBXFileReference; lastKnownFileType = file; path = "LOGIT-v7-legacy.sqlite"; sourceTree = "<group>"; };
 		80SE000B2F70CC0100SE000B /* make_v7_fixture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = make_v7_fixture.swift; sourceTree = "<group>"; };
 		80SE00122F70CC0100SE0012 /* SetEntryFieldsRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetEntryFieldsRow.swift; sourceTree = "<group>"; };
+		80TH00012F80AA0100TH0001 /* SetGroupThread.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetGroupThread.swift; sourceTree = "<group>"; };
 		829F12D41C231764936B6B83 /* WorkoutLiveActivityAttributes.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkoutLiveActivityAttributes.swift; sourceTree = "<group>"; };
 		8571CBB4B50589F1F8F36F44 /* StatPeriod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatPeriod.swift; sourceTree = "<group>"; };
 		8BA376FF1C58639B7542A334 /* WorkoutGoalScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutGoalScreen.swift; sourceTree = "<group>"; };
 		8E740E99321E2590B08B80A0 /* HealthKitSyncManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HealthKitSyncManager.swift; sourceTree = "<group>"; };
 		8F4A3C012E5A9B0100D4E5F1 /* SetVolumeBarChart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetVolumeBarChart.swift; sourceTree = "<group>"; };
+		95BD1BA8A1474C3D38694723 /* StrengthScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StrengthScreen.swift; sourceTree = "<group>"; };
 		9D2E7A012F30AA0100C1D2E1 /* DemoWorkoutSeeder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DemoWorkoutSeeder.swift; sourceTree = "<group>"; };
 		A10000000000000000000002 /* LocalizedMarkdown.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizedMarkdown.swift; sourceTree = "<group>"; };
 		A10000000000000000000050 /* logit_privacy_policy_de.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = logit_privacy_policy_de.md; sourceTree = "<group>"; };
@@ -1084,6 +1090,9 @@
 				801BBD032DF7338A00CDB1FB /* TargetPerWeekDetailScreen.swift */,
 				1FF2AD8F630BC39E7A090D62 /* ProgressHighlights.swift */,
 				391121B40138EB15F263AD08 /* ProgressHighlightCards.swift */,
+				6EC26E447A22B0B31E11DF31 /* StrengthProgress.swift */,
+				7B23FB52CA7FD72BF528A720 /* StrengthTile.swift */,
+				95BD1BA8A1474C3D38694723 /* StrengthScreen.swift */,
 			);
 			path = Home;
 			sourceTree = "<group>";
@@ -1887,6 +1896,9 @@
 				341961F0E25343384F192151 /* ProgressHighlights.swift in Sources */,
 				F9CE85436E7F6E6314F09662 /* ProgressHighlightCards.swift in Sources */,
 				37D658746432D205B9A100B7 /* DurationFormatting.swift in Sources */,
+				CF922A65C4F78FA952E32E14 /* StrengthProgress.swift in Sources */,
+				5EB4C2E402AFA8F141A51F77 /* StrengthTile.swift in Sources */,
+				F7C76517E05AC18F16E4AC39 /* StrengthScreen.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/LOGIT/Core/Environment/de.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/de.lproj/Localizable.strings
@@ -1018,13 +1018,10 @@
 
 
 /* Progress tab — overall progress trend */
-"strengthProgress" = "Kraftfortschritt";
 "trendingUp" = "Aufwärtstrend";
 "trendingSteady" = "Stabil";
 "trendingDown" = "Abwärtstrend";
 "byMuscleGroup" = "Nach Muskelgruppe";
-"strengthProgressBasis" = "Geschätztes 1RM · letzte 8 Wochen vs. die 8 davor";
-"strengthProgressEmpty" = "Logge weiter Workouts, um deinen Krafttrend zu sehen.";
 
 // Progress highlights (carousel cards)
 "firstTimePast" = "Erstmals über %@";
@@ -1127,3 +1124,18 @@
 "progressMetricRepetitionsDescription" = "Meiste Wiederholungen in einem Satz";
 "progressMetricDurationDescription" = "Längste Dauer in einem Satz";
 "progressMetricDistanceDescription" = "Weiteste Distanz in einem Satz";
+
+// Strength (Progress tab tile + detail)
+"strength" = "Kraft";
+"strengthBasis" = "Geschätztes 1RM · letzte 8 Wochen";
+"strengthEmpty" = "Logge weiter Workouts, um deinen Krafttrend zu sehen.";
+"strengthWindowCaption" = "vs. die %d Wochen davor";
+"nWeeks" = "%d Wochen";
+"nSets" = "%d Sätze";
+"allExercises" = "Alle Übungen";
+"strengthTapGroup" = "Tippe eine Gruppe an";
+"strengthBiggestMovers" = "Größte Veränderungen";
+"strengthMoversCaption" = "Balkenlänge = Veränderung · Sätze = Gewichtung";
+"strengthShowAllExercises" = "Alle %d Übungen anzeigen";
+"showLess" = "Weniger anzeigen";
+"strengthInfo" = "Das beste geschätzte 1RM jeder Übung der letzten %d Wochen im Vergleich zu den %d davor, gemittelt und nach Anzahl der Sätze gewichtet. Cardio- und Körpergewichtssätze haben kein 1RM und zählen nicht.";

--- a/LOGIT/Core/Environment/en.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/en.lproj/Localizable.strings
@@ -1022,13 +1022,10 @@
 
 
 /* Progress tab — overall progress trend */
-"strengthProgress" = "Strength Progress";
 "trendingUp" = "Trending up";
 "trendingSteady" = "Holding steady";
 "trendingDown" = "Trending down";
 "byMuscleGroup" = "By muscle group";
-"strengthProgressBasis" = "Estimated 1RM · last 8 weeks vs the 8 before";
-"strengthProgressEmpty" = "Keep logging workouts to see your strength trend.";
 
 // Progress highlights (carousel cards)
 "firstTimePast" = "First time past %@";
@@ -1131,3 +1128,18 @@
 "progressMetricRepetitionsDescription" = "Most reps in a single set";
 "progressMetricDurationDescription" = "Longest duration in a single set";
 "progressMetricDistanceDescription" = "Farthest distance in a single set";
+
+// Strength (Progress tab tile + detail)
+"strength" = "Strength";
+"strengthBasis" = "Estimated 1RM · last 8 weeks";
+"strengthEmpty" = "Keep logging workouts to see your strength trend.";
+"strengthWindowCaption" = "vs the %d weeks before";
+"nWeeks" = "%d weeks";
+"nSets" = "%d sets";
+"allExercises" = "All exercises";
+"strengthTapGroup" = "Tap a group to focus";
+"strengthBiggestMovers" = "Biggest movers";
+"strengthMoversCaption" = "Bar length = its change · set count = its weight";
+"strengthShowAllExercises" = "Show all %d exercises";
+"showLess" = "Show less";
+"strengthInfo" = "Each exercise's best estimated 1RM in the last %d weeks against the %d before, averaged and weighted by how many sets you did. Cardio and bodyweight sets carry no 1RM and don't count.";

--- a/LOGIT/Core/Environment/es.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/es.lproj/Localizable.strings
@@ -1022,13 +1022,10 @@
 
 
 /* Progress tab — overall progress trend */
-"strengthProgress" = "Progreso de fuerza";
 "trendingUp" = "Tendencia al alza";
 "trendingSteady" = "Estable";
 "trendingDown" = "Tendencia a la baja";
 "byMuscleGroup" = "Por grupo muscular";
-"strengthProgressBasis" = "1RM estimado · últimas 8 semanas vs. las 8 anteriores";
-"strengthProgressEmpty" = "Sigue registrando entrenamientos para ver tu tendencia de fuerza.";
 
 // Progress highlights (carousel cards)
 "firstTimePast" = "Primera vez por encima de %@";
@@ -1131,3 +1128,18 @@
 "progressMetricRepetitionsDescription" = "Más repeticiones en una sola serie";
 "progressMetricDurationDescription" = "Mayor duración en una sola serie";
 "progressMetricDistanceDescription" = "Mayor distancia en una sola serie";
+
+// Strength (Progress tab tile + detail)
+"strength" = "Fuerza";
+"strengthBasis" = "1RM estimado · últimas 8 semanas";
+"strengthEmpty" = "Sigue registrando entrenamientos para ver tu tendencia de fuerza.";
+"strengthWindowCaption" = "vs. las %d semanas anteriores";
+"nWeeks" = "%d semanas";
+"nSets" = "%d series";
+"allExercises" = "Todos los ejercicios";
+"strengthTapGroup" = "Toca un grupo para enfocarlo";
+"strengthBiggestMovers" = "Mayores cambios";
+"strengthMoversCaption" = "Longitud = su cambio · series = su peso";
+"strengthShowAllExercises" = "Ver los %d ejercicios";
+"showLess" = "Ver menos";
+"strengthInfo" = "El mejor 1RM estimado de cada ejercicio en las últimas %d semanas frente a las %d anteriores, promediado y ponderado por el número de series. Las series de cardio y peso corporal no tienen 1RM y no cuentan.";

--- a/LOGIT/Core/Environment/fr.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/fr.lproj/Localizable.strings
@@ -1022,13 +1022,10 @@
 
 
 /* Progress tab — overall progress trend */
-"strengthProgress" = "Progression en force";
 "trendingUp" = "En hausse";
 "trendingSteady" = "Stable";
 "trendingDown" = "En baisse";
 "byMuscleGroup" = "Par groupe musculaire";
-"strengthProgressBasis" = "1RM estimé · 8 dernières semaines vs les 8 précédentes";
-"strengthProgressEmpty" = "Continuez à enregistrer des séances pour voir votre tendance de force.";
 
 // Progress highlights (carousel cards)
 "firstTimePast" = "Première fois au-dessus de %@";
@@ -1131,3 +1128,18 @@
 "progressMetricRepetitionsDescription" = "Le plus de répétitions en une série";
 "progressMetricDurationDescription" = "La plus longue durée en une série";
 "progressMetricDistanceDescription" = "La plus grande distance en une série";
+
+// Strength (Progress tab tile + detail)
+"strength" = "Force";
+"strengthBasis" = "1RM estimé · 8 dernières semaines";
+"strengthEmpty" = "Continuez à enregistrer des séances pour voir votre tendance de force.";
+"strengthWindowCaption" = "vs les %d semaines précédentes";
+"nWeeks" = "%d semaines";
+"nSets" = "%d séries";
+"allExercises" = "Tous les exercices";
+"strengthTapGroup" = "Touchez un groupe pour l'isoler";
+"strengthBiggestMovers" = "Plus grands changements";
+"strengthMoversCaption" = "Longueur = son évolution · séries = son poids";
+"strengthShowAllExercises" = "Voir les %d exercices";
+"showLess" = "Voir moins";
+"strengthInfo" = "Le meilleur 1RM estimé de chaque exercice sur les %d dernières semaines par rapport aux %d précédentes, moyenné et pondéré par le nombre de séries. Les séries de cardio et au poids du corps n'ont pas de 1RM et ne comptent pas.";

--- a/LOGIT/Core/Environment/it.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/it.lproj/Localizable.strings
@@ -1022,13 +1022,10 @@
 
 
 /* Progress tab — overall progress trend */
-"strengthProgress" = "Progresso di forza";
 "trendingUp" = "In crescita";
 "trendingSteady" = "Stabile";
 "trendingDown" = "In calo";
 "byMuscleGroup" = "Per gruppo muscolare";
-"strengthProgressBasis" = "1RM stimato · ultime 8 settimane vs le 8 precedenti";
-"strengthProgressEmpty" = "Continua a registrare allenamenti per vedere il tuo andamento di forza.";
 
 // Progress highlights (carousel cards)
 "firstTimePast" = "Prima volta oltre %@";
@@ -1131,3 +1128,18 @@
 "progressMetricRepetitionsDescription" = "Più ripetizioni in una singola serie";
 "progressMetricDurationDescription" = "Durata più lunga in una singola serie";
 "progressMetricDistanceDescription" = "Distanza più lunga in una singola serie";
+
+// Strength (Progress tab tile + detail)
+"strength" = "Forza";
+"strengthBasis" = "1RM stimato · ultime 8 settimane";
+"strengthEmpty" = "Continua a registrare allenamenti per vedere il tuo andamento di forza.";
+"strengthWindowCaption" = "vs le %d settimane precedenti";
+"nWeeks" = "%d settimane";
+"nSets" = "%d serie";
+"allExercises" = "Tutti gli esercizi";
+"strengthTapGroup" = "Tocca un gruppo per isolarlo";
+"strengthBiggestMovers" = "Cambiamenti maggiori";
+"strengthMoversCaption" = "Lunghezza = la sua variazione · serie = il suo peso";
+"strengthShowAllExercises" = "Mostra tutti i %d esercizi";
+"showLess" = "Mostra meno";
+"strengthInfo" = "Il miglior 1RM stimato di ogni esercizio nelle ultime %d settimane rispetto alle %d precedenti, mediato e pesato in base al numero di serie. Le serie di cardio e a corpo libero non hanno 1RM e non contano.";

--- a/LOGIT/Core/Environment/ja.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/ja.lproj/Localizable.strings
@@ -1022,13 +1022,10 @@
 
 
 /* Progress tab — overall progress trend */
-"strengthProgress" = "筋力の進捗";
 "trendingUp" = "上昇傾向";
 "trendingSteady" = "横ばい";
 "trendingDown" = "下降傾向";
 "byMuscleGroup" = "筋群別";
-"strengthProgressBasis" = "推定1RM · 直近8週間 vs その前の8週間";
-"strengthProgressEmpty" = "ワークアウトを記録すると筋力の傾向が表示されます。";
 
 // Progress highlights (carousel cards)
 "firstTimePast" = "初めて%@を突破";
@@ -1131,3 +1128,18 @@
 "progressMetricRepetitionsDescription" = "1セットの最多レップ数";
 "progressMetricDurationDescription" = "1セットの最長時間";
 "progressMetricDistanceDescription" = "1セットの最長距離";
+
+// Strength (Progress tab tile + detail)
+"strength" = "筋力";
+"strengthBasis" = "推定1RM · 直近8週間";
+"strengthEmpty" = "ワークアウトを記録すると筋力の傾向が表示されます。";
+"strengthWindowCaption" = "その前の%d週間との比較";
+"nWeeks" = "%d週間";
+"nSets" = "%dセット";
+"allExercises" = "すべてのエクササイズ";
+"strengthTapGroup" = "グループをタップして絞り込み";
+"strengthBiggestMovers" = "変化が大きい種目";
+"strengthMoversCaption" = "バーの長さ = 変化 · セット数 = 重み";
+"strengthShowAllExercises" = "%d種目すべて表示";
+"showLess" = "表示を減らす";
+"strengthInfo" = "各エクササイズの直近%d週間の推定1RM最高値を、その前の%d週間と比較し、セット数で重み付けして平均した値です。カーディオと自重のセットは1RMがないため含まれません。";

--- a/LOGIT/Core/Environment/ko.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/ko.lproj/Localizable.strings
@@ -1022,13 +1022,10 @@
 
 
 /* Progress tab — overall progress trend */
-"strengthProgress" = "근력 진행 상황";
 "trendingUp" = "상승세";
 "trendingSteady" = "유지";
 "trendingDown" = "하락세";
 "byMuscleGroup" = "근육군별";
-"strengthProgressBasis" = "추정 1RM · 최근 8주 vs 이전 8주";
-"strengthProgressEmpty" = "운동을 계속 기록하면 근력 추세를 볼 수 있습니다.";
 
 // Progress highlights (carousel cards)
 "firstTimePast" = "처음으로 %@ 돌파";
@@ -1131,3 +1128,18 @@
 "progressMetricRepetitionsDescription" = "한 세트 최다 횟수";
 "progressMetricDurationDescription" = "한 세트 최장 시간";
 "progressMetricDistanceDescription" = "한 세트 최장 거리";
+
+// Strength (Progress tab tile + detail)
+"strength" = "근력";
+"strengthBasis" = "추정 1RM · 최근 8주";
+"strengthEmpty" = "운동을 계속 기록하면 근력 추세를 볼 수 있습니다.";
+"strengthWindowCaption" = "이전 %d주 대비";
+"nWeeks" = "%d주";
+"nSets" = "%d세트";
+"allExercises" = "모든 운동";
+"strengthTapGroup" = "그룹을 탭해 집중해서 보기";
+"strengthBiggestMovers" = "변화가 큰 운동";
+"strengthMoversCaption" = "막대 길이 = 변화 · 세트 수 = 가중치";
+"strengthShowAllExercises" = "%d개 운동 모두 보기";
+"showLess" = "간단히 보기";
+"strengthInfo" = "각 운동의 최근 %d주 최고 추정 1RM을 이전 %d주와 비교해 세트 수로 가중 평균한 값입니다. 유산소와 맨몸 세트는 1RM이 없어 포함되지 않습니다.";

--- a/LOGIT/Core/Environment/pt-BR.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/pt-BR.lproj/Localizable.strings
@@ -1022,13 +1022,10 @@
 
 
 /* Progress tab — overall progress trend */
-"strengthProgress" = "Progresso de força";
 "trendingUp" = "Em alta";
 "trendingSteady" = "Estável";
 "trendingDown" = "Em queda";
 "byMuscleGroup" = "Por grupo muscular";
-"strengthProgressBasis" = "1RM estimado · últimas 8 semanas vs. as 8 anteriores";
-"strengthProgressEmpty" = "Continue registrando treinos para ver sua tendência de força.";
 
 // Progress highlights (carousel cards)
 "firstTimePast" = "Primeira vez acima de %@";
@@ -1131,3 +1128,18 @@
 "progressMetricRepetitionsDescription" = "Mais repetições em uma única série";
 "progressMetricDurationDescription" = "Maior duração em uma única série";
 "progressMetricDistanceDescription" = "Maior distância em uma única série";
+
+// Strength (Progress tab tile + detail)
+"strength" = "Força";
+"strengthBasis" = "1RM estimado · últimas 8 semanas";
+"strengthEmpty" = "Continue registrando treinos para ver sua tendência de força.";
+"strengthWindowCaption" = "vs. as %d semanas anteriores";
+"nWeeks" = "%d semanas";
+"nSets" = "%d séries";
+"allExercises" = "Todos os exercícios";
+"strengthTapGroup" = "Toque em um grupo para focar";
+"strengthBiggestMovers" = "Maiores mudanças";
+"strengthMoversCaption" = "Comprimento = sua mudança · séries = seu peso";
+"strengthShowAllExercises" = "Ver todos os %d exercícios";
+"showLess" = "Ver menos";
+"strengthInfo" = "O melhor 1RM estimado de cada exercício nas últimas %d semanas em relação às %d anteriores, com média ponderada pelo número de séries. Séries de cardio e peso corporal não têm 1RM e não contam.";

--- a/LOGIT/Features/Home/HomeNavigationCoordinator.swift
+++ b/LOGIT/Features/Home/HomeNavigationCoordinator.swift
@@ -34,6 +34,7 @@ enum HomeNavigationDestinationType: Hashable, Identifiable, Equatable {
          muscleGroupDetail(MuscleGroup, StatPeriod),
          muscleTargetSplit,
          progressHighlights,
+         strength,
          // The optional period pins the stat screen to a window (highlight cards open the chart
          // they compare over); nil keeps the Summary's currently selected period.
          summaryStat(WorkoutStatMetric, StatPeriod?),

--- a/LOGIT/Features/Home/HomeScreen.swift
+++ b/LOGIT/Features/Home/HomeScreen.swift
@@ -261,6 +261,8 @@ struct HomeScreen: View {
                         )
                     case .progressHighlights:
                         ProgressHighlightsScreen(workouts: workouts)
+                    case .strength:
+                        StrengthScreen(workouts: workouts)
                     case let .summaryRecords(period):
                         SummaryRecordsScreen(
                             workouts: summaryViewModel.filtered(workouts, to: period),

--- a/LOGIT/Features/Home/StrengthProgress.swift
+++ b/LOGIT/Features/Home/StrengthProgress.swift
@@ -1,0 +1,190 @@
+//
+//  StrengthProgress.swift
+//  LOGIT
+//
+//  Created by Lukas Kaibel on 27.07.26.
+//
+
+import CoreData
+import SwiftUI
+
+// MARK: - Window
+
+/// The comparison window behind the Strength figure: the last N weeks against the N before them.
+/// Rolling, never a calendar month — a partial month would make the number lie for three weeks out
+/// of four. The tile always uses `.default`; the detail screen lets you widen or narrow it, which is
+/// a real change to what's measured rather than a chart range.
+enum StrengthWindow: Int, CaseIterable, Identifiable {
+    case fourWeeks = 4
+    case eightWeeks = 8
+    case twelveWeeks = 12
+
+    static let `default` = StrengthWindow.eightWeeks
+
+    var id: Int { rawValue }
+
+    /// "8 weeks" — the picker segment.
+    var title: String {
+        String(format: NSLocalizedString("nWeeks", comment: ""), rawValue)
+    }
+
+    /// "vs the 8 weeks before" — the caption under a value.
+    var comparisonCaption: String {
+        String(format: NSLocalizedString("strengthWindowCaption", comment: ""), rawValue)
+    }
+}
+
+// MARK: - Model
+
+/// The whole-training strength trend: every trained exercise's percent change in estimated 1RM over
+/// the recent window vs the equally long window before it, weighted by how many sets it took to get
+/// there. Cardio and bodyweight sets carry no e1RM and drop out; an exercise needs a usable best in
+/// BOTH windows to count — with nothing to compare against there is no trend.
+///
+/// The per-exercise changes are kept rather than averaged away, because they are what the headline
+/// number *is*: the detail screen shows the weighted mean pulled back apart.
+struct StrengthProgress {
+
+    /// One exercise's contribution to the average.
+    struct ExerciseChange: Identifiable {
+        let exercise: Exercise
+        let muscleGroup: MuscleGroup
+        /// Percent change of the recent best over the prior best, clamped (see `maxAbsPercentChange`).
+        let percentChange: Double
+        /// Sets recorded in the recent window — this change's weight in the mean.
+        let setCount: Int
+        var id: NSManagedObjectID { exercise.objectID }
+    }
+
+    struct GroupProgress: Identifiable {
+        let muscleGroup: MuscleGroup
+        let percentChange: Double
+        /// Exercises behind this group's figure — drives the grid's "no data" state.
+        let exerciseCount: Int
+        var id: String { muscleGroup.rawValue }
+    }
+
+    /// Every qualifying exercise, unordered.
+    let changes: [ExerciseChange]
+    let window: StrengthWindow
+
+    static let empty = StrengthProgress(changes: [], window: .default)
+
+    var hasData: Bool { !changes.isEmpty }
+
+    /// Outlier guard so one freak set can't swing the headline.
+    private static let maxAbsPercentChange = 50.0
+
+    // MARK: Derived
+
+    /// Set-weighted mean percent change over a scope — the whole training when `group` is nil.
+    /// Nil when the scope holds nothing to compare.
+    func percentChange(in group: MuscleGroup? = nil) -> Double? {
+        let scoped = group.map { g in changes.filter { $0.muscleGroup == g } } ?? changes
+        guard !scoped.isEmpty else { return nil }
+        let totalWeight = scoped.reduce(0.0) { $0 + Double(max($1.setCount, 1)) }
+        guard totalWeight > 0 else { return nil }
+        return scoped.reduce(0.0) { $0 + $1.percentChange * Double(max($1.setCount, 1)) } / totalWeight
+    }
+
+    var overallPercentChange: Double? { percentChange() }
+
+    /// Every muscle group that has data, strongest gain first.
+    var groups: [GroupProgress] {
+        Dictionary(grouping: changes, by: \.muscleGroup)
+            .compactMap { group, scoped -> GroupProgress? in
+                guard let percent = percentChange(in: group) else { return nil }
+                return GroupProgress(muscleGroup: group, percentChange: percent, exerciseCount: scoped.count)
+            }
+            .sorted { $0.percentChange > $1.percentChange }
+    }
+
+    /// A scope's exercises sorted by how far they moved — by *magnitude*, so a big decline ranks
+    /// high instead of hiding at the bottom. Ties break on the heavier (more sets) exercise.
+    func exerciseChanges(in group: MuscleGroup? = nil) -> [ExerciseChange] {
+        let scoped = group.map { g in changes.filter { $0.muscleGroup == g } } ?? changes
+        return scoped.sorted {
+            abs($0.percentChange) == abs($1.percentChange)
+                ? $0.setCount > $1.setCount
+                : abs($0.percentChange) > abs($1.percentChange)
+        }
+    }
+
+    // MARK: Computation
+
+    static func compute(
+        workouts: [Workout],
+        window: StrengthWindow = .default,
+        reference: Date = .now
+    ) -> StrengthProgress {
+        let calendar = Calendar.current
+        guard
+            let recentStart = calendar.date(byAdding: .weekOfYear, value: -window.rawValue, to: reference),
+            let priorStart = calendar.date(byAdding: .weekOfYear, value: -2 * window.rawValue, to: reference)
+        else { return StrengthProgress(changes: [], window: window) }
+
+        // Unique exercises trained across the fetched workouts.
+        var exercises: [Exercise] = []
+        var seen = Set<NSManagedObjectID>()
+        for workout in workouts where !workout.isEmpty {
+            for exercise in workout.exercises where !seen.contains(exercise.objectID) {
+                seen.insert(exercise.objectID)
+                exercises.append(exercise)
+            }
+        }
+
+        var changes: [ExerciseChange] = []
+        for exercise in exercises {
+            guard let group = exercise.muscleGroup else { continue }
+            var recentBest = 0
+            var priorBest = 0
+            var recentSetCount = 0
+            for set in exercise.sets {
+                guard let date = set.workout?.date else { continue }
+                let e1rm = set.estimatedOneRepMax(for: exercise)
+                guard e1rm > 0 else { continue }
+                if date >= recentStart, date <= reference {
+                    recentBest = max(recentBest, e1rm)
+                    recentSetCount += 1
+                } else if date >= priorStart, date < recentStart {
+                    priorBest = max(priorBest, e1rm)
+                }
+            }
+            guard recentBest > 0, priorBest > 0 else { continue }
+            let raw = (Double(recentBest) - Double(priorBest)) / Double(priorBest) * 100
+            changes.append(
+                ExerciseChange(
+                    exercise: exercise,
+                    muscleGroup: group,
+                    percentChange: min(max(raw, -maxAbsPercentChange), maxAbsPercentChange),
+                    setCount: recentSetCount
+                )
+            )
+        }
+        return StrengthProgress(changes: changes, window: window)
+    }
+}
+
+// MARK: - Trend direction
+
+/// Below this magnitude (in %) a trend reads as flat — a deadband so the arrow doesn't twitch.
+let STRENGTH_TREND_DEADBAND = 1.0
+
+func strengthTrendIsUp(_ percent: Double) -> Bool { percent >= STRENGTH_TREND_DEADBAND }
+func strengthTrendIsDown(_ percent: Double) -> Bool { percent <= -STRENGTH_TREND_DEADBAND }
+
+/// Accent for a gain; neutral grey for flat or a decline — progress green is the only colour that
+/// ever means "good", and a dip is never coloured as a warning.
+func strengthTrendColor(_ percent: Double) -> Color {
+    strengthTrendIsUp(percent) ? .accentColor : .secondaryLabel
+}
+
+/// The arrow for a trend. Unlike `TrendIndicatorView`, a flat result keeps an arrow here
+/// (`arrow.right`) rather than dropping it: on the one surface whose entire subject is the trend,
+/// an empty icon slot reads as missing rather than as "steady", and a horizontal arrow can't be
+/// mistaken for a decline.
+func strengthTrendSymbol(_ percent: Double) -> String {
+    if strengthTrendIsUp(percent) { return "arrow.up" }
+    if strengthTrendIsDown(percent) { return "arrow.down" }
+    return "arrow.right"
+}

--- a/LOGIT/Features/Home/StrengthProgress.swift
+++ b/LOGIT/Features/Home/StrengthProgress.swift
@@ -67,6 +67,9 @@ struct StrengthProgress {
     /// Every qualifying exercise, unordered.
     let changes: [ExerciseChange]
     let window: StrengthWindow
+    /// How much of the comparison span (two windows) the logged history covers, 0…1. Only used by
+    /// the empty state's ring, so it reads as "still filling up" rather than as nothing at all.
+    var historyFraction: Double = 0
 
     static let empty = StrengthProgress(changes: [], window: .default)
 
@@ -133,6 +136,14 @@ struct StrengthProgress {
             }
         }
 
+        // How far the history reaches into the span being compared — the empty state's progress.
+        let earliest = workouts.filter { !$0.isEmpty }.compactMap(\.date).min()
+        let spanDays = Double(2 * window.rawValue * 7)
+        let historyFraction: Double = earliest.map { first in
+            let days = reference.timeIntervalSince(first) / 86_400
+            return min(max(days / spanDays, 0), 1)
+        } ?? 0
+
         var changes: [ExerciseChange] = []
         for exercise in exercises {
             guard let group = exercise.muscleGroup else { continue }
@@ -161,7 +172,7 @@ struct StrengthProgress {
                 )
             )
         }
-        return StrengthProgress(changes: changes, window: window)
+        return StrengthProgress(changes: changes, window: window, historyFraction: historyFraction)
     }
 }
 

--- a/LOGIT/Features/Home/StrengthScreen.swift
+++ b/LOGIT/Features/Home/StrengthScreen.swift
@@ -1,0 +1,323 @@
+//
+//  StrengthScreen.swift
+//  LOGIT
+//
+//  Created by Lukas Kaibel on 27.07.26.
+//
+
+import SwiftUI
+
+// MARK: - Screen
+
+/// The detail behind the Strength tile. Deliberately has no time axis: the headline is a set-weighted
+/// mean of every exercise's e1RM change, so the honest detail of it is its *components* — which
+/// exercises moved, how far, and how heavily each counted — not a history of the percentage. (A chart
+/// of a rate is a second-order quantity, and consecutive rolling windows overlap so heavily that the
+/// line barely moves.)
+///
+/// Three sections: the hero for the selected scope, a muscle-group grid that *is* the scope selector,
+/// and the composition — every exercise on one shared zero axis.
+struct StrengthScreen: View {
+    let workouts: [Workout]
+
+    /// Nil is the whole training; a group narrows the hero, and the composition, to it.
+    @State private var selectedGroup: MuscleGroup?
+    @State private var window: StrengthWindow = .default
+    @State private var progress: StrengthProgress = .empty
+    @State private var showsAllExercises = false
+
+    /// Movers shown before the list collapses. Below about five the shortest bar is a stub and the
+    /// ranking stops reading, so the cap sits where the shape is still legible rather than at a
+    /// rounder number.
+    private static let collapsedExerciseCount = 5
+
+    init(workouts: [Workout], initialGroup: MuscleGroup? = nil) {
+        self.workouts = workouts
+        _selectedGroup = State(initialValue: initialGroup)
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: SECTION_SPACING) {
+                windowPicker
+                hero
+                if progress.hasData {
+                    groupGrid
+                    composition
+                }
+                footnote
+            }
+            .padding(.horizontal)
+            .padding(.top)
+            .padding(.bottom, SCROLLVIEW_BOTTOM_PADDING)
+        }
+        .isBlockedWithoutPro()
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .principal) {
+                Text(NSLocalizedString("strength", comment: ""))
+                    .font(.headline)
+            }
+        }
+        .task(id: "\(window.rawValue)-\(workouts.count)") {
+            progress = StrengthProgress.compute(workouts: workouts, window: window)
+            // A group that lost its data under a narrower window can't stay selected.
+            if let selectedGroup, progress.percentChange(in: selectedGroup) == nil {
+                self.selectedGroup = nil
+            }
+        }
+    }
+
+    // MARK: Window
+
+    private var windowPicker: some View {
+        Picker(NSLocalizedString("strength", comment: ""), selection: $window) {
+            ForEach(StrengthWindow.allCases) { option in
+                Text(option.title).tag(option)
+            }
+        }
+        .pickerStyle(.segmented)
+        .labelsHidden()
+    }
+
+    // MARK: Hero
+
+    private var hero: some View {
+        VStack(spacing: 10) {
+            if let percent = progress.percentChange(in: selectedGroup) {
+                StrengthHeroPill(percentChange: percent)
+                Text("\(scopeName) · \(window.comparisonCaption)")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+            } else {
+                Text(NSLocalizedString("strengthEmpty", comment: ""))
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.vertical, 20)
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .animation(.snappy, value: selectedGroup)
+    }
+
+    private var scopeName: String {
+        selectedGroup?.description ?? NSLocalizedString("allExercises", comment: "")
+    }
+
+    // MARK: Group grid
+
+    /// The scope selector: "All" plus every muscle group. Groups without data stay in the grid,
+    /// dimmed and disabled, so the grid keeps a stable shape instead of reshuffling as the window
+    /// changes.
+    private var groupGrid: some View {
+        VStack(alignment: .leading, spacing: SECTION_HEADER_SPACING) {
+            Text(NSLocalizedString("strengthTapGroup", comment: ""))
+                .font(.caption.weight(.bold))
+                .textCase(.uppercase)
+                .foregroundStyle(.secondary)
+            LazyVGrid(
+                columns: [GridItem(.flexible(), spacing: 8), GridItem(.flexible(), spacing: 8)],
+                spacing: 8
+            ) {
+                cell(for: nil, percent: progress.overallPercentChange)
+                ForEach(MuscleGroup.allCases, id: \.self) { group in
+                    cell(for: group, percent: progress.percentChange(in: group))
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func cell(for group: MuscleGroup?, percent: Double?) -> some View {
+        let color = group?.color ?? .accentColor
+        let isSelected = selectedGroup == group
+        Button {
+            selectedGroup = group
+            showsAllExercises = false
+        } label: {
+            HStack(spacing: 6) {
+                Text(group?.description ?? NSLocalizedString("all", comment: ""))
+                    .font(.system(.subheadline, design: .rounded, weight: .bold))
+                    .foregroundStyle(percent == nil ? Color.secondaryLabel : color)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.75)
+                Spacer(minLength: 2)
+                if let percent {
+                    TrendIndicatorView(percentChange: percent, positiveColor: color)
+                } else {
+                    Text(NSLocalizedString("noData", comment: ""))
+                        .font(.caption2.weight(.semibold))
+                        .foregroundStyle(.tertiary)
+                }
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: 18, style: .continuous)
+                    .fill(isSelected ? color.opacity(0.15) : Color.secondaryBackground)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 18, style: .continuous)
+                    .stroke(isSelected ? color.opacity(0.45) : .clear, lineWidth: 1)
+            )
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(TileButtonStyle())
+        .disabled(percent == nil)
+        .opacity(percent == nil ? 0.45 : 1)
+    }
+
+    // MARK: Composition
+
+    private var composition: some View {
+        let all = progress.exerciseChanges(in: selectedGroup)
+        let shown = showsAllExercises ? all : Array(all.prefix(Self.collapsedExerciseCount))
+        return VStack(alignment: .leading, spacing: SECTION_HEADER_SPACING) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(NSLocalizedString("strengthBiggestMovers", comment: ""))
+                    .font(.caption.weight(.bold))
+                    .textCase(.uppercase)
+                    .foregroundStyle(.secondary)
+                Text(NSLocalizedString("strengthMoversCaption", comment: ""))
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            }
+            StrengthCompositionChart(changes: shown, scale: all)
+            if all.count > Self.collapsedExerciseCount {
+                Button {
+                    withAnimation(.snappy) { showsAllExercises.toggle() }
+                } label: {
+                    HStack {
+                        Text(
+                            showsAllExercises
+                                ? NSLocalizedString("showLess", comment: "")
+                                : String(format: NSLocalizedString("strengthShowAllExercises", comment: ""), all.count)
+                        )
+                        .foregroundStyle(Color.label)
+                        Spacer()
+                        Image(systemName: showsAllExercises ? "chevron.up" : "chevron.down")
+                            .foregroundStyle(Color.secondaryLabel)
+                            .font(.footnote.weight(.bold))
+                    }
+                    .padding(.vertical, 12)
+                    .padding(.horizontal, 14)
+                    .frame(maxWidth: .infinity)
+                    .secondaryTileStyle(insetShadow: true)
+                }
+                .buttonStyle(TileButtonStyle())
+            }
+        }
+    }
+
+    private var footnote: some View {
+        HStack(alignment: .top, spacing: 6) {
+            Image(systemName: "info.circle")
+            Text(String(format: NSLocalizedString("strengthInfo", comment: ""), window.rawValue, window.rawValue))
+        }
+        .font(.footnote)
+        .foregroundStyle(.secondary)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 4)
+    }
+}
+
+// MARK: - Composition chart
+
+/// Every exercise's change on **one shared zero axis** — the weighted mean pulled apart. The shared
+/// axis is the whole point: it is what lets the rows be compared to each other at a glance, and it is
+/// what a per-row centred tick (the muscle-balance chart's earlier, rejected shape) destroys.
+///
+/// Gains grow right of the axis in the muscle colour, declines grow left in neutral grey — never a
+/// warning colour. The axis sits wherever the deepest decline needs it, so both directions share one
+/// scale rather than each getting its own.
+struct StrengthCompositionChart: View {
+    let changes: [StrengthProgress.ExerciseChange]
+    /// The full (uncapped) set the axis is scaled against, so collapsing the list doesn't rescale
+    /// the bars underneath the user.
+    let scale: [StrengthProgress.ExerciseChange]
+
+    private let rowHeight: CGFloat = 34
+    private let barHeight: CGFloat = 14
+    private let nameWidth: CGFloat = 104
+    /// Room kept at the trailing edge for the value label that follows the longest bar.
+    private static let labelGutter: CGFloat = 46
+
+    /// Largest gain and largest decline in the scale set — one unit serves both sides.
+    private var extremes: (up: Double, down: Double) {
+        let up = scale.map(\.percentChange).filter { $0 > 0 }.max() ?? 0
+        let down = abs(scale.map(\.percentChange).filter { $0 < 0 }.min() ?? 0)
+        return (max(up, 0.001), down)
+    }
+
+    var body: some View {
+        VStack(spacing: 8) {
+            ForEach(changes) { change in
+                row(change)
+            }
+        }
+    }
+
+    private func row(_ change: StrengthProgress.ExerciseChange) -> some View {
+        HStack(spacing: 0) {
+            VStack(alignment: .trailing, spacing: 0) {
+                Text(change.exercise.displayName)
+                    .font(.footnote.weight(.semibold))
+                    .foregroundStyle(Color.label)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.8)
+                Text(String(format: NSLocalizedString("nSets", comment: ""), change.setCount))
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            }
+            .frame(width: nameWidth, alignment: .trailing)
+            .padding(.trailing, 12)
+
+            GeometryReader { geometry in
+                let width = geometry.size.width
+                let (up, down) = extremes
+                // The value label sits past the end of its bar, so the bars are scaled against the
+                // width *minus* a gutter wide enough to hold it. Without this the longest bar — the
+                // one that sets the scale — always pushes its own label off the edge.
+                let unit = max(width - Self.labelGutter, 1) / CGFloat(up + down)
+                let zeroX = CGFloat(down) * unit
+                let isGain = change.percentChange > 0
+                let length = max(CGFloat(abs(change.percentChange)) * unit, 2)
+                let color = isGain ? change.muscleGroup.color : Color.secondaryLabel
+
+                ZStack(alignment: .topLeading) {
+                    // The shared axis.
+                    Rectangle()
+                        .fill(Color.separator)
+                        .frame(width: 1, height: rowHeight)
+                        .offset(x: zeroX)
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(isGain ? AnyShapeStyle(color.gradient) : AnyShapeStyle(color.opacity(0.4)))
+                        .frame(width: length, height: barHeight)
+                        .offset(x: isGain ? zeroX : zeroX - length, y: (rowHeight - barHeight) / 2)
+                    // The value sits on the far side of the axis from its bar, so the two can never
+                    // collide however long the bar gets.
+                    Text(signedPercentText(change.percentChange))
+                        .font(.system(.caption2, design: .rounded, weight: .bold))
+                        .foregroundStyle(isGain ? color : Color.secondaryLabel)
+                        .monospacedDigit()
+                        .fixedSize()
+                        .offset(x: isGain ? zeroX + length + 6 : zeroX + 6, y: (rowHeight - 14) / 2)
+                }
+            }
+            .frame(height: rowHeight)
+        }
+        .frame(height: rowHeight)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(
+            "\(change.exercise.displayName), \(signedPercentText(change.percentChange)), "
+                + String(format: NSLocalizedString("nSets", comment: ""), change.setCount)
+        )
+    }
+
+    private func signedPercentText(_ percent: Double) -> String {
+        String(format: "%+.0f%%", percent)
+    }
+}

--- a/LOGIT/Features/Home/StrengthScreen.swift
+++ b/LOGIT/Features/Home/StrengthScreen.swift
@@ -91,11 +91,15 @@ struct StrengthScreen: View {
                     .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)
             } else {
-                Text(NSLocalizedString("strengthEmpty", comment: ""))
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
-                    .multilineTextAlignment(.center)
-                    .padding(.vertical, 20)
+                // Same gray ring the tile and the core-stat tiles wear while they wait for data.
+                TrendPlaceholder(
+                    progress: progress.historyFraction,
+                    text: NSLocalizedString("strengthEmpty", comment: ""),
+                    systemImage: "chart.line.uptrend.xyaxis",
+                    alignment: .leading,
+                    diameter: 40
+                )
+                .padding(.vertical, 16)
             }
         }
         .frame(maxWidth: .infinity)

--- a/LOGIT/Features/Home/StrengthTile.swift
+++ b/LOGIT/Features/Home/StrengthTile.swift
@@ -129,17 +129,17 @@ struct StrengthTile: View {
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 
+    /// Before there's a trend, the tile wears the same gray ring the core-stat tiles use while their
+    /// first period fills — the ring tracking how far the history reaches into the span being
+    /// compared, so it creeps forward with every workout instead of sitting at nothing.
     private var emptyState: some View {
-        HStack(spacing: 12) {
-            Image(systemName: "chart.line.uptrend.xyaxis")
-                .font(.title3)
-                .foregroundStyle(.secondary)
-            Text(NSLocalizedString("strengthEmpty", comment: ""))
-                .font(.subheadline)
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
-            Spacer(minLength: 0)
-        }
+        TrendPlaceholder(
+            progress: progress.historyFraction,
+            text: NSLocalizedString("strengthEmpty", comment: ""),
+            systemImage: "chart.line.uptrend.xyaxis",
+            alignment: .leading,
+            diameter: 34
+        )
     }
 }
 

--- a/LOGIT/Features/Home/StrengthTile.swift
+++ b/LOGIT/Features/Home/StrengthTile.swift
@@ -1,0 +1,154 @@
+//
+//  StrengthTile.swift
+//  LOGIT
+//
+//  Created by Lukas Kaibel on 27.07.26.
+//
+
+import SwiftUI
+
+// MARK: - Hero
+
+/// The Strength headline: the trend arrow and its percent as one scaled-up `ProgressIndicatorPill`.
+///
+/// The pill is deliberate rather than decorative. `arrow.up` / `arrow.down` is the app's single
+/// progress glyph and it lives inside this pill everywhere else — so the one surface whose entire
+/// subject is that trend gets the same component, just at headline size. It also resolves a rule
+/// conflict: values elsewhere stay neutral and the *pill* carries the accent, so a bare tinted
+/// percent would break the convention while the same percent inside a pill is exactly where tinting
+/// belongs. For a metric that is a ratio rather than a quantity, the pill simply *is* the value.
+struct StrengthHeroPill: View {
+    let percentChange: Double
+    /// Scales the whole pill: the tile's headline vs the detail screen's larger one.
+    var isCompact: Bool = false
+
+    var body: some View {
+        let color = strengthTrendColor(percentChange)
+        ProgressIndicatorPill(
+            symbol: strengthTrendSymbol(percentChange),
+            color: color,
+            size: .hero,
+            symbolFont: .system(size: isCompact ? 22 : 26, weight: .bold)
+        ) {
+            Text(percentText)
+                .font(.system(size: isCompact ? 30 : 35, weight: .bold, design: .rounded))
+                .monospacedDigit()
+        }
+        // The pill never compresses: the movers beside it give way first.
+        .fixedSize()
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(accessibilityLabel)
+    }
+
+    /// One decimal, and no sign — the arrow carries the direction, exactly as the small trend pills
+    /// do. A headline earns the decimal the compact pills round away.
+    private var percentText: String {
+        String(format: "%.1f%%", abs(percentChange))
+    }
+
+    private var accessibilityLabel: Text {
+        let percent = (abs(percentChange) / 100).formatted(.percent.precision(.fractionLength(1)))
+        if strengthTrendIsUp(percentChange) {
+            return Text(String(format: NSLocalizedString("trendUp", comment: ""), percent))
+        }
+        if strengthTrendIsDown(percentChange) {
+            return Text(String(format: NSLocalizedString("trendDown", comment: ""), percent))
+        }
+        return Text(NSLocalizedString("trendFlat", comment: ""))
+    }
+}
+
+// MARK: - Tile
+
+/// The Progress tab's headline tile: the hero pill states the whole-training trend, and the movers
+/// beside it name the muscle groups carrying it — so the tile answers "how much" and "where from"
+/// without a chart. Taps into `StrengthScreen`, which pulls the same weighted mean fully apart.
+///
+/// There is deliberately no sparkline: the metric is a percent change, and a chart of a rate over
+/// time is both hard to read and nearly static (consecutive windows overlap almost entirely).
+struct StrengthTile: View {
+    let progress: StrengthProgress
+    /// How many muscle groups the tile names beside the hero.
+    var maxMovers: Int = 3
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            header
+            if let overall = progress.overallPercentChange {
+                HStack(alignment: .center, spacing: 16) {
+                    StrengthHeroPill(percentChange: overall, isCompact: true)
+                    movers
+                }
+                .padding(.top, 13)
+            } else {
+                emptyState
+                    .padding(.top, 12)
+            }
+        }
+        .padding(CELL_PADDING)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .tileStyle()
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            HStack(spacing: 8) {
+                Text(NSLocalizedString("strength", comment: ""))
+                    .tileHeaderStyle()
+                Spacer(minLength: 8)
+                NavigationChevron()
+                    .foregroundStyle(.secondary)
+            }
+            Text(NSLocalizedString("strengthBasis", comment: ""))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .minimumScaleFactor(0.8)
+        }
+    }
+
+    /// The groups carrying the number, strongest first. Sorted by change rather than filtered to
+    /// gains: if the top three are declines, that is the honest read and the pills grey themselves.
+    private var movers: some View {
+        VStack(alignment: .leading, spacing: 7) {
+            ForEach(progress.groups.prefix(maxMovers)) { group in
+                HStack(spacing: 8) {
+                    Text(group.muscleGroup.description)
+                        .font(.system(.subheadline, design: .rounded, weight: .bold))
+                        .foregroundStyle(group.muscleGroup.color)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.75)
+                    Spacer(minLength: 4)
+                    TrendIndicatorView(
+                        percentChange: group.percentChange,
+                        positiveColor: group.muscleGroup.color
+                    )
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var emptyState: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "chart.line.uptrend.xyaxis")
+                .font(.title3)
+                .foregroundStyle(.secondary)
+            Text(NSLocalizedString("strengthEmpty", comment: ""))
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            Spacer(minLength: 0)
+        }
+    }
+}
+
+struct StrengthTile_Previews: PreviewProvider {
+    static var previews: some View {
+        FetchRequestWrapper(Workout.self) { workouts in
+            StrengthTile(progress: StrengthProgress.compute(workouts: workouts))
+                .padding()
+        }
+        .previewEnvironmentObjects()
+    }
+}

--- a/LOGIT/Features/Home/SummaryProgressTab.swift
+++ b/LOGIT/Features/Home/SummaryProgressTab.swift
@@ -43,7 +43,7 @@ struct SummaryTabPicker: View {
 
 // MARK: - Progress tab
 
-/// The `Progress` tab body: the strength-trend tile leads as the tab's headline, the Highlights
+/// The `Progress` tab body: the Strength tile leads as the tab's headline, the Highlights
 /// carousel below — recent bests, milestones, and trends as swipeable cards (see
 /// `ProgressHighlights`). Computes both off the already-fetched `[Workout]` in a `.task` (no new
 /// Core Data fetches), the way the Summary's records tile does.
@@ -52,19 +52,25 @@ struct SummaryProgressTab: View {
 
     @EnvironmentObject private var database: Database
     @EnvironmentObject private var homeNavigationCoordinator: HomeNavigationCoordinator
-    @State private var overall: OverallProgress = .empty
+    @State private var strength: StrengthProgress = .empty
     @State private var highlights: [ProgressHighlight] = []
 
     var body: some View {
         VStack(spacing: 8) {
-            OverallProgressTile(progress: overall)
+            Button {
+                homeNavigationCoordinator.path.append(.strength)
+            } label: {
+                StrengthTile(progress: strength)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(TileButtonStyle())
             if !highlights.isEmpty {
                 highlightsSection
                     .padding(.top, 8)
             }
         }
         .task(id: workouts.count) {
-            overall = OverallProgress.compute(workouts: workouts)
+            strength = StrengthProgress.compute(workouts: workouts)
             highlights = ProgressHighlights.compute(workouts: workouts, database: database)
         }
     }
@@ -92,246 +98,3 @@ struct SummaryProgressTab: View {
         }
     }
 }
-
-// MARK: - Overall progress model
-
-/// The whole-training strength trend: each trained exercise's percent change in estimated 1RM over
-/// the recent block vs the equally long block before it, volume-weighted (by recent set count) into
-/// one overall figure plus a per-muscle-group breakdown. Cardio / bodyweight sets carry no e1RM and
-/// drop out; an exercise needs a usable best in BOTH blocks to count — with nothing to compare
-/// against there is no trend.
-struct OverallProgress {
-    struct GroupProgress: Identifiable {
-        let muscleGroup: MuscleGroup
-        let percentChange: Double
-        var id: String { muscleGroup.rawValue }
-    }
-
-    /// Volume-weighted mean percent change across all qualifying exercises, or nil when none qualify.
-    let overallPercentChange: Double?
-    /// Per-muscle-group weighted mean — groups with data only, sorted strongest gain first.
-    let groups: [GroupProgress]
-
-    var hasData: Bool { overallPercentChange != nil }
-
-    static let empty = OverallProgress(overallPercentChange: nil, groups: [])
-
-    /// Outlier guard so one freak set can't swing the headline.
-    private static let maxAbsPercentChange = 50.0
-
-    static func compute(workouts: [Workout], recentWeeks: Int = 8, reference: Date = .now) -> OverallProgress {
-        let calendar = Calendar.current
-        guard
-            let recentStart = calendar.date(byAdding: .weekOfYear, value: -recentWeeks, to: reference),
-            let priorStart = calendar.date(byAdding: .weekOfYear, value: -2 * recentWeeks, to: reference)
-        else { return .empty }
-
-        // Unique exercises trained across the fetched workouts.
-        var exercises: [Exercise] = []
-        var seen = Set<NSManagedObjectID>()
-        for workout in workouts where !workout.isEmpty {
-            for exercise in workout.exercises where !seen.contains(exercise.objectID) {
-                seen.insert(exercise.objectID)
-                exercises.append(exercise)
-            }
-        }
-
-        struct Change { let group: MuscleGroup; let percent: Double; let weight: Double }
-        var changes: [Change] = []
-
-        for exercise in exercises {
-            guard let group = exercise.muscleGroup else { continue }
-            var recentBest = 0
-            var priorBest = 0
-            var recentSetCount = 0
-            for set in exercise.sets {
-                guard let date = set.workout?.date else { continue }
-                let e1rm = set.estimatedOneRepMax(for: exercise)
-                guard e1rm > 0 else { continue }
-                if date >= recentStart, date <= reference {
-                    recentBest = max(recentBest, e1rm)
-                    recentSetCount += 1
-                } else if date >= priorStart, date < recentStart {
-                    priorBest = max(priorBest, e1rm)
-                }
-            }
-            guard recentBest > 0, priorBest > 0 else { continue }
-            let raw = (Double(recentBest) - Double(priorBest)) / Double(priorBest) * 100
-            let clamped = min(max(raw, -maxAbsPercentChange), maxAbsPercentChange)
-            changes.append(Change(group: group, percent: clamped, weight: Double(max(recentSetCount, 1))))
-        }
-
-        guard !changes.isEmpty else { return .empty }
-
-        let totalWeight = changes.reduce(0) { $0 + $1.weight }
-        let overall = changes.reduce(0) { $0 + $1.percent * $1.weight } / totalWeight
-
-        var byGroup: [MuscleGroup: (sum: Double, weight: Double)] = [:]
-        for change in changes {
-            let current = byGroup[change.group] ?? (0, 0)
-            byGroup[change.group] = (current.sum + change.percent * change.weight, current.weight + change.weight)
-        }
-        let groups = byGroup
-            .map { GroupProgress(muscleGroup: $0.key, percentChange: $0.value.sum / $0.value.weight) }
-            .sorted { $0.percentChange > $1.percentChange }
-
-        return OverallProgress(overallPercentChange: overall, groups: groups)
-    }
-}
-
-// MARK: - Trend arrow helpers
-
-/// Below this magnitude (in %) a trend reads as flat — a deadband so the arrow doesn't twitch.
-private let trendDeadband = 1.0
-
-private func trendIsUp(_ percent: Double) -> Bool { percent >= trendDeadband }
-private func trendIsDown(_ percent: Double) -> Bool { percent <= -trendDeadband }
-
-/// Accent for a gain; neutral grey for flat or a decline — progress green is the only colour that
-/// ever means "good", and a dip is never coloured as a warning.
-private func trendColor(_ percent: Double) -> Color {
-    trendIsUp(percent) ? .accentColor : .secondaryLabel
-}
-
-private func signedPercent(_ percent: Double, fractionDigits: Int) -> String {
-    String(format: "%+.\(fractionDigits)f%%", percent)
-}
-
-/// A strict up / down / steady arrow — the shared glyph for the hero and the per-muscle rows. No
-/// magnitude-scaled rotation: the direction alone is the signal (`arrow.up` up, `arrow.down` down,
-/// `arrow.right` for a flat trend holding steady), with the percent beside it carrying the size.
-private struct TrendArrow: View {
-    let percent: Double
-    let color: Color
-    let size: CGFloat
-
-    private var symbolName: String {
-        if trendIsUp(percent) { return "arrow.up" }
-        if trendIsDown(percent) { return "arrow.down" }
-        return "arrow.right"
-    }
-
-    var body: some View {
-        Image(systemName: symbolName)
-            .font(.system(size: size, weight: .bold))
-            .foregroundStyle(color)
-    }
-}
-
-// MARK: - Overall progress tile
-
-/// The Progress tab's headline tile: one continuous arrow for the whole-training trend, then a small
-/// per-muscle-group arrow in each group's colour. No detail screen yet, so no chevron.
-struct OverallProgressTile: View {
-    let progress: OverallProgress
-
-    private let columns = [GridItem(.flexible(), spacing: 16), GridItem(.flexible(), spacing: 16)]
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            TileHeader(NSLocalizedString("strengthProgress", comment: ""), showsChevron: false)
-                .padding([.top, .horizontal], CELL_PADDING)
-
-            if let overall = progress.overallPercentChange {
-                hero(overall)
-                    .padding(.horizontal, CELL_PADDING)
-                    .padding(.top, 12)
-
-                if !progress.groups.isEmpty {
-                    Divider()
-                        .padding(.horizontal, CELL_PADDING)
-                        .padding(.vertical, 12)
-                    muscleBreakdown
-                        .padding(.horizontal, CELL_PADDING)
-                        .padding(.bottom, CELL_PADDING)
-                } else {
-                    Spacer().frame(height: CELL_PADDING)
-                }
-            } else {
-                emptyState
-                    .padding(CELL_PADDING)
-            }
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .tileStyle()
-    }
-
-    private func hero(_ overall: Double) -> some View {
-        let color = trendColor(overall)
-        return HStack(spacing: 15) {
-            ZStack {
-                Circle().fill(color.opacity(0.13)).frame(width: 60, height: 60)
-                TrendArrow(percent: overall, color: color, size: 24)
-            }
-            VStack(alignment: .leading, spacing: 4) {
-                Text(statusText(overall))
-                    .font(.title3.weight(.bold))
-                    .foregroundStyle(color)
-                Text(signedPercent(overall, fractionDigits: 1))
-                    .font(.subheadline.weight(.semibold))
-                    .foregroundStyle(Color.label)
-                    .monospacedDigit()
-                Text(NSLocalizedString("strengthProgressBasis", comment: ""))
-                    .font(.caption2)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
-            Spacer(minLength: 0)
-        }
-    }
-
-    private var muscleBreakdown: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text(NSLocalizedString("byMuscleGroup", comment: ""))
-                .font(.caption2.weight(.bold))
-                .textCase(.uppercase)
-                .foregroundStyle(.secondary)
-            LazyVGrid(columns: columns, alignment: .leading, spacing: 12) {
-                ForEach(progress.groups) { group in
-                    muscleRow(group)
-                }
-            }
-        }
-    }
-
-    private func muscleRow(_ group: OverallProgress.GroupProgress) -> some View {
-        let color = group.muscleGroup.color
-        let dimmed = !trendIsUp(group.percentChange)
-        return HStack(spacing: 8) {
-            TrendArrow(percent: group.percentChange, color: color, size: 13)
-                .opacity(dimmed ? 0.6 : 1)
-                .frame(width: 18)
-            Text(group.muscleGroup.description)
-                .font(.subheadline)
-                .foregroundStyle(Color.label)
-                .lineLimit(1)
-            Spacer(minLength: 4)
-            Text(signedPercent(group.percentChange, fractionDigits: 0))
-                .font(.subheadline.weight(.bold))
-                .foregroundStyle(color.opacity(dimmed ? 0.6 : 1))
-                .monospacedDigit()
-        }
-    }
-
-    private var emptyState: some View {
-        HStack(spacing: 12) {
-            Image(systemName: "chart.line.uptrend.xyaxis")
-                .font(.title3)
-                .foregroundStyle(.secondary)
-            Text(NSLocalizedString("strengthProgressEmpty", comment: ""))
-                .font(.subheadline)
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
-            Spacer(minLength: 0)
-        }
-    }
-
-    private func statusText(_ percent: Double) -> String {
-        if trendIsUp(percent) { return NSLocalizedString("trendingUp", comment: "") }
-        if trendIsDown(percent) { return NSLocalizedString("trendingDown", comment: "") }
-        return NSLocalizedString("trendingSteady", comment: "")
-    }
-}
-
-// The old ProgressHighlightsTile (hero record + PersonalBestRow list) is superseded by the
-// Highlights carousel in ProgressHighlightCards.swift.

--- a/LOGIT/Features/Home/Tiles/SummaryStatTiles.swift
+++ b/LOGIT/Features/Home/Tiles/SummaryStatTiles.swift
@@ -52,7 +52,7 @@ struct SummaryStatTile: View {
                     // One lone bar (or none) isn't a trend — it just reads as a half-loaded tile. Until
                     // a second period has data, show a quiet "building your trend" hint instead; the real
                     // bars return on their own once there's something to compare.
-                    SummaryTrendPlaceholder(progress: trendProgress)
+                    TrendPlaceholder(progress: trendProgress, text: NSLocalizedString("buildingYourTrend", comment: ""))
                 } else {
                     // The highlighted "this week" bar always uses the accent, even for duration — it
                     // marks the current period, not a judgement, so it reads the same as the other tiles.
@@ -89,44 +89,6 @@ struct SummaryStatTile: View {
         return data.buckets.enumerated().map { index, value in
             WorkoutRunsBarChart.Bar(slot: index, value: value, isCurrent: index == count - 1)
         }
-    }
-}
-
-// MARK: - Trend Placeholder
-
-/// The chart-slot placeholder a core-stat tile shows before it has a trend to draw — a quiet gray
-/// progress ring (around a small bar-chart glyph) beside "Building your trend", sitting where the
-/// bars would, so a brand-new week reads as *in progress* rather than an empty tile. All gray, no
-/// accent: it's a nudge, not data — the honest answer to "there's nothing to chart yet" without
-/// faking bars. The ring tracks how far through the current period the tile is, so it creeps forward
-/// as the week goes on.
-private struct SummaryTrendPlaceholder: View {
-    /// How far through the current period we are (0…1) — the ring's fill.
-    let progress: Double
-
-    var body: some View {
-        HStack(spacing: 9) {
-            ZStack {
-                Circle()
-                    .stroke(Color.fill, lineWidth: 3)
-                Circle()
-                    .trim(from: 0, to: progress)
-                    .stroke(Color.secondaryLabel, style: StrokeStyle(lineWidth: 3, lineCap: .round))
-                    // Start at 12 o'clock and fill clockwise, like every other progress ring.
-                    .rotationEffect(.degrees(-90))
-                Image(systemName: "chart.bar.fill")
-                    .font(.system(size: 10))
-                    .foregroundStyle(.tertiary)
-            }
-            .frame(width: 30, height: 30)
-            Text(NSLocalizedString("buildingYourTrend", comment: ""))
-                .font(.caption.weight(.medium))
-                .foregroundStyle(.tertiary)
-                .lineLimit(1)
-                .minimumScaleFactor(0.8)
-            Spacer(minLength: 0)
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomLeading)
     }
 }
 

--- a/LOGIT/SharedUI/Views/ProgressIndicatorPill.swift
+++ b/LOGIT/SharedUI/Views/ProgressIndicatorPill.swift
@@ -25,15 +25,17 @@ import SwiftUI
 struct ProgressIndicatorPill<Label: View>: View {
     /// Padding and spacing presets. `.regular` is the trend / gain / "n improved" pill; `.prominent`
     /// is the in-workout metric badge (a touch wider for its two-line content); `.compact` is quieter
-    /// metadata like the lapsed-tile pill — smaller and tighter, a size below a score.
+    /// metadata like the lapsed-tile pill — smaller and tighter, a size below a score; `.hero` is the
+    /// Strength tile, the one place where the pill *is* the headline rather than an annotation on one.
     enum Size {
-        case regular, prominent, compact
+        case regular, prominent, compact, hero
 
         var horizontalPadding: CGFloat {
             switch self {
             case .regular: return 10
             case .prominent: return 12
             case .compact: return 8
+            case .hero: return 18
             }
         }
 
@@ -41,6 +43,7 @@ struct ProgressIndicatorPill<Label: View>: View {
             switch self {
             case .regular, .prominent: return 6
             case .compact: return 5
+            case .hero: return 9
             }
         }
 
@@ -48,6 +51,7 @@ struct ProgressIndicatorPill<Label: View>: View {
             switch self {
             case .regular, .prominent: return 4
             case .compact: return 3
+            case .hero: return 9
             }
         }
     }
@@ -59,6 +63,10 @@ struct ProgressIndicatorPill<Label: View>: View {
     /// Tints the symbol, the label's default foreground and the capsule fill (at 0.15 opacity).
     let style: AnyShapeStyle
     let size: Size
+    /// Font for the leading symbol. Nil keeps the badge default (`.caption2` bold) that every pill in
+    /// the app wears; the Strength hero passes a large one so the trend arrow can lead the tile
+    /// instead of annotating it.
+    let symbolFont: Font?
     let label: Label
     /// Whether the symbol+label share one gradient sweep (the `style:` initializer) rather than each
     /// resolving it on its own — see `continuousForegroundStyle`. Off for the flat-`color:` badges
@@ -69,11 +77,13 @@ struct ProgressIndicatorPill<Label: View>: View {
         symbol: String?,
         style: AnyShapeStyle,
         size: Size = .regular,
+        symbolFont: Font? = nil,
         @ViewBuilder label: () -> Label
     ) {
         self.symbol = symbol
         self.style = style
         self.size = size
+        self.symbolFont = symbolFont
         self.label = label()
         self.fillsContinuously = true
     }
@@ -83,11 +93,13 @@ struct ProgressIndicatorPill<Label: View>: View {
         symbol: String?,
         color: Color,
         size: Size = .regular,
+        symbolFont: Font? = nil,
         @ViewBuilder label: () -> Label
     ) {
         self.symbol = symbol
         self.style = AnyShapeStyle(color)
         self.size = size
+        self.symbolFont = symbolFont
         self.label = label()
         self.fillsContinuously = false
     }
@@ -112,7 +124,7 @@ struct ProgressIndicatorPill<Label: View>: View {
         let content = HStack(spacing: size.spacing) {
             if let symbol {
                 Image(systemName: symbol)
-                    .font(.caption2.weight(.bold))
+                    .font(symbolFont ?? .caption2.weight(.bold))
             }
             label
         }

--- a/LOGIT/SharedUI/Views/TrendPlaceholder.swift
+++ b/LOGIT/SharedUI/Views/TrendPlaceholder.swift
@@ -1,0 +1,77 @@
+//
+//  TrendPlaceholder.swift
+//  LOGIT
+//
+//  Created by Lukas Kaibel on 27.07.26.
+//
+
+import SwiftUI
+
+/// The placeholder a tile shows before it has a trend to draw — a quiet gray progress ring around a
+/// small glyph, beside a line of copy, sitting where the data would. All gray, no accent: it's a
+/// nudge, not data — the honest answer to "there's nothing to chart yet" without faking a chart.
+///
+/// The ring tracks how far along the wait is (how far through the period, or how much history has
+/// accumulated), so it creeps forward instead of sitting at a fixed mark. **It never renders as a
+/// bare track**: the fill floors at `minimumFill`, so a brand-new tile reads as *started* rather
+/// than as a broken or empty control.
+///
+/// Shared by the Summary's core-stat tiles and the Strength tile so "not enough data yet" looks the
+/// same wherever it appears.
+struct TrendPlaceholder: View {
+    /// How far along the wait is, 0…1. Values outside are clamped; zero still shows `minimumFill`.
+    let progress: Double
+    let text: String
+    var systemImage: String = "chart.bar.fill"
+    /// Where the placeholder sits in the space it's given — the stat tiles anchor it to the bottom
+    /// of their chart slot; the Strength tile centres it vertically in a text row.
+    var alignment: Alignment = .bottomLeading
+    var diameter: CGFloat = 30
+
+    /// Even at zero the ring keeps this much arc, so it reads as begun rather than empty.
+    private static let minimumFill = 0.05
+
+    private var fill: Double { min(max(progress, Self.minimumFill), 1) }
+
+    var body: some View {
+        HStack(spacing: 9) {
+            ZStack {
+                Circle()
+                    .stroke(Color.fill, lineWidth: 3)
+                Circle()
+                    .trim(from: 0, to: fill)
+                    .stroke(Color.secondaryLabel, style: StrokeStyle(lineWidth: 3, lineCap: .round))
+                    // Start at 12 o'clock and fill clockwise, like every other progress ring.
+                    .rotationEffect(.degrees(-90))
+                    .animation(.snappy, value: fill)
+                Image(systemName: systemImage)
+                    .font(.system(size: diameter / 3))
+                    .foregroundStyle(.tertiary)
+            }
+            .frame(width: diameter, height: diameter)
+            Text(text)
+                .font(.caption.weight(.medium))
+                .foregroundStyle(.tertiary)
+                .lineLimit(2)
+                .minimumScaleFactor(0.8)
+                .fixedSize(horizontal: false, vertical: true)
+            Spacer(minLength: 0)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: alignment)
+        .accessibilityElement(children: .combine)
+    }
+}
+
+#Preview {
+    VStack(spacing: 24) {
+        TrendPlaceholder(progress: 0, text: "Building your trend")
+        TrendPlaceholder(progress: 0.4, text: "Building your trend")
+        TrendPlaceholder(
+            progress: 0.15,
+            text: "Keep logging workouts to see your strength trend.",
+            systemImage: "chart.line.uptrend.xyaxis",
+            alignment: .leading
+        )
+    }
+    .padding()
+}

--- a/LOGITTests/VolumeCalculatingTests.swift
+++ b/LOGITTests/VolumeCalculatingTests.swift
@@ -488,3 +488,135 @@ final class DurationFormattingTests: XCTestCase {
         XCTAssertFalse(fortyFive.hasPrefix("0"), "Zero-valued units should be hidden: \(fortyFive)")
     }
 }
+
+// MARK: - Strength progress
+
+/// The Strength figure is a *set-weighted* mean of each exercise's e1RM change, and the detail
+/// screen pulls that mean back apart — so the weighting, the scoping and the ordering are the parts
+/// worth pinning down.
+final class StrengthProgressTests: XCTestCase {
+
+    private var database: Database!
+    private var builder: TestDataBuilder!
+
+    override func setUp() {
+        super.setUp()
+        database = Database(isPreview: true)
+        builder = TestDataBuilder(database: database)
+    }
+
+    override func tearDown() {
+        database = nil
+        builder = nil
+        super.tearDown()
+    }
+
+    private func change(
+        _ name: String,
+        _ group: MuscleGroup,
+        percent: Double,
+        sets: Int
+    ) -> StrengthProgress.ExerciseChange {
+        StrengthProgress.ExerciseChange(
+            exercise: builder.createExercise(name: name, muscleGroup: group),
+            muscleGroup: group,
+            percentChange: percent,
+            setCount: sets
+        )
+    }
+
+    func testOverallIsWeightedBySetCount() {
+        // 10 % over 30 sets and 0 % over 10 sets → 7.5 %, not the unweighted 5 %.
+        let progress = StrengthProgress(
+            changes: [
+                change("Bench Press", .chest, percent: 10, sets: 30),
+                change("Curls", .biceps, percent: 0, sets: 10),
+            ],
+            window: .eightWeeks
+        )
+        XCTAssertEqual(try XCTUnwrap(progress.overallPercentChange), 7.5, accuracy: 0.001)
+    }
+
+    func testScopingToAGroupIgnoresOtherGroups() {
+        let progress = StrengthProgress(
+            changes: [
+                change("Bench Press", .chest, percent: 10, sets: 10),
+                change("Incline Bench", .chest, percent: 20, sets: 10),
+                change("Curls", .biceps, percent: -40, sets: 100),
+            ],
+            window: .eightWeeks
+        )
+        XCTAssertEqual(try XCTUnwrap(progress.percentChange(in: .chest)), 15, accuracy: 0.001)
+        XCTAssertEqual(try XCTUnwrap(progress.percentChange(in: .biceps)), -40, accuracy: 0.001)
+        XCTAssertNil(progress.percentChange(in: .legs), "A group with no data has no figure")
+    }
+
+    /// A zero set count must not erase an exercise from the mean (weights floor at 1).
+    func testZeroSetCountStillCounts() {
+        let progress = StrengthProgress(
+            changes: [change("Bench Press", .chest, percent: 8, sets: 0)],
+            window: .eightWeeks
+        )
+        XCTAssertEqual(try XCTUnwrap(progress.overallPercentChange), 8, accuracy: 0.001)
+    }
+
+    func testGroupsAreSortedByGainAndCarryTheirExerciseCount() {
+        let progress = StrengthProgress(
+            changes: [
+                change("Curls", .biceps, percent: 3, sets: 10),
+                change("Bench Press", .chest, percent: 9, sets: 10),
+                change("Incline Bench", .chest, percent: 9, sets: 10),
+            ],
+            window: .eightWeeks
+        )
+        XCTAssertEqual(progress.groups.map(\.muscleGroup), [.chest, .biceps])
+        XCTAssertEqual(progress.groups.first?.exerciseCount, 2)
+    }
+
+    /// Sorted by magnitude, so a big decline ranks above a small gain rather than sinking to the
+    /// bottom of the list where the cap would hide it.
+    func testExerciseChangesRankDeclinesByMagnitude() {
+        let progress = StrengthProgress(
+            changes: [
+                change("Small Gain", .chest, percent: 2, sets: 10),
+                change("Big Decline", .back, percent: -18, sets: 10),
+                change("Mid Gain", .legs, percent: 7, sets: 10),
+            ],
+            window: .eightWeeks
+        )
+        XCTAssertEqual(
+            progress.exerciseChanges().map { $0.exercise.name },
+            ["Big Decline", "Mid Gain", "Small Gain"]
+        )
+    }
+
+    func testEmptyProgressHasNoFigure() {
+        XCTAssertFalse(StrengthProgress.empty.hasData)
+        XCTAssertNil(StrengthProgress.empty.overallPercentChange)
+        XCTAssertTrue(StrengthProgress.empty.groups.isEmpty)
+    }
+
+    func testComputeIgnoresExercisesWithoutBothWindows() {
+        // No sets at all → nothing to compare, so nothing qualifies.
+        let progress = StrengthProgress.compute(workouts: [], window: .fourWeeks)
+        XCTAssertFalse(progress.hasData)
+        XCTAssertEqual(progress.window, .fourWeeks)
+    }
+
+    func testWindowTitlesAreDistinct() {
+        let titles = Set(StrengthWindow.allCases.map(\.title))
+        XCTAssertEqual(titles.count, StrengthWindow.allCases.count)
+        XCTAssertEqual(StrengthWindow.default, .eightWeeks)
+    }
+
+    /// The trend deadband: small wobble reads as steady and keeps the neutral arrow, so the tile
+    /// can't flicker between "up" and "down" on noise.
+    func testTrendDirectionDeadband() {
+        XCTAssertEqual(strengthTrendSymbol(0.4), "arrow.right")
+        XCTAssertEqual(strengthTrendSymbol(-0.4), "arrow.right")
+        XCTAssertEqual(strengthTrendSymbol(5), "arrow.up")
+        XCTAssertEqual(strengthTrendSymbol(-5), "arrow.down")
+        XCTAssertFalse(strengthTrendIsUp(0.9))
+        XCTAssertTrue(strengthTrendIsUp(1.0))
+    }
+}


### PR DESCRIPTION
Follows #108. Renames the Progress tab's headline tile to **Strength** and rebuilds it, then gives it the detail screen it never had.

## Why the tile changed

It had grown its own dialect — each of these is a place where it said something the app already had a word for:

- a **60 pt arrow disc** used nowhere else (other badges are 34–38 pt)
- **“Trending up”** as a status headline, where every other tile leads with a value
- a **hand-rolled `+5.0%`**, while `TrendIndicatorView` exists for exactly that
- an **arrow grid** as a third data display, printing a tinted `+0 %` for groups with nothing to say
- **no chevron** — the only non-navigating tile on the tab

## The arrow, properly

The arrow stays and gets bigger: `arrow.up` / `arrow.down` is the app's single progress glyph. But it now comes from the component that owns it — `ProgressIndicatorPill` gains a `.hero` size and a `symbolFont` hook (its symbol font was hardcoded to `.caption2`, which is why a large arrow was impossible without drawing a second one).

That also resolves a rule conflict: values stay neutral and pills carry the accent, so a bare tinted percent would break the convention while the same percent inside a pill is exactly where tinting belongs. **For a metric that is a ratio rather than a quantity, the pill is the value.**

Beside the hero the tile names the muscle groups carrying the number, so it answers *how much* and *where from* in one glance — and lands shorter than the tile it replaces.

**No sparkline, deliberately.** A chart of a percent change is a second-order quantity, and consecutive rolling windows overlap so heavily that the line barely moves.

## The detail screen

Built from how the figure is actually computed — a **set-weighted mean of every exercise's e1RM change** — so it shows that mean pulled apart rather than its history:

| Section | |
|---|---|
| Window picker | 4 / 8 / 12 weeks — changes what's *measured*, not a chart range |
| Hero | the pill for the selected scope |
| Muscle grid | **is** the scope selector; groups without data stay in place, dimmed, so the grid keeps a stable shape as the window changes |
| Composition | every exercise on **one shared zero axis**, sorted by magnitude so a decline can't hide below the cap, set count showing its weight, capped at five with an inline expand |

The shared axis is the point — it's what lets rows be compared to each other, and what a per-row centred tick destroys.

`OverallProgress` becomes `StrengthProgress` and keeps its per-exercise changes instead of averaging them away, since those *are* the headline number.

## Verification

- 9 new unit tests on the model (set-count weighting, group scoping, magnitude ordering, zero-set floor, deadband) — 432 unit tests pass overall
- Scenario captures on `one` / `many` / `stress`, plus the detail screen driven end to end: group focus, window switch, and the show-all expansion
- Two bugs found and fixed by looking at the renders: the composition labels were clipped off the right edge (bars are now scaled against the width minus a label gutter), and a percent label could collide with its own bar (the value now sits on the far side of the axis from its bar)

🤖 Generated with [Claude Code](https://claude.com/claude-code)