### PR TITLE
CI: run UI tests — scenario-root smoke on PRs, full suite nightly

### DIFF
--- a/.github/scripts/select-simulator.sh
+++ b/.github/scripts/select-simulator.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# Picks an iPhone simulator for the UI test jobs and writes its destination to
+# $GITHUB_ENV as IOS_TEST_DESTINATION.
+#
+# Selects the newest installed iOS runtime that actually has an iPhone device: the
+# app's deployment target is iOS 26.0, so older runtimes can't run it at all, and
+# runner images gain runtimes over time. Targets the device by UDID rather than by
+# name so the destination can't resolve to some other booted device.
+#
+# Known-good locally is iOS 26.4 — the 26.0 test runner dies nondeterministically
+# ("Test crashed with signal kill"). The UI jobs pass -retry-tests-on-failure to
+# absorb that class of failure whatever the runner image ships.
+
+set -euo pipefail
+
+DEVICES_JSON=$(xcrun simctl list devices available --json)
+
+SELECTED=$(printf '%s' "$DEVICES_JSON" | jq -r '
+  .devices
+  | to_entries
+  | map(select(.key | test("SimRuntime\\.iOS-")))
+  | map(select(.value | map(select(.name | startswith("iPhone"))) | length > 0))
+  | sort_by(.key | capture("iOS-(?<major>[0-9]+)-(?<minor>[0-9]+)") | [(.major | tonumber), (.minor | tonumber)])
+  | last
+  | (.value | map(select(.name | startswith("iPhone"))) | .[0]) as $device
+  | "\(.key)\t\($device.name)\t\($device.udid)"
+')
+
+if [ -z "$SELECTED" ] || [ "$SELECTED" = "null" ]; then
+  echo "No available iPhone simulator on any iOS runtime"
+  xcrun simctl list devices available
+  exit 1
+fi
+
+RUNTIME=$(printf '%s' "$SELECTED" | cut -f1)
+NAME=$(printf '%s' "$SELECTED" | cut -f2)
+UDID=$(printf '%s' "$SELECTED" | cut -f3)
+
+echo "Using $NAME ($UDID) on ${RUNTIME##*SimRuntime.}"
+echo "IOS_TEST_DESTINATION=platform=iOS Simulator,id=$UDID" >> "$GITHUB_ENV"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,3 +76,66 @@ jobs:
         with:
           name: test-results
           path: TestResults.xcresult
+
+  # The four scenario-root tests from the standing ScenarioScreenshots suite: they
+  # launch the app in each critical data state (empty / one workout / rich history /
+  # free tier) and walk the tab roots, so they catch launch, seeding and tab-root
+  # regressions for ~2.5 minutes of test time. The rest of the suite is another ~18
+  # minutes and runs nightly instead (ui-tests-nightly.yml).
+  #
+  # Before this job existed the unit job's -skip-testing:LOGITUITests meant CI had
+  # never run a single UI test, and three recorder tests rotted unnoticed across
+  # #103/#105/#107 (fixed in #110).
+  ui-smoke:
+    name: UI Smoke Tests
+    runs-on: macos-15
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Select latest Xcode version
+        run: |
+          LATEST_XCODE=$(ls -d /Applications/Xcode*.app 2>/dev/null | sort -V | tail -1)
+          echo "Using: $LATEST_XCODE"
+          sudo xcode-select -s "$LATEST_XCODE/Contents/Developer"
+
+      - name: Resolve Swift Package dependencies
+        run: xcodebuild -resolvePackageDependencies -project LOGIT.xcodeproj -scheme LOGITScreenshots
+
+      - name: Create Secrets.swift stub
+        run: |
+          cat > LOGIT/Config/Secrets.swift << 'EOF'
+          let OPENAI_API_KEY = "test-key-for-ci"
+          let WISHKIT_API_KEY = "test-key-for-ci"
+          EOF
+
+      - name: Select iPhone simulator
+        run: bash .github/scripts/select-simulator.sh
+
+      - name: Run UI smoke tests
+        run: |
+          set -o pipefail
+          xcodebuild test \
+            -project LOGIT.xcodeproj \
+            -scheme LOGITScreenshots \
+            -destination "$IOS_TEST_DESTINATION" \
+            -resultBundlePath UITestResults.xcresult \
+            -only-testing:LOGITUITests/ScenarioScreenshots/testEmptyScenario \
+            -only-testing:LOGITUITests/ScenarioScreenshots/testOneWorkoutScenario \
+            -only-testing:LOGITUITests/ScenarioScreenshots/testManyWorkoutsScenario \
+            -only-testing:LOGITUITests/ScenarioScreenshots/testFreeUserScenario \
+            -retry-tests-on-failure \
+            -test-iterations 2 \
+            CODE_SIGN_IDENTITY="" \
+            CODE_SIGNING_REQUIRED=NO \
+            | xcpretty --color --report junit
+
+      # Carries the captured screenshots as well as the failure logs, so a red run
+      # can be diagnosed without reproducing it locally.
+      - name: Upload UI test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: ui-smoke-results
+          path: UITestResults.xcresult

--- a/.github/workflows/ui-tests-nightly.yml
+++ b/.github/workflows/ui-tests-nightly.yml
@@ -1,0 +1,76 @@
+name: Nightly UI Tests
+
+# The whole ScenarioScreenshots suite — 30 tests, ~21 minutes of test time, too much
+# to hang on every push. Every PR gets the four scenario-root tests instead (the
+# ui-smoke job in tests.yml); this run covers everything else: the recorder flows,
+# the superset pager, the measurement/distance types, the exercise builder, the tray
+# sheet lifecycles.
+#
+# The point is that the suite stops rotting silently. It has no CI coverage at all
+# before this, and three recorder tests broke unnoticed across #103/#105/#107.
+
+on:
+  schedule:
+    # 04:00 UTC daily — well after the working day in CET, so a red run is waiting
+    # in the morning rather than landing mid-session.
+    - cron: '0 4 * * *'
+  workflow_dispatch:
+
+jobs:
+  ui-tests:
+    name: Full UI Suite
+    runs-on: macos-15
+    timeout-minutes: 90
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Select latest Xcode version
+        run: |
+          LATEST_XCODE=$(ls -d /Applications/Xcode*.app 2>/dev/null | sort -V | tail -1)
+          echo "Using: $LATEST_XCODE"
+          sudo xcode-select -s "$LATEST_XCODE/Contents/Developer"
+
+      - name: Show Xcode version
+        run: xcodebuild -version
+
+      - name: Resolve Swift Package dependencies
+        run: xcodebuild -resolvePackageDependencies -project LOGIT.xcodeproj -scheme LOGITScreenshots
+
+      - name: Create Secrets.swift stub
+        run: |
+          cat > LOGIT/Config/Secrets.swift << 'EOF'
+          let OPENAI_API_KEY = "test-key-for-ci"
+          let WISHKIT_API_KEY = "test-key-for-ci"
+          EOF
+
+      - name: Select iPhone simulator
+        run: bash .github/scripts/select-simulator.sh
+
+      - name: Run full ScenarioScreenshots suite
+        run: |
+          set -o pipefail
+          xcodebuild test \
+            -project LOGIT.xcodeproj \
+            -scheme LOGITScreenshots \
+            -destination "$IOS_TEST_DESTINATION" \
+            -resultBundlePath UITestResults.xcresult \
+            -only-testing:LOGITUITests/ScenarioScreenshots \
+            -retry-tests-on-failure \
+            -test-iterations 2 \
+            CODE_SIGN_IDENTITY="" \
+            CODE_SIGNING_REQUIRED=NO \
+            | xcpretty --color --report junit
+
+      # Every test attaches screenshots, so this bundle is the scenario matrix for the
+      # day as well as the failure evidence. Export with:
+      #   xcrun xcresulttool export attachments --path UITestResults.xcresult \
+      #     --output-path shots
+      - name: Upload UI test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: ui-suite-results
+          path: UITestResults.xcresult
+          retention-days: 14


### PR DESCRIPTION
Follow-up to #110. CI has never run a single UI test — the Tests job passes `-skip-testing:LOGITUITests`, so the standing `ScenarioScreenshots` suite guarded nothing and could rot silently. It did: three recorder tests broke across #103/#105/#107 and nobody noticed.

The whole suite is 30 tests / ~21 min of test time, too much to hang on every push, so it's split by what each run is worth.

## `ui-smoke` — gates every push and PR

The four scenario-root tests (`testEmptyScenario`, `testOneWorkoutScenario`, `testManyWorkoutsScenario`, `testFreeUserScenario`). They launch the app in each critical data state and walk the tab roots, so they catch launch, seeding and tab-root regressions. **Measured at 146s for the four**, running in parallel with the existing unit job.

## `ui-tests-nightly.yml` — the whole suite, 04:00 UTC daily

Plus `workflow_dispatch` for on-demand runs. Its result bundle is kept 14 days; every test attaches screenshots, so it doubles as the day's scenario matrix:

```bash
xcrun xcresulttool export attachments --path UITestResults.xcresult --output-path shots
```

## `-retry-tests-on-failure -test-iterations 2` on both

Worth showing this is load-bearing rather than defensive. A local validation run of the exact smoke invocation hit a transient CoreSimulator `failed to install the application` error on the first attempt:

```
Test Case '...testEmptyScenario' failed (1.828 seconds).
Test Case '...testEmptyScenario' passed (38.407 seconds).
...
** TEST SUCCEEDED **   (exit 0)
```

It passed on the retry and the run stayed green. Without the flag the gate would go red on simulator glitches and get ignored within a week. Note the per-suite `Test Suite ... failed` lines are just attempt accounting — the verdict and exit code are what count.

## Simulator selection

Both jobs use `.github/scripts/select-simulator.sh`: newest installed iOS runtime that actually has an iPhone, targeted **by UDID**. The app's deployment target is iOS 26.0 so older runtimes can't run it at all, and a UDID destination can't resolve to some other booted device the way a name can.

One thing to watch on the first run: locally the known-good runtime is 26.4 (the 26.0 runner dies nondeterministically), and "newest" on the runner image may be something else. The retry policy is there to absorb that; if a specific runtime turns out to be consistently bad, the script is the one place to pin it.

## Not touched

The existing unit job — same scheme, same flags, its own simulator selection, and its known `testDeleteWorkoutSet` flake. If you want that flake retried too, it's the same two flags, but I left existing CI behavior alone.

To make the smoke job actually block merges it needs adding to the branch protection rules for `main` — that's a repo setting, not something this PR can carry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)