### PR TITLE
Superset: one card with the exercises paged inside it, one action bar

### DIFF
--- a/LOGIT/Features/Template/Cells/TemplateSetCells/TemplateSetCell.swift
+++ b/LOGIT/Features/Template/Cells/TemplateSetCells/TemplateSetCell.swift
@@ -46,9 +46,15 @@ struct TemplateSetCell: View {
     private var content: some View {
         VStack(spacing: 0) {
             if let indexInSetGroup = indexInSetGroup {
+                // Bare number, styled exactly like `WorkoutSetCell`'s — templates mirror
+                // workouts (AGENT.md), and "Set 1" beside a workout's "1" was the last thing
+                // making the two set rows read differently.
                 HStack {
-                    Text("\(NSLocalizedString("set", comment: "")) \(indexInSetGroup + 1)")
-                    Spacer()
+                    Text("\(indexInSetGroup + 1)")
+                        .fontWeight(.bold)
+                        .fontDesign(.rounded)
+                        .foregroundStyle(.secondary)
+                        .fixedSize()
                     setContent
                 }
                 if let dropSet = templateSet as? TemplateDropSet, canEdit {

--- a/LOGIT/Features/Template/Cells/TemplateSetGroupCell.swift
+++ b/LOGIT/Features/Template/Cells/TemplateSetGroupCell.swift
@@ -8,10 +8,10 @@
 import CoreData
 import SwiftUI
 
-/// A template's set group, mirroring `WorkoutSetGroupCell`: a superset renders containerless as
-/// one full-size card per exercise paged horizontally, every card wears the thread's index
-/// bulge, and the rails fork/merge across the pages. Workout-only concepts (metric badges,
-/// previous-set references, the session note) have no template counterpart and are absent.
+/// A template's set group, mirroring `WorkoutSetGroupCell`: a superset is one card wearing one
+/// index bulge, with its exercises paged horizontally inside it and a single, group-level action
+/// bar below. Workout-only concepts (metric badges, previous-set references, the session note)
+/// have no template counterpart and are absent.
 struct TemplateSetGroupCell: View {
     // MARK: - Environment
 
@@ -40,9 +40,12 @@ struct TemplateSetGroupCell: View {
     @State private var isSelectingPrimaryExercise = false
     @State private var primaryExerciseSelectionSheetDetend: PresentationDetent? = .large
     @State private var isSelectingSecondaryExercise = false
-    /// Which exercise's page the superset pager is snapped to (objectID; nil = first page).
-    /// Also driven programmatically when keyboard focus lands on the partner's fields.
+    /// Where the superset pager has been *told* to scroll (objectID; nil = first lane), driven
+    /// programmatically when keyboard focus lands on the partner's fields.
     @State private var pagedExerciseID: NSManagedObjectID?
+    /// Which lane is actually on screen — see `WorkoutSetGroupCell.visibleExerciseID` for why
+    /// `scrollPosition(id:)` can't answer that when lanes are narrower than the card.
+    @State private var visibleExerciseID: NSManagedObjectID?
 
     // MARK: - Body
 
@@ -102,13 +105,14 @@ struct TemplateSetGroupCell: View {
             .accentColor(setGroup.exercise?.muscleGroup?.color ?? .accentColor)
     }
 
-    /// A superset with both exercises chosen renders as containerless side-by-side pages; while
-    /// reordering (compact header row) or before the second exercise is picked it falls back to
-    /// the classic single card, whose header still offers the "select exercise" entry point.
+    /// A superset with both exercises chosen renders as one card whose exercises page inside it;
+    /// while reordering (compact header row) or before the second exercise is picked it falls
+    /// back to the classic single card, whose header still offers the "select exercise" entry
+    /// point.
     @ViewBuilder
     private var content: some View {
         if isPagedSuperset {
-            supersetPager
+            supersetCard
         } else {
             standardCard
         }
@@ -133,19 +137,6 @@ struct TemplateSetGroupCell: View {
 
     private var bulgeLabel: String? {
         SetGroupThread.indexLabel(index: resolvedIndexInTemplate, count: resolvedGroupCount)
-    }
-
-    /// The merge rail is drawn under the pages only when another group follows, so the
-    /// converged line has somewhere to continue to (the list draws the trunk between cells).
-    private var showsMergeRail: Bool {
-        guard let index = resolvedIndexInTemplate else { return false }
-        return index < resolvedGroupCount - 1
-    }
-
-    /// The fork rail only when a group precedes — a floating rail above the first group with
-    /// nothing feeding it just looks broken.
-    private var showsForkRail: Bool {
-        (resolvedIndexInTemplate ?? 0) > 0
     }
 
     // MARK: - Standard card
@@ -192,62 +183,91 @@ struct TemplateSetGroupCell: View {
         }
     }
 
-    // MARK: - Superset pager
+    // MARK: - Superset card
 
-    /// The containerless superset: one full-size card per exercise, paged horizontally, each
-    /// with its own bulge socket and add-set controls. The thread's rails ride in the bands
-    /// above and below the pages and scroll WITH them, so the fixed trunk the list draws
-    /// between cells always meets a rail at a right angle, whatever the scroll position.
-    private var supersetPager: some View {
+    /// The superset: ONE card for the group — one index bulge, one action bar — with the
+    /// exercises paged horizontally inside it. Only what belongs to a single exercise rides in
+    /// the pager (its header and its entry of every set); the bar below acts on the set group,
+    /// so one copy serves both lanes. Mirrors `WorkoutSetGroupCell.supersetCard`.
+    private var supersetCard: some View {
         let exercises = [setGroup.exercise, setGroup.secondaryExercise].compactMap { $0 }
-        return ScrollView(.horizontal) {
-            HStack(alignment: .top, spacing: SetGroupThread.pageSpacing) {
+        return VStack(spacing: CELL_PADDING) {
+            supersetLanes(exercises: exercises)
+            SupersetLaneIndicator(
+                colors: exercises.map { $0.muscleGroup?.color ?? .accentColor },
+                selectedIndex: laneIndex(in: exercises)
+            )
+            if canEdit {
+                controls(for: setGroup.exercise)
+                    .padding(.horizontal, CELL_PADDING)
+            }
+        }
+        .padding(.bottom, canEdit ? CELL_PADDING : CELL_PADDING / 2)
+        .background(
+            RoundedRectangle(cornerRadius: 30)
+                .fill(.shadow(.inner(color: .white.opacity(0.04), radius: 3)))
+                .foregroundStyle(Color.secondaryBackground)
+        )
+        .cornerRadius(30)
+        .bulgeSocket(label: bulgeLabel)
+    }
+
+    /// No content margins: the snapped first lane sits flush with the card's leading edge (and
+    /// the last, clamped at the scroll bound, flush with the trailing edge), so a lane's header
+    /// lines up with a standard card's exactly.
+    private func supersetLanes(exercises: [Exercise]) -> some View {
+        ScrollView(.horizontal) {
+            HStack(alignment: .top, spacing: SetGroupThread.laneSpacing) {
                 ForEach(exercises, id: \.objectID) { exercise in
-                    TemplateSupersetExercisePage(
+                    TemplateSupersetExerciseLane(
                         setGroup: setGroup,
                         exercise: exercise,
-                        isPrimaryPage: exercise == setGroup.exercise,
-                        bulgeLabel: bulgeLabel,
+                        isPrimaryLane: exercise == setGroup.exercise,
                         focusedIntegerFieldIndex: $focusedIntegerFieldIndex,
                         supplementaryText: supplementaryText,
                         showDetailAsSheet: showDetailAsSheet,
-                        onTapRestDuration: onTapRestDuration,
-                        groupMenu: AnyView(menu)
+                        onTapRestDuration: onTapRestDuration
                     )
                     .containerRelativeFrame(.horizontal) { length, _ in
-                        max(length - SetGroupThread.pageInset * 2, 100)
+                        SetGroupThread.laneWidth(in: length)
                     }
                 }
             }
             .scrollTargetLayout()
-            .supersetThreadRails(
-                pageCount: exercises.count,
-                showsFork: showsForkRail,
-                showsMerge: showsMergeRail
-            )
         }
-        // No content margins: the snapped first page sits flush with the leading edge (and the
-        // last page, clamped at the scroll bound, flush with the trailing edge) exactly like
-        // every non-superset cell — see `WorkoutSetGroupCell.supersetPager`.
         .scrollTargetBehavior(.viewAligned)
-        .scrollClipDisabled()
         .scrollIndicators(.hidden)
         .scrollPosition(id: $pagedExerciseID)
+        // A lane only counts as "on screen" once most of it is — the peeking neighbour is
+        // always partly visible. See `WorkoutSetGroupCell.supersetLanes`.
+        .onScrollTargetVisibilityChange(idType: NSManagedObjectID.self, threshold: 0.6) { visible in
+            guard let onScreen = visible.first else { return }
+            visibleExerciseID = onScreen
+        }
         .onChange(of: focusedIntegerFieldIndex) { _, newValue in
             autopageIfNeeded(for: newValue, exercises: exercises)
         }
     }
 
+    /// Which lane fills the card, for the dot indicator — nothing reported yet is the first.
+    private func laneIndex(in exercises: [Exercise]) -> Int {
+        guard
+            let currentID = visibleExerciseID ?? pagedExerciseID,
+            let index = exercises.firstIndex(where: { $0.objectID == currentID })
+        else { return 0 }
+        return index
+    }
+
     /// Keyboard next/previous walks a set's entries, which alternate exercises in a superset —
     /// when focus lands on a field whose entry belongs to the other exercise, the pager follows
-    /// so the focused field is never on an off-screen page.
+    /// so the focused field is never on an off-screen lane.
     private func autopageIfNeeded(for index: IntegerField.Index?, exercises: [Exercise]) {
         guard let index,
               let templateSet = setGroup.sets.first(where: { $0.id == index.setID }),
               templateSet.entries.indices.contains(index.secondary),
               let owner = templateSet.owningExercise(of: templateSet.entries[index.secondary])
         else { return }
-        let currentID = pagedExerciseID ?? exercises.first?.objectID
+        let currentID = visibleExerciseID ?? pagedExerciseID ?? exercises.first?.objectID
         guard owner.objectID != currentID else { return }
         withAnimation(.snappy) { pagedExerciseID = owner.objectID }
     }
@@ -306,7 +326,8 @@ struct TemplateSetGroupCell: View {
         setGroup.sets.last == templateSet
     }
 
-    /// Duplicate-last-set, add-set and the group menu, tinted by the page's own exercise.
+    /// Duplicate-last-set, add-set and the group menu — the set group's controls, drawn once per
+    /// card. All three act on the group, so a superset's two lanes share this one bar.
     fileprivate func controls(for exercise: Exercise?) -> some View {
         HStack(spacing: 8) {
             Button {
@@ -507,32 +528,29 @@ struct TemplateSetGroupCell: View {
     }
 }
 
-// MARK: - Superset exercise page
+// MARK: - Superset exercise lane
 
-/// One exercise's card inside the template superset pager: its own bulge socket, header, set
-/// column (only this exercise's entry per set) and add-set controls. The group-level menu is
-/// built by the cell (it owns the exercise-selection state) and passed in.
-private struct TemplateSupersetExercisePage: View {
+/// One exercise's lane inside the template superset card: its header and its entry of every set —
+/// nothing else. Containerless: the card, the index bulge and the action bar belong to the GROUP
+/// and are drawn once by the cell around the pager. Mirrors `SupersetExerciseLane`.
+private struct TemplateSupersetExerciseLane: View {
     @Environment(\.canEdit) var canEdit: Bool
     @EnvironmentObject var database: Database
 
     @ObservedObject var setGroup: TemplateSetGroup
     let exercise: Exercise
-    let isPrimaryPage: Bool
-    let bulgeLabel: String?
+    let isPrimaryLane: Bool
     @Binding var focusedIntegerFieldIndex: IntegerField.Index?
     let supplementaryText: String?
     let showDetailAsSheet: Bool
     let onTapRestDuration: ((TemplateSet) -> Void)?
-    let groupMenu: AnyView
 
     var body: some View {
-        card
-            .bulgeSocket(label: bulgeLabel)
+        lane
             .accentColor(exercise.muscleGroup?.color ?? .accentColor)
     }
 
-    private var card: some View {
+    private var lane: some View {
         VStack(spacing: CELL_PADDING) {
             header
                 .padding([.top, .horizontal], CELL_PADDING)
@@ -567,18 +585,7 @@ private struct TemplateSupersetExercisePage: View {
             }
             .padding(.horizontal, CELL_PADDING / 2)
             .animation(.interactiveSpring(), value: setGroup.sets)
-            if canEdit {
-                controls
-                    .padding(.horizontal, CELL_PADDING)
-            }
         }
-        .padding(.bottom, canEdit ? CELL_PADDING : CELL_PADDING / 2)
-        .background(
-            RoundedRectangle(cornerRadius: 30)
-                .fill(.shadow(.inner(color: .white.opacity(0.04), radius: 3)))
-                .foregroundStyle(Color.secondaryBackground)
-        )
-        .cornerRadius(30)
     }
 
     private var header: some View {
@@ -597,7 +604,7 @@ private struct TemplateSupersetExercisePage: View {
                     Text(exercise.muscleGroup?.description ?? "")
                         .foregroundColor(exercise.muscleGroup?.color ?? .accentColor)
                     Spacer()
-                    if isPrimaryPage, let supplementaryText {
+                    if isPrimaryLane, let supplementaryText {
                         Text(supplementaryText)
                             .foregroundStyle(.secondary)
                             .fontWeight(.medium)
@@ -631,41 +638,6 @@ private struct TemplateSupersetExercisePage: View {
         }
     }
 
-    private var controls: some View {
-        HStack(spacing: 8) {
-            Button {
-                UIImpactFeedbackGenerator(style: .soft).impactOccurred()
-                withAnimation(.interactiveSpring()) {
-                    database.duplicateLastSet(from: setGroup)
-                }
-            } label: {
-                Image(systemName: "plus.square.on.square")
-                    .foregroundStyle((exercise.muscleGroup?.color ?? .accentColor).gradient)
-                    .font(.system(.body, design: .rounded, weight: .bold))
-                    .padding(15)
-                    .background(Color.accentColor.secondaryTranslucentBackground)
-                    .clipShape(Capsule())
-            }
-            Button {
-                UIImpactFeedbackGenerator(style: .soft).impactOccurred()
-                withAnimation(.interactiveSpring()) {
-                    database.addSet(to: setGroup)
-                }
-            } label: {
-                Label(
-                    NSLocalizedString("addSet", comment: ""),
-                    systemImage: "plus.circle.fill"
-                )
-                .foregroundStyle((exercise.muscleGroup?.color ?? .accentColor).gradient)
-                .font(.system(.body, design: .rounded, weight: .bold))
-                .padding(.vertical, 15)
-                .frame(maxWidth: .infinity)
-                .background(Color.accentColor.secondaryTranslucentBackground)
-                .clipShape(Capsule())
-            }
-            groupMenu
-        }
-    }
 }
 
 private struct PreviewWrapperView: View {

--- a/LOGIT/Features/Workout/Cells/WorkoutSetGroupCell.swift
+++ b/LOGIT/Features/Workout/Cells/WorkoutSetGroupCell.swift
@@ -43,7 +43,7 @@ struct WorkoutSetGroupCell: View {
     var onReorderSetGroups: (() -> Void)? = nil
     var onTapPreviousSet: ((Exercise) -> Void)? = nil
     var onTapExerciseName: ((Exercise) -> Void)? = nil
-    /// The tapped badge's set group, its subject exercise (each superset page has its own badge),
+    /// The tapped badge's set group, its subject exercise (each superset lane has its own badge),
     /// and the badge frame to anchor the info popover at.
     var onTapMetricBadge: ((WorkoutSetGroup, Exercise?, CGRect) -> Void)? = nil
 
@@ -61,10 +61,16 @@ struct WorkoutSetGroupCell: View {
     /// width budget can be derived as (column − badge reservation) and handed to `ExerciseHeader`.
     @State private var nameSlotWidth: CGFloat = 0
     @FocusState private var isNoteFieldFocused: Bool
-    /// Which exercise's page the superset pager is snapped to (objectID; nil = first page).
-    /// Also driven programmatically: when keyboard "next" focuses a field on the partner
-    /// exercise's page, the pager follows (see `autopageIfNeeded`).
+    /// Where the superset pager has been *told* to scroll (objectID; nil = first lane) — the
+    /// write channel for keyboard auto-paging, when "next" focuses a field on the partner
+    /// exercise's lane (see `autopageIfNeeded`).
     @State private var pagedExerciseID: NSManagedObjectID?
+    /// Which lane is actually on screen. `scrollPosition(id:)` can't answer that here: lanes
+    /// are narrower than the card, so the lane snapped to the trailing edge never has its
+    /// leading edge at the viewport's, and the position binding keeps naming the neighbour
+    /// peeking there instead. Target *visibility* past a threshold names the lane that fills
+    /// the card — which is what both the dots and auto-paging mean by "current".
+    @State private var visibleExerciseID: NSManagedObjectID?
 
     // MARK: - Body
 
@@ -138,13 +144,14 @@ struct WorkoutSetGroupCell: View {
         .accentColor(setGroup.exercise?.muscleGroup?.color ?? .accentColor)
     }
 
-    /// A superset with both exercises chosen renders as containerless side-by-side pages; while
-    /// reordering (compact header row) or before the second exercise is picked it falls back to
-    /// the classic single card, whose header still offers the "select exercise" entry point.
+    /// A superset with both exercises chosen renders as one card whose exercises page inside it;
+    /// while reordering (compact header row) or before the second exercise is picked it falls
+    /// back to the classic single card, whose header still offers the "select exercise" entry
+    /// point.
     @ViewBuilder
     private func content(previousSetGroup: WorkoutSetGroup?) -> some View {
         if isPagedSuperset {
-            supersetPager(previousSetGroup: previousSetGroup)
+            supersetCard(previousSetGroup: previousSetGroup)
         } else {
             standardCard(previousSetGroup: previousSetGroup)
         }
@@ -167,25 +174,10 @@ struct WorkoutSetGroupCell: View {
         groupCount ?? setGroup.workout?.setGroups.count ?? 0
     }
 
-    /// "2 of 5" — the group's place in the workout, shown in the bulge socket on top of the card
-    /// (each superset page repeats it) instead of the old header number.
+    /// "2 of 5" — the group's place in the workout, shown once in the bulge socket on top of the
+    /// card (a superset is one card, so one socket) instead of the old header number.
     private var bulgeLabel: String? {
         SetGroupThread.indexLabel(index: resolvedIndexInWorkout, count: resolvedGroupCount)
-    }
-
-    /// Whether the thread's merge rail is drawn under the superset pages — only when another
-    /// group follows, so the converged line has somewhere to continue to (the list draws the
-    /// trunk segment between cells).
-    private var showsMergeRail: Bool {
-        guard let index = resolvedIndexInWorkout else { return false }
-        return index < resolvedGroupCount - 1
-    }
-
-    /// Whether the fork rail is drawn above the superset pages — only when a group precedes,
-    /// so the rail has a trunk feeding it. On a first-group superset a floating rail with
-    /// nothing above just looks broken.
-    private var showsForkRail: Bool {
-        (resolvedIndexInWorkout ?? 0) > 0
     }
 
     // MARK: - Standard card
@@ -260,63 +252,8 @@ struct WorkoutSetGroupCell: View {
                     .padding(.horizontal, CELL_PADDING / 2)
                     .animation(.interactiveSpring(), value: setGroup.sets)
                     if canEdit {
-                        HStack(spacing: 8) {
-                            Button {
-                                UIImpactFeedbackGenerator(style: .soft).impactOccurred()
-                                withAnimation(.interactiveSpring()) {
-                                    database.duplicateLastSet(from: setGroup)
-                                }
-                            } label: {
-                                Image(systemName: "plus.square.on.square")
-                                    .foregroundStyle((setGroup.exercise?.muscleGroup?.color ?? .accentColor).gradient)
-                                    .font(.system(.body, design: .rounded, weight: .bold))
-                                    .padding(15)
-                                    .background(Color.accentColor.secondaryTranslucentBackground)
-                                    .clipShape(Capsule())
-                            }
-                            .contextMenu {
-                                Button {
-                                    withAnimation(.interactiveSpring()) {
-                                        database.duplicateLastWeight(from: setGroup)
-                                    }
-                                } label: {
-                                    Label(NSLocalizedString("copyWeight", comment: ""), systemImage: "scalemass")
-                                }
-                                Button {
-                                    withAnimation(.interactiveSpring()) {
-                                        database.duplicateLastRepetitions(from: setGroup)
-                                    }
-                                } label: {
-                                    Label(NSLocalizedString("copyRepetitions", comment: ""), systemImage: "repeat.circle")
-                                }
-                                Button {
-                                    withAnimation(.interactiveSpring()) {
-                                        database.duplicateLastSet(from: setGroup)
-                                    }
-                                } label: {
-                                    Label(NSLocalizedString("copySet", comment: ""), systemImage: "plus.square.on.square")
-                                }
-                            }
-                            Button {
-                                UIImpactFeedbackGenerator(style: .soft).impactOccurred()
-                                withAnimation(.interactiveSpring()) {
-                                    database.addSet(to: setGroup)
-                                }
-                            } label: {
-                                Label(
-                                    NSLocalizedString("addSet", comment: ""),
-                                    systemImage: "plus.circle.fill"
-                                )
-                                .foregroundStyle((setGroup.exercise?.muscleGroup?.color ?? .accentColor).gradient)
-                                .font(.system(.body, design: .rounded, weight: .bold))
-                                .padding(.vertical, 15)
-                                .frame(maxWidth: .infinity)
-                                .background(Color.accentColor.secondaryTranslucentBackground)
-                                .clipShape(Capsule())
-                            }
-                            menu
-                        }
-                        .padding(.horizontal, CELL_PADDING)
+                        controls(for: setGroup.exercise)
+                            .padding(.horizontal, CELL_PADDING)
                     }
                 }
             }
@@ -341,66 +278,104 @@ struct WorkoutSetGroupCell: View {
         }
     }
 
-    // MARK: - Superset pager
+    // MARK: - Superset card
 
-    /// The containerless superset: one full-size card per exercise, paged horizontally, each
-    /// with its own bulge socket, metric badge and add-set controls. The thread's horizontal
-    /// rail rides in the band above the pages (and below them when another group follows) and
-    /// scrolls WITH the pages, so the fixed trunk the list draws between cells always meets it
-    /// at a right angle, whatever the scroll position.
-    private func supersetPager(previousSetGroup: WorkoutSetGroup?) -> some View {
+    /// The superset: ONE card for the group — one index bulge, one note, one action bar — with
+    /// the exercises paged horizontally *inside* it. Only what belongs to a single exercise
+    /// rides in the pager (its header, its metric badge, its entry of every set); everything
+    /// the group owns is drawn once beneath the lanes.
+    ///
+    /// That is the whole point of the single card: every control in the bar acts on the set
+    /// GROUP — `addSet(to:)` appends one set carrying both exercises' entries, the menu edits
+    /// the group's type, note and exercise slots — so a per-exercise copy of it did the same
+    /// thing twice. No fork/merge rails either: with one card the list's trunk plugs into the
+    /// one socket exactly like it does for every other group.
+    private func supersetCard(previousSetGroup: WorkoutSetGroup?) -> some View {
         let exercises = [setGroup.exercise, setGroup.secondaryExercise].compactMap { $0 }
-        return ScrollView(.horizontal) {
-            HStack(alignment: .top, spacing: SetGroupThread.pageSpacing) {
+        return VStack(spacing: CELL_PADDING) {
+            supersetLanes(exercises: exercises, previousSetGroup: previousSetGroup)
+            SupersetLaneIndicator(
+                colors: exercises.map { $0.muscleGroup?.color ?? .accentColor },
+                selectedIndex: laneIndex(in: exercises)
+            )
+            if showsNoteField {
+                noteField
+                    .padding(.horizontal, CELL_PADDING)
+            }
+            if canEdit {
+                controls(for: setGroup.exercise)
+                    .padding(.horizontal, CELL_PADDING)
+            }
+        }
+        .padding(.bottom, canEdit ? CELL_PADDING : CELL_PADDING / 2)
+        .background(
+            RoundedRectangle(cornerRadius: 30)
+                .fill(.shadow(.inner(color: .white.opacity(0.04), radius: 3)))
+                .foregroundStyle(Color.secondaryBackground)
+        )
+        .cornerRadius(30)
+        .bulgeSocket(label: bulgeLabel)
+    }
+
+    /// The lanes themselves. No content margins: the snapped first lane sits flush with the
+    /// card's leading edge (and the last, clamped at the scroll bound, flush with the trailing
+    /// edge), so a lane's header lines up with a standard card's exactly. Scroll clipping stays
+    /// ON — the peeking neighbour is meant to be cut off by the card.
+    private func supersetLanes(
+        exercises: [Exercise],
+        previousSetGroup: WorkoutSetGroup?
+    ) -> some View {
+        ScrollView(.horizontal) {
+            HStack(alignment: .top, spacing: SetGroupThread.laneSpacing) {
                 ForEach(exercises, id: \.objectID) { exercise in
-                    SupersetExercisePage(
+                    SupersetExerciseLane(
                         setGroup: setGroup,
                         exercise: exercise,
-                        isPrimaryPage: exercise == setGroup.exercise,
-                        bulgeLabel: bulgeLabel,
+                        isPrimaryLane: exercise == setGroup.exercise,
                         focusedIntegerFieldIndex: $focusedIntegerFieldIndex,
                         previousSetGroup: previousSetGroup,
                         supplementaryText: supplementaryText,
                         showDetailAsSheet: showDetailAsSheet,
                         showPendingRestInTertiary: showPendingRestInTertiary,
                         isFieldFocused: isFieldFocused,
-                        isEditingNote: $isEditingNote,
                         onTapRestDuration: onTapRestDuration,
                         onTapPreviousSet: onTapPreviousSet,
                         onTapExerciseName: onTapExerciseName,
-                        onTapMetricBadge: onTapMetricBadge,
-                        groupMenu: AnyView(menu)
+                        onTapMetricBadge: onTapMetricBadge
                     )
                     .containerRelativeFrame(.horizontal) { length, _ in
-                        max(length - SetGroupThread.pageInset * 2, 100)
+                        SetGroupThread.laneWidth(in: length)
                     }
                 }
             }
             .scrollTargetLayout()
-            .supersetThreadRails(
-                pageCount: exercises.count,
-                showsFork: showsForkRail,
-                showsMerge: showsMergeRail
-            )
         }
-        // No content margins: the snapped first page sits flush with the leading edge (and
-        // the last page, clamped at the scroll bound, flush with the trailing edge) exactly
-        // like every non-superset cell. The pages being narrower than the column, their
-        // centers sit inside the fixed trunk's x — so the trunk always meets the rail's
-        // straight middle, and the elbows curve outward to the offset sockets. No scroll
-        // position can leave the trunk hanging past the rail's end.
         .scrollTargetBehavior(.viewAligned)
-        .scrollClipDisabled()
         .scrollIndicators(.hidden)
         .scrollPosition(id: $pagedExerciseID)
+        // A lane only counts as "on screen" once most of it is: the peeking neighbour is always
+        // partly visible, and at the default threshold both lanes would qualify at rest.
+        .onScrollTargetVisibilityChange(idType: NSManagedObjectID.self, threshold: 0.6) { visible in
+            guard let onScreen = visible.first else { return }
+            visibleExerciseID = onScreen
+        }
         .onChange(of: focusedIntegerFieldIndex) { _, newValue in
             autopageIfNeeded(for: newValue, exercises: exercises)
         }
     }
 
+    /// Which lane fills the card, for the dot indicator — nothing reported yet is the first.
+    private func laneIndex(in exercises: [Exercise]) -> Int {
+        guard
+            let currentID = visibleExerciseID ?? pagedExerciseID,
+            let index = exercises.firstIndex(where: { $0.objectID == currentID })
+        else { return 0 }
+        return index
+    }
+
     /// Keyboard next/previous walks a set's entries, which alternate exercises in a superset —
     /// when focus lands on a field whose entry belongs to the other exercise, the pager follows
-    /// so the focused field is never on an off-screen page. Focus indices are identity-keyed
+    /// so the focused field is never on an off-screen lane. Focus indices are identity-keyed
     /// (`Index.setID`), so the set is looked up by id; a focused set outside this group simply
     /// doesn't resolve.
     private func autopageIfNeeded(for index: IntegerField.Index?, exercises: [Exercise]) {
@@ -409,7 +384,7 @@ struct WorkoutSetGroupCell: View {
               workoutSet.entries.indices.contains(index.secondary),
               let owner = workoutSet.owningExercise(of: workoutSet.entries[index.secondary])
         else { return }
-        let currentID = pagedExerciseID ?? exercises.first?.objectID
+        let currentID = visibleExerciseID ?? pagedExerciseID ?? exercises.first?.objectID
         guard owner.objectID != currentID else { return }
         withAnimation(.snappy) { pagedExerciseID = owner.objectID }
     }
@@ -486,17 +461,8 @@ struct WorkoutSetGroupCell: View {
                         .foregroundStyle(.secondary)
                 }
             }
-            if isEditingNote || !(setGroup.note?.isEmpty ?? true) {
-                TextField("Note", text: Binding(get: { setGroup.note ?? "" }, set: { setGroup.note = $0 }), prompt: Text(NSLocalizedString("addNote...", comment: "")), axis: .vertical)
-                    .focused($isNoteFieldFocused)
-                    .onSubmit(of: .text) {
-                        setGroup.note = (setGroup.note ?? "") + "\n"
-                        isNoteFieldFocused = true
-                    }
-                    .lineLimit(1...5)
-                    .fixedSize(horizontal: false, vertical: true)
-                    .font(.footnote)
-                    .foregroundStyle(.tertiary)
+            if showsNoteField {
+                noteField
             }
         }
         .onChange(of: isNoteFieldFocused) {
@@ -506,7 +472,95 @@ struct WorkoutSetGroupCell: View {
         }
     }
 
+    private var showsNoteField: Bool {
+        isEditingNote || !(setGroup.note?.isEmpty ?? true)
+    }
+
+    /// The group's note. Inside the standard card it sits under the exercise header; a superset
+    /// draws it once below the lanes instead — it belongs to the group, not to either exercise,
+    /// and repeating it on both lanes was only ever a way to keep their heights equal.
+    private var noteField: some View {
+        TextField(
+            "Note",
+            text: Binding(get: { setGroup.note ?? "" }, set: { setGroup.note = $0 }),
+            prompt: Text(NSLocalizedString("addNote...", comment: "")),
+            axis: .vertical
+        )
+        .focused($isNoteFieldFocused)
+        .onSubmit(of: .text) {
+            setGroup.note = (setGroup.note ?? "") + "\n"
+            isNoteFieldFocused = true
+        }
+        .lineLimit(1 ... 5)
+        .fixedSize(horizontal: false, vertical: true)
+        .font(.footnote)
+        .foregroundStyle(.tertiary)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
     // MARK: - Supporting Views
+
+    /// Duplicate-last-set, add-set and the group menu — the set group's controls, drawn once per
+    /// card. All three act on the group: a superset's two lanes share this one bar rather than
+    /// each carrying a copy that would do the very same thing.
+    private func controls(for exercise: Exercise?) -> some View {
+        HStack(spacing: 8) {
+            Button {
+                UIImpactFeedbackGenerator(style: .soft).impactOccurred()
+                withAnimation(.interactiveSpring()) {
+                    database.duplicateLastSet(from: setGroup)
+                }
+            } label: {
+                Image(systemName: "plus.square.on.square")
+                    .foregroundStyle((exercise?.muscleGroup?.color ?? .accentColor).gradient)
+                    .font(.system(.body, design: .rounded, weight: .bold))
+                    .padding(15)
+                    .background(Color.accentColor.secondaryTranslucentBackground)
+                    .clipShape(Capsule())
+            }
+            .contextMenu {
+                Button {
+                    withAnimation(.interactiveSpring()) {
+                        database.duplicateLastWeight(from: setGroup)
+                    }
+                } label: {
+                    Label(NSLocalizedString("copyWeight", comment: ""), systemImage: "scalemass")
+                }
+                Button {
+                    withAnimation(.interactiveSpring()) {
+                        database.duplicateLastRepetitions(from: setGroup)
+                    }
+                } label: {
+                    Label(NSLocalizedString("copyRepetitions", comment: ""), systemImage: "repeat.circle")
+                }
+                Button {
+                    withAnimation(.interactiveSpring()) {
+                        database.duplicateLastSet(from: setGroup)
+                    }
+                } label: {
+                    Label(NSLocalizedString("copySet", comment: ""), systemImage: "plus.square.on.square")
+                }
+            }
+            Button {
+                UIImpactFeedbackGenerator(style: .soft).impactOccurred()
+                withAnimation(.interactiveSpring()) {
+                    database.addSet(to: setGroup)
+                }
+            } label: {
+                Label(
+                    NSLocalizedString("addSet", comment: ""),
+                    systemImage: "plus.circle.fill"
+                )
+                .foregroundStyle((exercise?.muscleGroup?.color ?? .accentColor).gradient)
+                .font(.system(.body, design: .rounded, weight: .bold))
+                .padding(.vertical, 15)
+                .frame(maxWidth: .infinity)
+                .background(Color.accentColor.secondaryTranslucentBackground)
+                .clipShape(Capsule())
+            }
+            menu
+        }
+    }
 
     private var menu: some View {
         Menu {
@@ -716,43 +770,38 @@ extension WorkoutSetGroupCell: Equatable {
     }
 }
 
-// MARK: - Superset exercise page
+// MARK: - Superset exercise lane
 
-/// One exercise's card inside the superset pager: its own bulge socket, header, metric badge,
-/// set column (only this exercise's entry per set) and add-set controls. The group-level menu is
-/// built by the cell (it owns the exercise-selection and note state) and passed in.
-private struct SupersetExercisePage: View {
+/// One exercise's lane inside the superset card: its header, its metric badge and its entry of
+/// every set — nothing else. Deliberately containerless: the card, the index bulge, the note and
+/// the action bar all belong to the GROUP and are drawn once by the cell around the pager.
+private struct SupersetExerciseLane: View {
     @Environment(\.canEdit) var canEdit: Bool
     @EnvironmentObject var database: Database
 
     @ObservedObject var setGroup: WorkoutSetGroup
     let exercise: Exercise
-    let isPrimaryPage: Bool
-    let bulgeLabel: String?
+    let isPrimaryLane: Bool
     @Binding var focusedIntegerFieldIndex: IntegerField.Index?
     let previousSetGroup: WorkoutSetGroup?
     let supplementaryText: String?
     let showDetailAsSheet: Bool
     let showPendingRestInTertiary: Bool
     let isFieldFocused: Bool
-    @Binding var isEditingNote: Bool
     let onTapRestDuration: ((WorkoutSet) -> Void)?
     let onTapPreviousSet: ((Exercise) -> Void)?
     let onTapExerciseName: ((Exercise) -> Void)?
     let onTapMetricBadge: ((WorkoutSetGroup, Exercise?, CGRect) -> Void)?
-    let groupMenu: AnyView
 
     @State private var metricBadgeWidth: CGFloat = 0
     @State private var nameSlotWidth: CGFloat = 0
-    @FocusState private var isNoteFieldFocused: Bool
 
     var body: some View {
-        card
-            .bulgeSocket(label: bulgeLabel)
+        lane
             .accentColor(exercise.muscleGroup?.color ?? .accentColor)
     }
 
-    private var card: some View {
+    private var lane: some View {
         VStack(spacing: CELL_PADDING) {
             header
                 .padding([.top, .horizontal], CELL_PADDING)
@@ -800,18 +849,7 @@ private struct SupersetExercisePage: View {
             }
             .padding(.horizontal, CELL_PADDING / 2)
             .animation(.interactiveSpring(), value: setGroup.sets)
-            if canEdit {
-                controls
-                    .padding(.horizontal, CELL_PADDING)
-            }
         }
-        .padding(.bottom, canEdit ? CELL_PADDING : CELL_PADDING / 2)
-        .background(
-            RoundedRectangle(cornerRadius: 30)
-                .fill(.shadow(.inner(color: .white.opacity(0.04), radius: 3)))
-                .foregroundStyle(Color.secondaryBackground)
-        )
-        .cornerRadius(30)
         .overlay(alignment: .topTrailing) {
             badgeOverlay
         }
@@ -836,7 +874,7 @@ private struct SupersetExercisePage: View {
                         Text(exercise.muscleGroup?.description ?? "")
                             .foregroundColor(exercise.muscleGroup?.color ?? .accentColor)
                         Spacer()
-                        if isPrimaryPage, let supplementaryText {
+                        if isPrimaryLane, let supplementaryText {
                             Text(supplementaryText)
                                 .foregroundStyle(.secondary)
                                 .fontWeight(.medium)
@@ -851,89 +889,6 @@ private struct SupersetExercisePage: View {
                 }
                 Spacer()
             }
-            // The note is a group-level field, rendered on every page (bound to the same text)
-            // so the pages keep identical heights and the thread's merge rail meets them evenly.
-            if isEditingNote || !(setGroup.note?.isEmpty ?? true) {
-                TextField(
-                    "Note",
-                    text: Binding(get: { setGroup.note ?? "" }, set: { setGroup.note = $0 }),
-                    prompt: Text(NSLocalizedString("addNote...", comment: "")),
-                    axis: .vertical
-                )
-                .focused($isNoteFieldFocused)
-                .onSubmit(of: .text) {
-                    setGroup.note = (setGroup.note ?? "") + "\n"
-                    isNoteFieldFocused = true
-                }
-                .lineLimit(1 ... 5)
-                .fixedSize(horizontal: false, vertical: true)
-                .font(.footnote)
-                .foregroundStyle(.tertiary)
-            }
-        }
-        .onChange(of: isNoteFieldFocused) {
-            if !isNoteFieldFocused {
-                isEditingNote = false
-            }
-        }
-    }
-
-    private var controls: some View {
-        HStack(spacing: 8) {
-            Button {
-                UIImpactFeedbackGenerator(style: .soft).impactOccurred()
-                withAnimation(.interactiveSpring()) {
-                    database.duplicateLastSet(from: setGroup)
-                }
-            } label: {
-                Image(systemName: "plus.square.on.square")
-                    .foregroundStyle((exercise.muscleGroup?.color ?? .accentColor).gradient)
-                    .font(.system(.body, design: .rounded, weight: .bold))
-                    .padding(15)
-                    .background(Color.accentColor.secondaryTranslucentBackground)
-                    .clipShape(Capsule())
-            }
-            .contextMenu {
-                Button {
-                    withAnimation(.interactiveSpring()) {
-                        database.duplicateLastWeight(from: setGroup)
-                    }
-                } label: {
-                    Label(NSLocalizedString("copyWeight", comment: ""), systemImage: "scalemass")
-                }
-                Button {
-                    withAnimation(.interactiveSpring()) {
-                        database.duplicateLastRepetitions(from: setGroup)
-                    }
-                } label: {
-                    Label(NSLocalizedString("copyRepetitions", comment: ""), systemImage: "repeat.circle")
-                }
-                Button {
-                    withAnimation(.interactiveSpring()) {
-                        database.duplicateLastSet(from: setGroup)
-                    }
-                } label: {
-                    Label(NSLocalizedString("copySet", comment: ""), systemImage: "plus.square.on.square")
-                }
-            }
-            Button {
-                UIImpactFeedbackGenerator(style: .soft).impactOccurred()
-                withAnimation(.interactiveSpring()) {
-                    database.addSet(to: setGroup)
-                }
-            } label: {
-                Label(
-                    NSLocalizedString("addSet", comment: ""),
-                    systemImage: "plus.circle.fill"
-                )
-                .foregroundStyle((exercise.muscleGroup?.color ?? .accentColor).gradient)
-                .font(.system(.body, design: .rounded, weight: .bold))
-                .padding(.vertical, 15)
-                .frame(maxWidth: .infinity)
-                .background(Color.accentColor.secondaryTranslucentBackground)
-                .clipShape(Capsule())
-            }
-            groupMenu
         }
     }
 
@@ -1102,7 +1057,7 @@ private final class ExerciseHistoryBestsCache: @unchecked Sendable {
 /// so the badge's pill and the panel's spelled-out values can never tell different stories.
 private struct SetGroupMetricComparison {
     let setGroup: WorkoutSetGroup
-    /// The exercise this comparison scores. Each superset page passes its own; nil falls back to
+    /// The exercise this comparison scores. Each superset lane passes its own; nil falls back to
     /// the group's primary exercise (the only one there is everywhere else).
     var subjectExercise: Exercise? = nil
 
@@ -1238,7 +1193,7 @@ private struct SetGroupMetricComparison {
 /// they dismiss each other (UIKit only presents one thing per view controller at a time).
 private struct MetricBadgeView: View {
     @ObservedObject var setGroup: WorkoutSetGroup
-    /// The exercise this badge scores — each superset page shows its own badge; nil falls back
+    /// The exercise this badge scores — each superset lane shows its own badge; nil falls back
     /// to the group's primary exercise.
     let subjectExercise: Exercise?
     /// Observed so the badge re-renders on every recorder change. Editing a set mutates the set —

--- a/LOGIT/SharedUI/Views/SetGroupThread.swift
+++ b/LOGIT/SharedUI/Views/SetGroupThread.swift
@@ -3,8 +3,8 @@
 //  LOGIT
 //
 //  The "thread": the connecting line that runs down a workout's (or template's) set-group
-//  list, plus the bulge sockets it plugs into and the rails it forks into across a superset's
-//  horizontally paged exercises.
+//  list, plus the bulge sockets it plugs into. A superset is one card like any other group —
+//  its exercises page horizontally *inside* that card — so the thread never forks.
 //
 //  Shared by the workout recorder/detail and the template editor/detail so both stay one
 //  visual system — see AGENT.md, "Templates mirror workouts". Anything defined here is the
@@ -25,15 +25,17 @@ enum SetGroupThread {
     /// How far a segment draws past its own bounds into the neighbouring fill. Joins are
     /// sealed by overlap, never by exact edge-kissing — antialiasing opens hairlines there.
     static let jointOverlap: CGFloat = 2
-    /// Height of the band above (and below) a superset's pages where the fork/merge rails
-    /// and their drops into the bulges are drawn.
-    static let railZoneHeight: CGFloat = 16
-    /// Horizontal inset of a snapped superset page: pages are this much narrower than the
-    /// column on each side, so the first page still sits flush with the list's leading edge
-    /// while the neighbour peeks. Keeps every page center inside the fixed trunk's x, so the
-    /// trunk always meets the rail's straight middle.
-    static let pageInset: CGFloat = 24
-    static let pageSpacing: CGFloat = 12
+    /// Horizontal inset of a snapped superset lane, per side: lanes are this much narrower
+    /// than the card they page inside, so the neighbouring lane peeks and the group always
+    /// shows there is more to swipe to. The first lane still sits flush with the card's
+    /// leading edge, the last (clamped at the scroll bound) flush with the trailing one.
+    static let laneInset: CGFloat = 24
+    static let laneSpacing: CGFloat = 12
+
+    /// Width of one superset lane inside a card of `containerWidth`.
+    static func laneWidth(in containerWidth: CGFloat) -> CGFloat {
+        max(containerWidth - laneInset * 2, 100)
+    }
 
     /// "2 of 5" — a group's place in its workout/template, shown in the bulge socket.
     static func indexLabel(index: Int?, count: Int) -> String? {
@@ -175,90 +177,35 @@ struct SetGroupBulgeShape: Shape {
     }
 }
 
-// MARK: - Superset rails
+// MARK: - Superset lane indicator
 
-extension View {
-    /// Wraps a superset's paged content in the thread's fork (above) and merge (below) rails,
-    /// reserving their bands as padding. Applied to the scroll CONTENT, so the rails move with
-    /// the pages while the list's trunk stays fixed — that's what keeps the T-junction square
-    /// at every scroll position. A rail is omitted when nothing feeds it: no group before the
-    /// superset means no fork, none after means no merge.
-    func supersetThreadRails(pageCount: Int, showsFork: Bool, showsMerge: Bool) -> some View {
-        padding(.top, showsFork ? SetGroupThread.railZoneHeight : 0)
-            .padding(.bottom, showsMerge ? SetGroupThread.railZoneHeight : 0)
-            .overlay(alignment: .top) {
-                if showsFork {
-                    supersetRail(pageCount: pageCount, flipped: false)
-                }
+/// Which lane of a superset card is on screen: one dot per exercise, the current one filled in
+/// its own muscle colour. It sits between the lanes and the card's action bar — and that bar
+/// belongs to the GROUP, so once you've swiped, these dots and the lane's own header are what
+/// say which exercise the fields above are for.
+struct SupersetLaneIndicator: View {
+    /// One colour per lane, in lane order.
+    let colors: [Color]
+    let selectedIndex: Int
+
+    static let dotSize: CGFloat = 6
+
+    var body: some View {
+        HStack(spacing: 6) {
+            ForEach(Array(colors.enumerated()), id: \.offset) { index, color in
+                Circle()
+                    .foregroundStyle(
+                        index == selectedIndex
+                            ? AnyShapeStyle(color.gradient)
+                            : AnyShapeStyle(Color.tertiaryLabel)
+                    )
+                    .frame(width: Self.dotSize, height: Self.dotSize)
             }
-            .overlay(alignment: .bottom) {
-                if showsMerge {
-                    supersetRail(pageCount: pageCount, flipped: true)
-                }
-            }
-    }
-
-    private func supersetRail(pageCount: Int, flipped: Bool) -> some View {
-        SupersetRailShape(
-            pageCount: pageCount,
-            pageSpacing: SetGroupThread.pageSpacing,
-            flipped: flipped
-        )
-        .stroke(style: StrokeStyle(lineWidth: SetGroupThread.lineWidth, lineCap: .round))
-        .foregroundStyle(Color.threadLine)
-        .frame(height: SetGroupThread.railZoneHeight)
-    }
-}
-
-/// The thread's horizontal rail across a superset's pages, drawn in the band above (or,
-/// flipped, below) them and scrolling with them: rounded elbows turn down into the first and
-/// last page's center, straight drops serve any pages in between. Page centers are derived
-/// from the band's own width, so the shape needs no measured geometry.
-struct SupersetRailShape: Shape {
-    let pageCount: Int
-    let pageSpacing: CGFloat
-    var flipped: Bool = false
-    var cornerRadius: CGFloat = 10
-
-    func path(in rect: CGRect) -> Path {
-        var path = Path()
-        guard pageCount > 0 else { return path }
-        let pageWidth = (rect.width - CGFloat(pageCount - 1) * pageSpacing) / CGFloat(pageCount)
-        let centers = (0 ..< pageCount).map { pageWidth / 2 + CGFloat($0) * (pageWidth + pageSpacing) }
-        let railY: CGFloat = SetGroupThread.lineWidth / 2
-        // Verticals overshoot the band by a couple of points into the neighboring fill (bulge
-        // below, card above once flipped) so no join can open an antialiasing hairline.
-        let overshoot = rect.height + SetGroupThread.jointOverlap
-        guard let first = centers.first, let last = centers.last, pageCount > 1 else {
-            path.move(to: CGPoint(x: centers[0], y: 0))
-            path.addLine(to: CGPoint(x: centers[0], y: overshoot))
-            return flipped ? path.flippedVertically(height: rect.height) : path
         }
-        path.move(to: CGPoint(x: first, y: overshoot))
-        path.addLine(to: CGPoint(x: first, y: railY + cornerRadius))
-        path.addArc(
-            center: CGPoint(x: first + cornerRadius, y: railY + cornerRadius),
-            radius: cornerRadius,
-            startAngle: .degrees(180), endAngle: .degrees(270), clockwise: false
-        )
-        path.addLine(to: CGPoint(x: last - cornerRadius, y: railY))
-        path.addArc(
-            center: CGPoint(x: last - cornerRadius, y: railY + cornerRadius),
-            radius: cornerRadius,
-            startAngle: .degrees(270), endAngle: .degrees(0), clockwise: false
-        )
-        path.addLine(to: CGPoint(x: last, y: overshoot))
-        for center in centers.dropFirst().dropLast() {
-            path.move(to: CGPoint(x: center, y: railY))
-            path.addLine(to: CGPoint(x: center, y: overshoot))
-        }
-        return flipped ? path.flippedVertically(height: rect.height) : path
-    }
-}
-
-private extension Path {
-    func flippedVertically(height: CGFloat) -> Path {
-        applying(CGAffineTransform(scaleX: 1, y: -1).translatedBy(x: 0, y: -height))
+        .animation(.snappy, value: selectedIndex)
+        // The lane's own exercise header already announces which exercise is on screen; a
+        // second, wordless announcement of the same thing only adds noise in VoiceOver.
+        .accessibilityHidden(true)
     }
 }
 


### PR DESCRIPTION
A superset rendered as two independent cards, so everything the *group* owns was drawn twice: the `3 of 5` socket, the note, and — the actual problem — **Add Set, duplicate and the ⋯ menu**. All three already act on the set group (`addSet(to:)` appends one set carrying both exercises' entries; the menu edits the group's type, note and exercise slots), so the second copy of each button did exactly what the first one did.

The exercises now page horizontally **inside a single card** as containerless lanes — header, metric badge, and that exercise's entry per set. The socket, the note and one unchanged action bar sit beneath them. The badge stays per lane: it scores one exercise against its own history.

### What that let us delete

- **The fork/merge rails.** `SupersetRailShape`, `supersetThreadRails`, `railZoneHeight` and `flippedVertically` existed only to split the thread across two cards and rejoin it. With one card the trunk plugs into the one socket like every other group.
- **The duplicated control bar.** Both copies collapsed into a single `controls(for:)`, now shared with the standard card too. It keeps the group's *primary* muscle colour on both lanes — the bar acts on the group, so re-tinting on swipe would imply it belongs to whichever exercise is showing.
- **The doubled note.** It was rendered on both pages, bound to the same text, only to keep their heights equal for the merge rail.

New `SupersetLaneIndicator` dots sit between the lanes and the bar; without the rails, they and the lane header are what say which exercise is up.

### One bug worth knowing about

`scrollPosition(id:)` could not drive those dots. It names the item at the scroll view's **leading edge**, and because lanes are narrower than the card, the trailing-snapped lane never has its leading edge there — the binding kept naming the neighbour peeking in that corner, so the dots sat on lane 1 forever. `anchor: .center` did not fix it. `onScrollTargetVisibilityChange(threshold: 0.6)` does, because it asks the question directly: which lane actually fills the card. It writes a separate `visibleExerciseID` that now also feeds `autopageIfNeeded`'s notion of the current lane; `pagedExerciseID` stays purely as the programmatic write channel.

### Templates

Mirrored in the same pass (AGENT.md, "Templates mirror workouts"), and their set rows drop the `Set 1` prefix for the workout side's bare `1` — the last thing making the two set rows read differently.

### Verification

iPhone 17 Pro / iOS 26.4, all green with no test changes needed:

- `testRecorderSupersetPager` — both lanes, dots correct
- `testTemplateEditorSuperset` — detail + editor, both lanes
- `testWorkoutDetailSuperset` — read-only card, no bar
- `testEmptyScenario` / `testOneWorkoutScenario` / `testManyWorkoutsScenario` / `testFreeUserScenario`
- `testRecorderInteractionFlow`, `testRecorderFocusStaysOnTappedFieldAfterInsertingEarlierSet`

Before/after captures and the five layout options this came from: https://claude.ai/code/artifact/b6e1b8a2-0e19-4cc2-82ab-5d6a365a7e13

Net −120 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)