### PR TITLE
Strength detail: hold to select, highlight instead of filter

### DIFF
--- a/LOGIT/Core/Environment/de.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/de.lproj/Localizable.strings
@@ -1129,6 +1129,7 @@
 "allExercises" = "Alle Übungen";
 "strengthTapGroup" = "Tippe eine Gruppe an";
 "strengthBiggestMovers" = "Größte Veränderungen";
-"strengthScrubHint" = "Sortiert von schwach zu stark · zum Ansehen ziehen";
+"strengthHoldHint" = "Von schwach zu stark · Balken halten oder Gruppe wählen";
+"strengthBestMover" = "Größter Zuwachs";
 "showLess" = "Weniger anzeigen";
 "strengthInfo" = "Das beste geschätzte 1RM jeder Übung der letzten %d Wochen im Vergleich zu den %d davor, gemittelt und nach Anzahl der Sätze gewichtet. Cardio- und Körpergewichtssätze haben kein 1RM und zählen nicht.";

--- a/LOGIT/Core/Environment/en.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/en.lproj/Localizable.strings
@@ -1133,6 +1133,7 @@
 "allExercises" = "All exercises";
 "strengthTapGroup" = "Tap a group to focus";
 "strengthBiggestMovers" = "Biggest movers";
-"strengthScrubHint" = "Ranked worst to best · drag to inspect one";
+"strengthHoldHint" = "Ranked worst to best · hold a bar, or pick a group";
+"strengthBestMover" = "Best mover";
 "showLess" = "Show less";
 "strengthInfo" = "Each exercise's best estimated 1RM in the last %d weeks against the %d before, averaged and weighted by how many sets you did. Cardio and bodyweight sets carry no 1RM and don't count.";

--- a/LOGIT/Core/Environment/es.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/es.lproj/Localizable.strings
@@ -1133,6 +1133,7 @@
 "allExercises" = "Todos los ejercicios";
 "strengthTapGroup" = "Toca un grupo para enfocarlo";
 "strengthBiggestMovers" = "Mayores cambios";
-"strengthScrubHint" = "De peor a mejor · desliza para ver uno";
+"strengthHoldHint" = "De peor a mejor · mantén una barra o elige un grupo";
+"strengthBestMover" = "Mayor avance";
 "showLess" = "Ver menos";
 "strengthInfo" = "El mejor 1RM estimado de cada ejercicio en las últimas %d semanas frente a las %d anteriores, promediado y ponderado por el número de series. Las series de cardio y peso corporal no tienen 1RM y no cuentan.";

--- a/LOGIT/Core/Environment/fr.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/fr.lproj/Localizable.strings
@@ -1133,6 +1133,7 @@
 "allExercises" = "Tous les exercices";
 "strengthTapGroup" = "Touchez un groupe pour l'isoler";
 "strengthBiggestMovers" = "Plus grands changements";
-"strengthScrubHint" = "Du plus faible au plus fort · glissez pour en voir un";
+"strengthHoldHint" = "Du plus faible au plus fort · maintenez une barre ou choisissez un groupe";
+"strengthBestMover" = "Meilleure progression";
 "showLess" = "Voir moins";
 "strengthInfo" = "Le meilleur 1RM estimé de chaque exercice sur les %d dernières semaines par rapport aux %d précédentes, moyenné et pondéré par le nombre de séries. Les séries de cardio et au poids du corps n'ont pas de 1RM et ne comptent pas.";

--- a/LOGIT/Core/Environment/it.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/it.lproj/Localizable.strings
@@ -1133,6 +1133,7 @@
 "allExercises" = "Tutti gli esercizi";
 "strengthTapGroup" = "Tocca un gruppo per isolarlo";
 "strengthBiggestMovers" = "Cambiamenti maggiori";
-"strengthScrubHint" = "Dal peggiore al migliore · trascina per vederne uno";
+"strengthHoldHint" = "Dal peggiore al migliore · tieni premuta una barra o scegli un gruppo";
+"strengthBestMover" = "Miglior progresso";
 "showLess" = "Mostra meno";
 "strengthInfo" = "Il miglior 1RM stimato di ogni esercizio nelle ultime %d settimane rispetto alle %d precedenti, mediato e pesato in base al numero di serie. Le serie di cardio e a corpo libero non hanno 1RM e non contano.";

--- a/LOGIT/Core/Environment/ja.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/ja.lproj/Localizable.strings
@@ -1133,6 +1133,7 @@
 "allExercises" = "すべてのエクササイズ";
 "strengthTapGroup" = "グループをタップして絞り込み";
 "strengthBiggestMovers" = "変化が大きい種目";
-"strengthScrubHint" = "小さい順 · ドラッグして確認";
+"strengthHoldHint" = "小さい順 · バーを長押し、または部位を選択";
+"strengthBestMover" = "最も伸びた種目";
 "showLess" = "表示を減らす";
 "strengthInfo" = "各エクササイズの直近%d週間の推定1RM最高値を、その前の%d週間と比較し、セット数で重み付けして平均した値です。カーディオと自重のセットは1RMがないため含まれません。";

--- a/LOGIT/Core/Environment/ko.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/ko.lproj/Localizable.strings
@@ -1133,6 +1133,7 @@
 "allExercises" = "모든 운동";
 "strengthTapGroup" = "그룹을 탭해 집중해서 보기";
 "strengthBiggestMovers" = "변화가 큰 운동";
-"strengthScrubHint" = "낮은 순 정렬 · 드래그해서 확인";
+"strengthHoldHint" = "낮은 순 · 막대를 길게 누르거나 부위 선택";
+"strengthBestMover" = "가장 향상된 종목";
 "showLess" = "간단히 보기";
 "strengthInfo" = "각 운동의 최근 %d주 최고 추정 1RM을 이전 %d주와 비교해 세트 수로 가중 평균한 값입니다. 유산소와 맨몸 세트는 1RM이 없어 포함되지 않습니다.";

--- a/LOGIT/Core/Environment/pt-BR.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/pt-BR.lproj/Localizable.strings
@@ -1133,6 +1133,7 @@
 "allExercises" = "Todos os exercícios";
 "strengthTapGroup" = "Toque em um grupo para focar";
 "strengthBiggestMovers" = "Maiores mudanças";
-"strengthScrubHint" = "Do pior ao melhor · arraste para ver um";
+"strengthHoldHint" = "Do pior ao melhor · segure uma barra ou escolha um grupo";
+"strengthBestMover" = "Maior avanço";
 "showLess" = "Ver menos";
 "strengthInfo" = "O melhor 1RM estimado de cada exercício nas últimas %d semanas em relação às %d anteriores, com média ponderada pelo número de séries. Séries de cardio e peso corporal não têm 1RM e não contam.";

--- a/LOGIT/Features/Home/StrengthBarChart.swift
+++ b/LOGIT/Features/Home/StrengthBarChart.swift
@@ -31,8 +31,11 @@ struct StrengthBarChart: View {
     var spacing: CGFloat = 2
     /// Drawn unless the caller is showing a chart small enough that a hairline would be noise.
     var showsZeroLine: Bool = true
-    /// Set by `StrengthScreen` to drive scrub selection; nil on the tile, which isn't interactive.
+    /// Set by `StrengthScreen` to drive selection; nil on the tile, which isn't interactive.
     var selection: Binding<NSManagedObjectID?>?
+    /// When set, that group's bars keep their colour and every other bar drops to neutral grey —
+    /// the chart stays whole instead of filtering down, so a group is read *against* the rest.
+    var highlightedGroup: MuscleGroup?
 
     /// Below this the bars stop reading as bars, so the gap gives way first and then the bar itself
     /// is floored — past that point the chart is a texture, which is an acceptable thing for a tile
@@ -42,6 +45,9 @@ struct StrengthBarChart: View {
     /// step still visible on the tile surface.
     private static let rampSteps = 6
     private static let rampFloor: Double = 0.35
+    /// Declines keep the hue and lose the solidity — dimmer than the ramp's own floor so they read
+    /// as below the line rather than as a very small gain.
+    private static let declineOpacity: Double = 0.22
     /// Shortest a bar can be drawn. Every exercise in the ranking keeps one: a flat lift is part of
     /// the ranking and should hold its column, and columns that render nothing leave the movers
     /// crowded into a corner of an otherwise empty chart.
@@ -94,7 +100,7 @@ struct StrengthBarChart: View {
                 }
             }
             .contentShape(Rectangle())
-            .gesture(scrubGesture(ranked: ranked, width: geo.size.width))
+            .gesture(selectGesture(ranked: ranked, width: geo.size.width))
         }
     }
 
@@ -124,7 +130,7 @@ struct StrengthBarChart: View {
                     topTrailingRadius: change.percentChange > 0 ? 2 : 0,
                     style: .continuous
                 )
-                .fill(color(for: change.percentChange, maxGain: maxGain))
+                .fill(color(for: change, maxGain: maxGain))
                 .frame(height: max(magnitude, Self.minimumBarHeight))
                 .overlay {
                     if isSelected {
@@ -145,13 +151,27 @@ struct StrengthBarChart: View {
         .frame(height: height)
     }
 
-    /// Gains step through the accent ramp by rank; declines are flat neutral grey.
-    private func color(for percent: Double, maxGain: Double) -> Color {
-        guard percent > 0 else { return Color.secondaryLabel.opacity(0.55) }
-        guard maxGain > 0 else { return Color.accentColor }
-        let step = min(Int(percent / maxGain * Double(Self.rampSteps)), Self.rampSteps - 1)
+    /// Colour carries two things at once: identity and direction.
+    ///
+    /// Identity is the base hue — the accent normally, the muscle group's own colour once a group is
+    /// highlighted, and neutral grey for every bar outside that group. Direction is opacity: gains
+    /// step through the six-step ramp by rank, declines are drawn translucent in the same hue rather
+    /// than recoloured, so a decline reads as "less of this" instead of as a different category.
+    private func color(for change: StrengthProgress.ExerciseChange, maxGain: Double) -> Color {
+        let base: Color
+        if let highlightedGroup {
+            guard change.muscleGroup == highlightedGroup else {
+                return Color.secondaryLabel.opacity(change.percentChange > 0 ? 0.5 : 0.25)
+            }
+            base = highlightedGroup.color
+        } else {
+            base = .accentColor
+        }
+        guard change.percentChange > 0 else { return base.opacity(Self.declineOpacity) }
+        guard maxGain > 0 else { return base }
+        let step = min(Int(change.percentChange / maxGain * Double(Self.rampSteps)), Self.rampSteps - 1)
         let t = Double(step) / Double(Self.rampSteps - 1)
-        return Color.accentColor.opacity(Self.rampFloor + (1 - Self.rampFloor) * t)
+        return base.opacity(Self.rampFloor + (1 - Self.rampFloor) * t)
     }
 
     /// Keeps the 2 pt gap while the bars can afford it, then closes it rather than letting the bars
@@ -163,17 +183,29 @@ struct StrengthBarChart: View {
         return max((width - Self.minimumBarWidth * CGFloat(count)) / CGFloat(count - 1), 0)
     }
 
-    /// Nearest-column scrubbing. Individual bars are far under a tappable size at any realistic
-    /// exercise count, so the whole plot is the target and the finger picks the closest column.
-    private func scrubGesture(ranked: [StrengthProgress.ExerciseChange], width: CGFloat) -> some Gesture {
-        DragGesture(minimumDistance: 0)
+    /// Press and hold to select, then keep scrubbing while the finger is down.
+    ///
+    /// Not a plain drag: the chart lives inside a ScrollView, and a zero-distance drag claims every
+    /// touch that starts on the plot — so scrolling the screen from the chart became impossible and
+    /// a stray flick reassigned the selection. Requiring the hold first leaves the scroll gesture
+    /// untouched, and it makes selection deliberate rather than something a passing finger does.
+    /// The muscle-group grid below is the other way in, and it needs no gesture at all.
+    private func selectGesture(ranked: [StrengthProgress.ExerciseChange], width: CGFloat) -> some Gesture {
+        LongPressGesture(minimumDuration: 0.2)
+            .sequenced(before: DragGesture(minimumDistance: 0))
             .onChanged { value in
-                guard let selection, !ranked.isEmpty, width > 0 else { return }
-                let fraction = min(max(value.location.x / width, 0), 0.9999)
-                let index = Int(fraction * CGFloat(ranked.count))
-                let id = ranked[min(index, ranked.count - 1)].id
-                if selection.wrappedValue != id { selection.wrappedValue = id }
+                guard case let .second(_, drag?) = value else { return }
+                select(at: drag.location.x, ranked: ranked, width: width)
             }
+    }
+
+    /// Individual bars are far under a tappable size at any realistic exercise count, so the whole
+    /// plot is the target and the finger picks the closest column.
+    private func select(at x: CGFloat, ranked: [StrengthProgress.ExerciseChange], width: CGFloat) {
+        guard let selection, !ranked.isEmpty, width > 0 else { return }
+        let fraction = min(max(x / width, 0), 0.9999)
+        let id = ranked[min(Int(fraction * CGFloat(ranked.count)), ranked.count - 1)].id
+        if selection.wrappedValue != id { selection.wrappedValue = id }
     }
 }
 

--- a/LOGIT/Features/Home/StrengthScreen.swift
+++ b/LOGIT/Features/Home/StrengthScreen.swift
@@ -54,6 +54,7 @@ struct StrengthScreen: View {
             .padding(.top)
             .padding(.bottom, SCROLLVIEW_BOTTOM_PADDING)
         }
+        .sensoryFeedback(.selection, trigger: selectedGroup)
         .isBlockedWithoutPro()
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
@@ -90,14 +91,22 @@ struct StrengthScreen: View {
 
     // MARK: Hero
 
+    /// The figure, left-aligned like the tile's, with whichever exercise the screen is currently
+    /// talking about beside it.
+    ///
+    /// It has three states and they share one shape. With nothing selected it shows the scope's
+    /// change and names its **best mover** — the single most useful thing the number can't say.
+    /// Hold a bar and it becomes that exercise: its own change, in its muscle group's colour, with
+    /// its name on the right. Selecting a group swaps the scope. The caption underneath is gone;
+    /// the window picker directly above already states the period, and saying it twice was noise.
     private var hero: some View {
-        VStack(spacing: 10) {
-            if let percent = progress.percentChange(in: selectedGroup) {
-                StrengthHeroPill(percentChange: percent)
-                Text("\(scopeName) · \(window.comparisonCaption)")
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
-                    .multilineTextAlignment(.center)
+        HStack(alignment: .center, spacing: 14) {
+            if let percent = heroPercent {
+                figure(percent, color: heroColor)
+                Spacer(minLength: 8)
+                if let subject = heroSubject {
+                    subjectLabel(subject)
+                }
             } else {
                 // Same gray ring the tile and the core-stat tiles wear while they wait for data.
                 TrendPlaceholder(
@@ -110,12 +119,88 @@ struct StrengthScreen: View {
                 .padding(.vertical, 16)
             }
         }
-        .frame(maxWidth: .infinity)
+        .frame(maxWidth: .infinity, alignment: .leading)
         .animation(.snappy, value: selectedGroup)
+        .animation(.snappy, value: selectedExerciseID)
     }
 
-    private var scopeName: String {
-        selectedGroup?.description ?? NSLocalizedString("allExercises", comment: "")
+    /// Selected exercise wins, then the selected group, then the whole training.
+    private var heroPercent: Double? {
+        selectedChange?.percentChange ?? progress.percentChange(in: selectedGroup)
+    }
+
+    private var heroColor: Color {
+        selectedChange?.muscleGroup.color ?? selectedGroup?.color ?? .accentColor
+    }
+
+    /// The exercise the hero is naming: the selected one, or the scope's biggest gainer.
+    private var heroSubject: StrengthProgress.ExerciseChange? {
+        selectedChange ?? progress.exerciseChanges(in: selectedGroup)
+            .max { $0.percentChange < $1.percentChange }
+    }
+
+    private var selectedChange: StrengthProgress.ExerciseChange? {
+        guard let selectedExerciseID else { return nil }
+        return progress.changes.first { $0.id == selectedExerciseID }
+    }
+
+    private func figure(_ percent: Double, color: Color) -> some View {
+        HStack(alignment: .center, spacing: 4) {
+            Image(systemName: strengthTrendSymbol(percent))
+                .font(.system(size: 22, weight: .black))
+            Text(String(format: "%.1f%%", abs(percent)))
+                .font(.system(size: 44, weight: .bold, design: .rounded))
+                .monospacedDigit()
+                .contentTransition(.numericText())
+                .minimumScaleFactor(0.6)
+                .lineLimit(1)
+        }
+        .foregroundStyle(strengthTrendIsDown(percent) ? Color.secondaryLabel : color)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(figureAccessibilityLabel(percent))
+    }
+
+    private func figureAccessibilityLabel(_ percent: Double) -> Text {
+        let value = (abs(percent) / 100).formatted(.percent.precision(.fractionLength(1)))
+        if strengthTrendIsUp(percent) {
+            return Text(String(format: NSLocalizedString("trendUp", comment: ""), value))
+        }
+        if strengthTrendIsDown(percent) {
+            return Text(String(format: NSLocalizedString("trendDown", comment: ""), value))
+        }
+        return Text(NSLocalizedString("trendFlat", comment: ""))
+    }
+
+    /// The exercise beside the figure. Tapping it opens that exercise, which is why the whole label
+    /// is a button rather than the separate readout row it replaces.
+    private func subjectLabel(_ change: StrengthProgress.ExerciseChange) -> some View {
+        Button {
+            homeNavigationCoordinator.path.append(.exercise(change.exercise))
+        } label: {
+            VStack(alignment: .trailing, spacing: 2) {
+                Text(
+                    selectedExerciseID == nil
+                        ? NSLocalizedString("strengthBestMover", comment: "")
+                        : String(format: NSLocalizedString("nSets", comment: ""), change.setCount)
+                )
+                .font(.caption2.weight(.bold))
+                .textCase(.uppercase)
+                .foregroundStyle(.tertiary)
+                HStack(spacing: 4) {
+                    Text(change.exercise.displayName)
+                        .font(.subheadline.weight(.bold))
+                        .foregroundStyle(change.muscleGroup.color)
+                        .lineLimit(2)
+                        .multilineTextAlignment(.trailing)
+                        .minimumScaleFactor(0.8)
+                    NavigationChevron()
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .frame(maxWidth: 165, alignment: .trailing)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(TileButtonStyle())
     }
 
     // MARK: Group grid
@@ -146,7 +231,7 @@ struct StrengthScreen: View {
         let color = group?.color ?? .accentColor
         let isSelected = selectedGroup == group
         Button {
-            selectedGroup = group
+            selectedGroup = selectedGroup == group ? nil : group
             selectedExerciseID = nil
         } label: {
             HStack(spacing: 6) {
@@ -184,70 +269,38 @@ struct StrengthScreen: View {
 
     // MARK: Composition
 
-    /// Every exercise in scope as one ranked bar, worst to best. Replaces the horizontal
-    /// `StrengthCompositionChart`: all of them fit at once, which is what retired that chart's
-    /// five-row cap and its "Show all" button.
-    ///
-    /// The readout sits **above** the plot rather than below it, so a scrubbing finger never covers
-    /// the thing it is selecting.
+    /// Every exercise as one ranked bar, worst to best — and *always* every exercise. Selecting a
+    /// group no longer filters the chart down to it; the group's bars simply keep their colour while
+    /// the rest drop to grey. Filtering answered "how did chest do"; highlighting answers "how did
+    /// chest do *compared with everything else*", which is the question a balance-minded screen is
+    /// actually for, and it stops the chart's shape changing under the finger on every tap.
     private var composition: some View {
-        let changes = progress.exerciseChanges(in: selectedGroup)
-        let ranked = changes.sorted { $0.percentChange < $1.percentChange }
-        let selected = ranked.first { $0.id == selectedExerciseID } ?? ranked.last
+        let all = progress.changes
+        let ranked = all.sorted { $0.percentChange < $1.percentChange }
         return VStack(alignment: .leading, spacing: SECTION_HEADER_SPACING) {
             VStack(alignment: .leading, spacing: 2) {
                 Text(NSLocalizedString("strengthBiggestMovers", comment: ""))
                     .font(.caption.weight(.bold))
                     .textCase(.uppercase)
                     .foregroundStyle(.secondary)
-                Text(NSLocalizedString("strengthScrubHint", comment: ""))
+                Text(NSLocalizedString("strengthHoldHint", comment: ""))
                     .font(.caption2)
                     .foregroundStyle(.tertiary)
             }
-            if let selected {
-                readout(selected)
-            }
             StrengthBarChart(
-                changes: changes,
+                changes: all,
                 spacing: ranked.count < Self.labelledChartThreshold ? 8 : 2,
-                selection: $selectedExerciseID
+                selection: $selectedExerciseID,
+                highlightedGroup: selectedGroup
             )
             .frame(height: 150)
             .animation(.snappy(duration: 0.2), value: selectedExerciseID)
+            .animation(.snappy(duration: 0.2), value: selectedGroup)
             .sensoryFeedback(.selection, trigger: selectedExerciseID)
             if ranked.count < Self.labelledChartThreshold {
                 axisLabels(ranked)
             }
         }
-    }
-
-    /// The scrubbed exercise, as a row that taps through to its detail screen.
-    private func readout(_ change: StrengthProgress.ExerciseChange) -> some View {
-        Button {
-            homeNavigationCoordinator.path.append(.exercise(change.exercise))
-        } label: {
-            HStack(spacing: 10) {
-                Circle()
-                    .fill(change.muscleGroup.color)
-                    .frame(width: 9, height: 9)
-                Text(change.exercise.displayName)
-                    .font(.subheadline.weight(.bold))
-                    .foregroundStyle(Color.label)
-                    .lineLimit(1)
-                Spacer(minLength: 4)
-                Text(String(format: NSLocalizedString("nSets", comment: ""), change.setCount))
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                TrendIndicatorView(percentChange: change.percentChange)
-                NavigationChevron()
-                    .foregroundStyle(.secondary)
-            }
-            .padding(.horizontal, 13)
-            .padding(.vertical, 11)
-            .frame(maxWidth: .infinity)
-            .secondaryTileStyle(insetShadow: true)
-        }
-        .buttonStyle(TileButtonStyle())
     }
 
     /// Under about eight bars there is room to name each column, so the chart stops depending on a

--- a/LOGIT/Features/Home/StrengthTile.swift
+++ b/LOGIT/Features/Home/StrengthTile.swift
@@ -119,7 +119,8 @@ struct StrengthTile: View {
     /// half-width tile beside the chart, and the chart below already carries the accent — so here
     /// the figure wears it directly and the pill keeps its place on the detail screen's hero.
     private func hero(_ percent: Double) -> some View {
-        HStack(alignment: .firstTextBaseline, spacing: 3) {
+        // Centred, not baseline-aligned: a glyph on a text baseline hangs low beside a 30 pt figure.
+        HStack(alignment: .center, spacing: 3) {
             Image(systemName: strengthTrendSymbol(percent))
                 .font(.system(size: 15, weight: .black))
             Text(String(format: "%.1f%%", abs(percent)))


### PR DESCRIPTION
Eight adjustments to the Strength surfaces, two of which change behaviour rather than looks.

## Selection is press-and-hold

It was a zero-distance drag over the plot, which claimed every touch starting there — scrolling the screen from the chart was impossible, and a stray flick reassigned the selection. Now a hold engages it and scrubbing continues while the finger is down. The muscle-group grid is the other way in and needs no gesture at all, so the hint reads "hold a bar, or pick a group".

## Selecting a group highlights rather than filters

Its bars keep their colour; every other bar drops to neutral grey.

Filtering answered *"how did chest do"*. Highlighting answers *"how did chest do compared with everything else"* — the question a balance-minded screen exists for. It also stops the chart's shape changing under the finger on every tap.

Colour now carries two things at once:

| Channel | Meaning |
| --- | --- |
| Hue | identity — accent normally, the group's own colour when highlighted, grey outside it |
| Opacity | direction — gains step the six-step ramp, declines keep the hue and lose solidity |

So a decline reads as "less of this" rather than as a different category.

## The hero does the talking

Left-aligned like the tile's figure, with the subject beside it: the scope's **best mover** by default, or — once a bar is held — that exercise's own change **in its muscle group's colour**, with its name on the right. The caption underneath is gone; the window picker directly above already states the period. That retires the separate readout row entirely.

## Smaller

- Tapping an already-selected group deselects it — there was otherwise no way back to "All" except the All tile.
- Selection haptic on group changes.
- The tile's arrow is centred on the figure rather than sitting on its text baseline.

## Verification

432 unit tests, the four scenario roots and the accessibility guard, all on a **private simulator**. Worth noting why: a concurrent session was running `xcodebuild test` against the shared device and SIGTERM-ing the app mid-inspection, which looked convincingly like a crash on this screen until the device log showed `exited due to SIGTERM | sent by xcodebuild`. There was no crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)