### PR TITLE
Recorder: stop the swipe-to-delete row from eating the scroll slack

### DIFF
--- a/LOGIT/SharedUI/Modifiers/OnDeleteModifier.swift
+++ b/LOGIT/SharedUI/Modifiers/OnDeleteModifier.swift
@@ -7,32 +7,33 @@
 
 import SwiftUI
 
-private struct SizePreferenceKey: PreferenceKey {
-    static var defaultValue: CGSize = .zero
-    static func reduce(value: inout CGSize, nextValue: () -> CGSize) {
-        value = nextValue()
-    }
-}
-
+/// Swipe-to-delete for a view that isn't in a `List`: the row is rendered twice inside a
+/// ZStack — once invisibly, purely to lay out and measure it, and once inside a one-row `List`
+/// that contributes nothing but the swipe action.
+///
+/// That `List` is a UIKit collection view and takes *every* point proposed to it, so it must be
+/// pinned to the measured height or it deforms whatever contains it. The recorder proposes a
+/// screenful of scroll slack to its cards (`minScrollContentHeight`), and an unpinned row spread
+/// that slack between the sets — a card with two sets drew them a third of a screen apart.
+/// Hence: measure with `onGeometryChange` (the preference-key version this used to do never
+/// delivered a size, leaving the height nil — i.e. greedy — forever), and `fixedSize` the stack
+/// so the row's height is the measured content's whatever the `List` reports.
 struct OnDeleteModifier: ViewModifier {
     let action: () -> Void
-    
-    @State private var size: CGSize = .zero
-    @State private var hasLoaded = false
+
+    /// The row's own height. Nil until measured — the `List` stays unconstrained for that first
+    /// frame, which `fixedSize` below keeps from mattering.
+    @State private var contentHeight: CGFloat?
 
     func body(content: Content) -> some View {
         ZStack {
             content
-                .background(
-                    GeometryReader { proxy in
-                        Color.clear
-                            .preference(key: SizePreferenceKey.self, value: proxy.size)
-                    }
-                )
-                .suppressIntegerFieldFocus(true)
-                .onPreferenceChange(SizePreferenceKey.self) { newSize in
-                    size = newSize
+                .onGeometryChange(for: CGFloat.self) { proxy in
+                    proxy.size.height
+                } action: { newHeight in
+                    contentHeight = newHeight
                 }
+                .suppressIntegerFieldFocus(true)
                 .opacity(0.000001)
                 .allowsHitTesting(false)
                 .disabled(true)
@@ -56,8 +57,10 @@ struct OnDeleteModifier: ViewModifier {
             .contentMargins(.top, 0)
             .listStyle(.plain)
             .scrollDisabled(true)
-            .frame(height: size == .zero ? nil : size.height)
+            .frame(height: contentHeight)
         }
+        // The row is as tall as its content lays out, never as tall as it is offered.
+        .fixedSize(horizontal: false, vertical: true)
     }
 }
 

--- a/LOGITUITests/ScenarioScreenshots.swift
+++ b/LOGITUITests/ScenarioScreenshots.swift
@@ -261,10 +261,29 @@ final class ScenarioScreenshots: XCTestCase {
         XCTAssertTrue(exercise.waitForExistence(timeout: 10), "Exercise tray missing")
         exercise.tap()
         sleep(2)
+        let addSet = app.buttons["Add Set"].firstMatch
+
+        // Two sets first: the card must stay COMPACT. The scroll slack a short list is given
+        // is travel to scroll into, not height to grow into — the set rows sit one after
+        // another whatever the viewport has left over. Checked at two sets because the slack
+        // is split between the rows, so this is where a stretching card is most obvious (a
+        // regression from an unpinned swipe-to-delete row drew them ~150pt apart here).
+        XCTAssertTrue(addSet.exists, "Add Set button missing")
+        addSet.tap()
+        sleep(1)
+        let firstRow = app.staticTexts["1"].firstMatch
+        let secondRow = app.staticTexts["2"].firstMatch
+        XCTAssertTrue(firstRow.exists && secondRow.exists, "Set-index labels missing")
+        let rowPitch = secondRow.frame.minY - firstRow.frame.minY
+        XCTAssertLessThan(
+            rowPitch,
+            100,
+            "Set rows are \(rowPitch)pt apart — the card is stretching to fill the viewport instead of staying compact"
+        )
+
         // Grow the list to ~6 sets (the reported case): the card's Add Set row must not
         // be clipped and the card should run to the bottom edge under the tray.
-        let addSet = app.buttons["Add Set"].firstMatch
-        for _ in 0 ..< 5 where addSet.exists { addSet.tap() }
+        for _ in 0 ..< 4 where addSet.exists { addSet.tap() }
         sleep(2)
         attach(app, "short_bottom")
         // The Add Set row (bottom of the only card) must be fully on-screen, not clipped


### PR DESCRIPTION
A one-exercise workout drew its sets a third of a screen apart. The rows were not drifting — the card was growing, and a `VStack` splits the extra height evenly between its children.

The height came from #114. A short list gets `.frame(minHeight: minScrollContentHeight)` so the header still has travel to fold away, and that proposal goes straight down into the cards. Anything vertically greedy inside one therefore takes a share of it.

Something was: every set row carries `onDeleteView`, which renders the row twice — once invisibly to measure it, once inside a one-row `List` that supplies nothing but the swipe action — and pins that `List` to the measured height, because a `List` is a collection view and takes every point it is offered. The measurement never arrived: the `GeometryReader` + `PreferenceKey` pair reported nothing, so the height stayed nil, i.e. unconstrained, i.e. greedy. Latent for as long as nothing proposed a card more height than it asked for.

So: measure with `onGeometryChange`, and `fixedSize` the stack, so the row is as tall as its content lays out whatever the `List` reports. One modifier, no call sites touched — the recorder, the workout editor, the template editor and the measurement screen all share it.

The set count hid this. The slack is split between the rows, so six sets drift ~72pt each and two sets ~215pt: full workouts and the fixture recorder look fine, and only a freshly started short workout shows it. That is also why `testShortWorkoutBottomEdge` — which walks this exact screen — stayed green: "Add Set is not clipped" was true throughout. It now also measures set 1 to set 2 while only two sets exist, the point of maximum stretch (215pt before, 61pt after, confirmed by reverting the fix).

Verified on iPhone 17 Pro / iOS 26.4: the recorder at 1/2/6 sets and a superset card in the same short workout, swipe-to-delete and the delete itself (recorder + measurement detail), the template editor and detail, the empty/one/many/free matrix, and the superset, recorder-flow and workout-detail tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)