### PR TITLE
Strength: tappable tile, thinner detail, strongest-lifts list

### DIFF
--- a/LOGIT/Core/Environment/de.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/de.lproj/Localizable.strings
@@ -1128,8 +1128,10 @@
 "nSets" = "%d Sätze";
 "allExercises" = "Alle Übungen";
 "strengthTapGroup" = "Tippe eine Gruppe an";
-"strengthBiggestMovers" = "Größte Veränderungen";
-"strengthHoldHint" = "Von schwach zu stark · Balken halten oder Gruppe wählen";
 "strengthBestMover" = "Größter Zuwachs";
+"strengthAxisMostDeclined" = "Stärkster Rückgang";
+"strengthAxisLeastImproved" = "Geringster Zuwachs";
+"strengthAxisMostImproved" = "Größter Zuwachs";
+"strengthAxisLeastDeclined" = "Geringster Rückgang";
 "showLess" = "Weniger anzeigen";
 "strengthInfo" = "Das beste geschätzte 1RM jeder Übung der letzten %d Wochen im Vergleich zu den %d davor, gemittelt und nach Anzahl der Sätze gewichtet. Cardio- und Körpergewichtssätze haben kein 1RM und zählen nicht.";

--- a/LOGIT/Core/Environment/de.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/de.lproj/Localizable.strings
@@ -1127,11 +1127,11 @@
 "nWeeks" = "%d Wochen";
 "nSets" = "%d Sätze";
 "allExercises" = "Alle Übungen";
-"strengthTapGroup" = "Tippe eine Gruppe an";
-"strengthBestMover" = "Größter Zuwachs";
 "strengthAxisMostDeclined" = "Stärkster Rückgang";
 "strengthAxisLeastImproved" = "Geringster Zuwachs";
 "strengthAxisMostImproved" = "Größter Zuwachs";
+"strengthStrongestLifts" = "Stärkste Übungen";
+"strengthShowAllLifts" = "Alle %d Übungen zeigen";
 "strengthAxisLeastDeclined" = "Geringster Rückgang";
 "showLess" = "Weniger anzeigen";
 "strengthInfo" = "Das beste geschätzte 1RM jeder Übung der letzten %d Wochen im Vergleich zu den %d davor, gemittelt und nach Anzahl der Sätze gewichtet. Cardio- und Körpergewichtssätze haben kein 1RM und zählen nicht.";

--- a/LOGIT/Core/Environment/en.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/en.lproj/Localizable.strings
@@ -1132,8 +1132,10 @@
 "nSets" = "%d sets";
 "allExercises" = "All exercises";
 "strengthTapGroup" = "Tap a group to focus";
-"strengthBiggestMovers" = "Biggest movers";
-"strengthHoldHint" = "Ranked worst to best · hold a bar, or pick a group";
 "strengthBestMover" = "Best mover";
+"strengthAxisMostDeclined" = "Most declined";
+"strengthAxisLeastImproved" = "Least improved";
+"strengthAxisMostImproved" = "Most improved";
+"strengthAxisLeastDeclined" = "Least declined";
 "showLess" = "Show less";
 "strengthInfo" = "Each exercise's best estimated 1RM in the last %d weeks against the %d before, averaged and weighted by how many sets you did. Cardio and bodyweight sets carry no 1RM and don't count.";

--- a/LOGIT/Core/Environment/en.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/en.lproj/Localizable.strings
@@ -1131,11 +1131,11 @@
 "nWeeks" = "%d weeks";
 "nSets" = "%d sets";
 "allExercises" = "All exercises";
-"strengthTapGroup" = "Tap a group to focus";
-"strengthBestMover" = "Best mover";
 "strengthAxisMostDeclined" = "Most declined";
 "strengthAxisLeastImproved" = "Least improved";
 "strengthAxisMostImproved" = "Most improved";
+"strengthStrongestLifts" = "Strongest lifts";
+"strengthShowAllLifts" = "Show all %d lifts";
 "strengthAxisLeastDeclined" = "Least declined";
 "showLess" = "Show less";
 "strengthInfo" = "Each exercise's best estimated 1RM in the last %d weeks against the %d before, averaged and weighted by how many sets you did. Cardio and bodyweight sets carry no 1RM and don't count.";

--- a/LOGIT/Core/Environment/es.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/es.lproj/Localizable.strings
@@ -1131,11 +1131,11 @@
 "nWeeks" = "%d semanas";
 "nSets" = "%d series";
 "allExercises" = "Todos los ejercicios";
-"strengthTapGroup" = "Toca un grupo para enfocarlo";
-"strengthBestMover" = "Mayor avance";
 "strengthAxisMostDeclined" = "Mayor descenso";
 "strengthAxisLeastImproved" = "Menor avance";
 "strengthAxisMostImproved" = "Mayor avance";
+"strengthStrongestLifts" = "Levantamientos más fuertes";
+"strengthShowAllLifts" = "Ver los %d levantamientos";
 "strengthAxisLeastDeclined" = "Menor descenso";
 "showLess" = "Ver menos";
 "strengthInfo" = "El mejor 1RM estimado de cada ejercicio en las últimas %d semanas frente a las %d anteriores, promediado y ponderado por el número de series. Las series de cardio y peso corporal no tienen 1RM y no cuentan.";

--- a/LOGIT/Core/Environment/es.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/es.lproj/Localizable.strings
@@ -1132,8 +1132,10 @@
 "nSets" = "%d series";
 "allExercises" = "Todos los ejercicios";
 "strengthTapGroup" = "Toca un grupo para enfocarlo";
-"strengthBiggestMovers" = "Mayores cambios";
-"strengthHoldHint" = "De peor a mejor · mantén una barra o elige un grupo";
 "strengthBestMover" = "Mayor avance";
+"strengthAxisMostDeclined" = "Mayor descenso";
+"strengthAxisLeastImproved" = "Menor avance";
+"strengthAxisMostImproved" = "Mayor avance";
+"strengthAxisLeastDeclined" = "Menor descenso";
 "showLess" = "Ver menos";
 "strengthInfo" = "El mejor 1RM estimado de cada ejercicio en las últimas %d semanas frente a las %d anteriores, promediado y ponderado por el número de series. Las series de cardio y peso corporal no tienen 1RM y no cuentan.";

--- a/LOGIT/Core/Environment/fr.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/fr.lproj/Localizable.strings
@@ -1132,8 +1132,10 @@
 "nSets" = "%d séries";
 "allExercises" = "Tous les exercices";
 "strengthTapGroup" = "Touchez un groupe pour l'isoler";
-"strengthBiggestMovers" = "Plus grands changements";
-"strengthHoldHint" = "Du plus faible au plus fort · maintenez une barre ou choisissez un groupe";
 "strengthBestMover" = "Meilleure progression";
+"strengthAxisMostDeclined" = "Plus forte baisse";
+"strengthAxisLeastImproved" = "Plus faible hausse";
+"strengthAxisMostImproved" = "Plus forte hausse";
+"strengthAxisLeastDeclined" = "Plus faible baisse";
 "showLess" = "Voir moins";
 "strengthInfo" = "Le meilleur 1RM estimé de chaque exercice sur les %d dernières semaines par rapport aux %d précédentes, moyenné et pondéré par le nombre de séries. Les séries de cardio et au poids du corps n'ont pas de 1RM et ne comptent pas.";

--- a/LOGIT/Core/Environment/fr.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/fr.lproj/Localizable.strings
@@ -1131,11 +1131,11 @@
 "nWeeks" = "%d semaines";
 "nSets" = "%d séries";
 "allExercises" = "Tous les exercices";
-"strengthTapGroup" = "Touchez un groupe pour l'isoler";
-"strengthBestMover" = "Meilleure progression";
 "strengthAxisMostDeclined" = "Plus forte baisse";
 "strengthAxisLeastImproved" = "Plus faible hausse";
 "strengthAxisMostImproved" = "Plus forte hausse";
+"strengthStrongestLifts" = "Charges les plus lourdes";
+"strengthShowAllLifts" = "Voir les %d exercices";
 "strengthAxisLeastDeclined" = "Plus faible baisse";
 "showLess" = "Voir moins";
 "strengthInfo" = "Le meilleur 1RM estimé de chaque exercice sur les %d dernières semaines par rapport aux %d précédentes, moyenné et pondéré par le nombre de séries. Les séries de cardio et au poids du corps n'ont pas de 1RM et ne comptent pas.";

--- a/LOGIT/Core/Environment/it.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/it.lproj/Localizable.strings
@@ -1131,11 +1131,11 @@
 "nWeeks" = "%d settimane";
 "nSets" = "%d serie";
 "allExercises" = "Tutti gli esercizi";
-"strengthTapGroup" = "Tocca un gruppo per isolarlo";
-"strengthBestMover" = "Miglior progresso";
 "strengthAxisMostDeclined" = "Calo maggiore";
 "strengthAxisLeastImproved" = "Progresso minore";
 "strengthAxisMostImproved" = "Progresso maggiore";
+"strengthStrongestLifts" = "Sollevamenti più pesanti";
+"strengthShowAllLifts" = "Mostra tutti i %d esercizi";
 "strengthAxisLeastDeclined" = "Calo minore";
 "showLess" = "Mostra meno";
 "strengthInfo" = "Il miglior 1RM stimato di ogni esercizio nelle ultime %d settimane rispetto alle %d precedenti, mediato e pesato in base al numero di serie. Le serie di cardio e a corpo libero non hanno 1RM e non contano.";

--- a/LOGIT/Core/Environment/it.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/it.lproj/Localizable.strings
@@ -1132,8 +1132,10 @@
 "nSets" = "%d serie";
 "allExercises" = "Tutti gli esercizi";
 "strengthTapGroup" = "Tocca un gruppo per isolarlo";
-"strengthBiggestMovers" = "Cambiamenti maggiori";
-"strengthHoldHint" = "Dal peggiore al migliore · tieni premuta una barra o scegli un gruppo";
 "strengthBestMover" = "Miglior progresso";
+"strengthAxisMostDeclined" = "Calo maggiore";
+"strengthAxisLeastImproved" = "Progresso minore";
+"strengthAxisMostImproved" = "Progresso maggiore";
+"strengthAxisLeastDeclined" = "Calo minore";
 "showLess" = "Mostra meno";
 "strengthInfo" = "Il miglior 1RM stimato di ogni esercizio nelle ultime %d settimane rispetto alle %d precedenti, mediato e pesato in base al numero di serie. Le serie di cardio e a corpo libero non hanno 1RM e non contano.";

--- a/LOGIT/Core/Environment/ja.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/ja.lproj/Localizable.strings
@@ -1131,11 +1131,11 @@
 "nWeeks" = "%d週間";
 "nSets" = "%dセット";
 "allExercises" = "すべてのエクササイズ";
-"strengthTapGroup" = "グループをタップして絞り込み";
-"strengthBestMover" = "最も伸びた種目";
 "strengthAxisMostDeclined" = "最大の低下";
 "strengthAxisLeastImproved" = "最小の伸び";
 "strengthAxisMostImproved" = "最大の伸び";
+"strengthStrongestLifts" = "最も重い種目";
+"strengthShowAllLifts" = "%d 種目をすべて表示";
 "strengthAxisLeastDeclined" = "最小の低下";
 "showLess" = "表示を減らす";
 "strengthInfo" = "各エクササイズの直近%d週間の推定1RM最高値を、その前の%d週間と比較し、セット数で重み付けして平均した値です。カーディオと自重のセットは1RMがないため含まれません。";

--- a/LOGIT/Core/Environment/ja.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/ja.lproj/Localizable.strings
@@ -1132,8 +1132,10 @@
 "nSets" = "%dセット";
 "allExercises" = "すべてのエクササイズ";
 "strengthTapGroup" = "グループをタップして絞り込み";
-"strengthBiggestMovers" = "変化が大きい種目";
-"strengthHoldHint" = "小さい順 · バーを長押し、または部位を選択";
 "strengthBestMover" = "最も伸びた種目";
+"strengthAxisMostDeclined" = "最大の低下";
+"strengthAxisLeastImproved" = "最小の伸び";
+"strengthAxisMostImproved" = "最大の伸び";
+"strengthAxisLeastDeclined" = "最小の低下";
 "showLess" = "表示を減らす";
 "strengthInfo" = "各エクササイズの直近%d週間の推定1RM最高値を、その前の%d週間と比較し、セット数で重み付けして平均した値です。カーディオと自重のセットは1RMがないため含まれません。";

--- a/LOGIT/Core/Environment/ko.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/ko.lproj/Localizable.strings
@@ -1132,8 +1132,10 @@
 "nSets" = "%d세트";
 "allExercises" = "모든 운동";
 "strengthTapGroup" = "그룹을 탭해 집중해서 보기";
-"strengthBiggestMovers" = "변화가 큰 운동";
-"strengthHoldHint" = "낮은 순 · 막대를 길게 누르거나 부위 선택";
 "strengthBestMover" = "가장 향상된 종목";
+"strengthAxisMostDeclined" = "가장 큰 감소";
+"strengthAxisLeastImproved" = "가장 작은 향상";
+"strengthAxisMostImproved" = "가장 큰 향상";
+"strengthAxisLeastDeclined" = "가장 작은 감소";
 "showLess" = "간단히 보기";
 "strengthInfo" = "각 운동의 최근 %d주 최고 추정 1RM을 이전 %d주와 비교해 세트 수로 가중 평균한 값입니다. 유산소와 맨몸 세트는 1RM이 없어 포함되지 않습니다.";

--- a/LOGIT/Core/Environment/ko.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/ko.lproj/Localizable.strings
@@ -1131,11 +1131,11 @@
 "nWeeks" = "%d주";
 "nSets" = "%d세트";
 "allExercises" = "모든 운동";
-"strengthTapGroup" = "그룹을 탭해 집중해서 보기";
-"strengthBestMover" = "가장 향상된 종목";
 "strengthAxisMostDeclined" = "가장 큰 감소";
 "strengthAxisLeastImproved" = "가장 작은 향상";
 "strengthAxisMostImproved" = "가장 큰 향상";
+"strengthStrongestLifts" = "가장 무거운 종목";
+"strengthShowAllLifts" = "%d개 종목 모두 보기";
 "strengthAxisLeastDeclined" = "가장 작은 감소";
 "showLess" = "간단히 보기";
 "strengthInfo" = "각 운동의 최근 %d주 최고 추정 1RM을 이전 %d주와 비교해 세트 수로 가중 평균한 값입니다. 유산소와 맨몸 세트는 1RM이 없어 포함되지 않습니다.";

--- a/LOGIT/Core/Environment/pt-BR.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/pt-BR.lproj/Localizable.strings
@@ -1132,8 +1132,10 @@
 "nSets" = "%d séries";
 "allExercises" = "Todos os exercícios";
 "strengthTapGroup" = "Toque em um grupo para focar";
-"strengthBiggestMovers" = "Maiores mudanças";
-"strengthHoldHint" = "Do pior ao melhor · segure uma barra ou escolha um grupo";
 "strengthBestMover" = "Maior avanço";
+"strengthAxisMostDeclined" = "Maior queda";
+"strengthAxisLeastImproved" = "Menor avanço";
+"strengthAxisMostImproved" = "Maior avanço";
+"strengthAxisLeastDeclined" = "Menor queda";
 "showLess" = "Ver menos";
 "strengthInfo" = "O melhor 1RM estimado de cada exercício nas últimas %d semanas em relação às %d anteriores, com média ponderada pelo número de séries. Séries de cardio e peso corporal não têm 1RM e não contam.";

--- a/LOGIT/Core/Environment/pt-BR.lproj/Localizable.strings
+++ b/LOGIT/Core/Environment/pt-BR.lproj/Localizable.strings
@@ -1131,11 +1131,11 @@
 "nWeeks" = "%d semanas";
 "nSets" = "%d séries";
 "allExercises" = "Todos os exercícios";
-"strengthTapGroup" = "Toque em um grupo para focar";
-"strengthBestMover" = "Maior avanço";
 "strengthAxisMostDeclined" = "Maior queda";
 "strengthAxisLeastImproved" = "Menor avanço";
 "strengthAxisMostImproved" = "Maior avanço";
+"strengthStrongestLifts" = "Levantamentos mais pesados";
+"strengthShowAllLifts" = "Ver todos os %d exercícios";
 "strengthAxisLeastDeclined" = "Menor queda";
 "showLess" = "Ver menos";
 "strengthInfo" = "O melhor 1RM estimado de cada exercício nas últimas %d semanas em relação às %d anteriores, com média ponderada pelo número de séries. Séries de cardio e peso corporal não têm 1RM e não contam.";

--- a/LOGIT/Features/Home/StrengthBarChart.swift
+++ b/LOGIT/Features/Home/StrengthBarChart.swift
@@ -45,9 +45,9 @@ struct StrengthBarChart: View {
     /// step still visible on the tile surface.
     private static let rampSteps = 6
     private static let rampFloor: Double = 0.35
-    /// Declines keep the hue and lose the solidity — dimmer than the ramp's own floor so they read
-    /// as below the line rather than as a very small gain.
-    private static let declineOpacity: Double = 0.22
+    /// Declines are grey at this weight — solid enough to read as a bar, muted enough that the
+    /// accent side stays the thing you look at.
+    private static let declineOpacity: Double = 0.55
     /// Shortest a bar can be drawn. Every exercise in the ranking keeps one: a flat lift is part of
     /// the ranking and should hold its column, and columns that render nothing leave the movers
     /// crowded into a corner of an otherwise empty chart.
@@ -101,6 +101,10 @@ struct StrengthBarChart: View {
             }
             .contentShape(Rectangle())
             .gesture(selectGesture(ranked: ranked, width: geo.size.width))
+            // Only claim touches where selection is actually wired up. On the Summary tile the chart
+            // fills most of the card, and a hit-testable shape here swallowed the taps meant for the
+            // button behind it — the tile opened only when a label happened to be hit.
+            .allowsHitTesting(selection != nil)
         }
     }
 
@@ -151,23 +155,23 @@ struct StrengthBarChart: View {
         .frame(height: height)
     }
 
-    /// Colour carries two things at once: identity and direction.
+    /// Gains carry identity and rank; declines are always neutral grey.
     ///
-    /// Identity is the base hue — the accent normally, the muscle group's own colour once a group is
-    /// highlighted, and neutral grey for every bar outside that group. Direction is opacity: gains
-    /// step through the six-step ramp by rank, declines are drawn translucent in the same hue rather
-    /// than recoloured, so a decline reads as "less of this" instead of as a different category.
+    /// Identity is the hue of a *gain* — the accent normally, the muscle group's own colour once a
+    /// group is highlighted, dim grey for gains outside that group. A decline never takes a hue at
+    /// all: tinting it in the same colour made it read as a faint gain of the same thing, and grey
+    /// is what every other trend surface in the app already uses for "down".
     private func color(for change: StrengthProgress.ExerciseChange, maxGain: Double) -> Color {
+        guard change.percentChange > 0 else { return Color.secondaryLabel.opacity(Self.declineOpacity) }
         let base: Color
         if let highlightedGroup {
             guard change.muscleGroup == highlightedGroup else {
-                return Color.secondaryLabel.opacity(change.percentChange > 0 ? 0.5 : 0.25)
+                return Color.secondaryLabel.opacity(0.28)
             }
             base = highlightedGroup.color
         } else {
             base = .accentColor
         }
-        guard change.percentChange > 0 else { return base.opacity(Self.declineOpacity) }
         guard maxGain > 0 else { return base }
         let step = min(Int(change.percentChange / maxGain * Double(Self.rampSteps)), Self.rampSteps - 1)
         let t = Double(step) / Double(Self.rampSteps - 1)
@@ -197,6 +201,10 @@ struct StrengthBarChart: View {
                 guard case let .second(_, drag?) = value else { return }
                 select(at: drag.location.x, ranked: ranked, width: width)
             }
+            // Lifting the finger clears it: the selection is a peek at one bar, not a mode you have
+            // to leave. Without this the hero kept talking about an exercise long after the gesture,
+            // and there was no obvious way to get back to the scope's own figure.
+            .onEnded { _ in selection?.wrappedValue = nil }
     }
 
     /// Individual bars are far under a tappable size at any realistic exercise count, so the whole

--- a/LOGIT/Features/Home/StrengthProgress.swift
+++ b/LOGIT/Features/Home/StrengthProgress.swift
@@ -60,6 +60,17 @@ struct StrengthProgress {
         var id: NSManagedObjectID { exercise.objectID }
     }
 
+    /// One exercise's heaviest estimated 1RM in the recent window — the "strongest lifts" list, which
+    /// answers a different question from the rest of this type: not *how much did it move* but *what
+    /// can you actually lift*. Kept here because it falls out of the same pass over the sets.
+    struct ExerciseBest: Identifiable {
+        let exercise: Exercise
+        let muscleGroup: MuscleGroup
+        /// Best estimated 1RM in the recent window, in grams.
+        let oneRepMax: Int
+        var id: NSManagedObjectID { exercise.objectID }
+    }
+
     struct GroupProgress: Identifiable {
         let muscleGroup: MuscleGroup
         let percentChange: Double
@@ -70,6 +81,10 @@ struct StrengthProgress {
 
     /// Every qualifying exercise, unordered.
     let changes: [ExerciseChange]
+    /// Every exercise with a usable e1RM in the recent window, heaviest first. Unlike `changes` this
+    /// does *not* require a prior-window best: a lift you only started this month still has a weight,
+    /// and leaving it out of a "strongest" list would be plainly wrong.
+    var bests: [ExerciseBest] = []
     let window: StrengthWindow
     /// How much of the comparison span (two windows) the logged history covers, 0…1. Only used by
     /// the empty state's ring, so it reads as "still filling up" rather than as nothing at all.
@@ -149,6 +164,7 @@ struct StrengthProgress {
         } ?? 0
 
         var changes: [ExerciseChange] = []
+        var bests: [ExerciseBest] = []
         for exercise in exercises {
             guard let group = exercise.muscleGroup else { continue }
             var recentBest = 0
@@ -165,6 +181,9 @@ struct StrengthProgress {
                     priorBest = max(priorBest, e1rm)
                 }
             }
+            if recentBest > 0 {
+                bests.append(ExerciseBest(exercise: exercise, muscleGroup: group, oneRepMax: recentBest))
+            }
             guard recentBest > 0, priorBest > 0 else { continue }
             let raw = (Double(recentBest) - Double(priorBest)) / Double(priorBest) * 100
             changes.append(
@@ -176,7 +195,12 @@ struct StrengthProgress {
                 )
             )
         }
-        return StrengthProgress(changes: changes, window: window, historyFraction: historyFraction)
+        return StrengthProgress(
+            changes: changes,
+            bests: bests.sorted { $0.oneRepMax > $1.oneRepMax },
+            window: window,
+            historyFraction: historyFraction
+        )
     }
 }
 

--- a/LOGIT/Features/Home/StrengthScreen.swift
+++ b/LOGIT/Features/Home/StrengthScreen.swift
@@ -274,48 +274,41 @@ struct StrengthScreen: View {
     /// the rest drop to grey. Filtering answered "how did chest do"; highlighting answers "how did
     /// chest do *compared with everything else*", which is the question a balance-minded screen is
     /// actually for, and it stops the chart's shape changing under the finger on every tap.
+    ///
+    /// No section header and no per-bar names. The hero above already says what this is, and eight
+    /// rotated exercise labels were the densest thing on the screen while telling you the least —
+    /// the two ends of the ranking are what the axis actually needs to say.
     private var composition: some View {
-        let all = progress.changes
-        let ranked = all.sorted { $0.percentChange < $1.percentChange }
-        return VStack(alignment: .leading, spacing: SECTION_HEADER_SPACING) {
-            VStack(alignment: .leading, spacing: 2) {
-                Text(NSLocalizedString("strengthBiggestMovers", comment: ""))
-                    .font(.caption.weight(.bold))
-                    .textCase(.uppercase)
-                    .foregroundStyle(.secondary)
-                Text(NSLocalizedString("strengthHoldHint", comment: ""))
-                    .font(.caption2)
-                    .foregroundStyle(.tertiary)
-            }
+        let ranked = progress.changes.sorted { $0.percentChange < $1.percentChange }
+        return VStack(alignment: .leading, spacing: 8) {
             StrengthBarChart(
-                changes: all,
+                changes: progress.changes,
                 spacing: ranked.count < Self.labelledChartThreshold ? 8 : 2,
                 selection: $selectedExerciseID,
                 highlightedGroup: selectedGroup
             )
-            .frame(height: 150)
+            .frame(height: 170)
             .animation(.snappy(duration: 0.2), value: selectedExerciseID)
             .animation(.snappy(duration: 0.2), value: selectedGroup)
             .sensoryFeedback(.selection, trigger: selectedExerciseID)
-            if ranked.count < Self.labelledChartThreshold {
-                axisLabels(ranked)
-            }
+            axisEnds(ranked)
         }
     }
 
-    /// Under about eight bars there is room to name each column, so the chart stops depending on a
-    /// gesture to be readable at all.
-    private func axisLabels(_ ranked: [StrengthProgress.ExerciseChange]) -> some View {
-        HStack(spacing: 8) {
-            ForEach(ranked) { change in
-                Text(change.exercise.displayName)
-                    .font(.caption2)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(2)
-                    .multilineTextAlignment(.center)
-                    .frame(maxWidth: .infinity)
-            }
+    /// The axis names the *ranking*, not the bars: what the left end and the right end mean. Which
+    /// words depends on the data — with declines present the left end is a drop, not a small gain.
+    private func axisEnds(_ ranked: [StrengthProgress.ExerciseChange]) -> some View {
+        let hasDecline = (ranked.first?.percentChange ?? 0) < 0
+        let hasGain = (ranked.last?.percentChange ?? 0) > 0
+        return HStack {
+            Text(NSLocalizedString(hasDecline ? "strengthAxisMostDeclined" : "strengthAxisLeastImproved", comment: ""))
+            Spacer(minLength: 12)
+            Text(NSLocalizedString(hasGain ? "strengthAxisMostImproved" : "strengthAxisLeastDeclined", comment: ""))
         }
+        .font(.caption2)
+        .foregroundStyle(.tertiary)
+        .lineLimit(1)
+        .minimumScaleFactor(0.8)
     }
 
     private var footnote: some View {

--- a/LOGIT/Features/Home/StrengthScreen.swift
+++ b/LOGIT/Features/Home/StrengthScreen.swift
@@ -29,10 +29,15 @@ struct StrengthScreen: View {
     @State private var progress: StrengthProgress = .empty
     /// The scrubbed exercise, by object ID. Nil until a finger lands on the chart.
     @State private var selectedExerciseID: NSManagedObjectID?
+    @State private var showsAllBests = false
 
     /// Below this many bars the chart stops being a ranking and becomes a handful of columns, so it
     /// widens them and labels each one instead of asking for a scrub it doesn't need.
     private static let labelledChartThreshold = 8
+    /// Every group cell stands this tall, with or without a trend pill inside it.
+    private static let groupCellHeight: CGFloat = 44
+    /// Strongest lifts shown before the list collapses.
+    private static let collapsedBestsCount = 5
 
     init(workouts: [Workout], initialGroup: MuscleGroup? = nil) {
         self.workouts = workouts
@@ -47,6 +52,7 @@ struct StrengthScreen: View {
                 if progress.hasData {
                     composition
                     groupGrid
+                    strongest
                 }
                 footnote
             }
@@ -91,22 +97,20 @@ struct StrengthScreen: View {
 
     // MARK: Hero
 
-    /// The figure, left-aligned like the tile's, with whichever exercise the screen is currently
-    /// talking about beside it.
+    /// A caption over the figure, matching the tile's anatomy. The caption is the only thing that
+    /// changes with selection: normally it names the basis ("Estimated 1RM"), and while a bar is held
+    /// it names that exercise in its muscle colour, with the figure below switching to that lift's
+    /// own change.
     ///
-    /// It has three states and they share one shape. With nothing selected it shows the scope's
-    /// change and names its **best mover** — the single most useful thing the number can't say.
-    /// Hold a bar and it becomes that exercise: its own change, in its muscle group's colour, with
-    /// its name on the right. Selecting a group swaps the scope. The caption underneath is gone;
-    /// the window picker directly above already states the period, and saying it twice was noise.
+    /// Nothing sits to the right any more. A second figure beside the headline was read as one
+    /// statement about it — "best mover Squat" next to a falling percentage parsed as a verdict on
+    /// Squat — and no label above it could win that fight. The chart's own axis ends now carry which
+    /// end is which, which is where that belongs.
     private var hero: some View {
-        HStack(alignment: .center, spacing: 14) {
+        VStack(alignment: .leading, spacing: 2) {
+            caption
             if let percent = heroPercent {
                 figure(percent, color: heroColor)
-                Spacer(minLength: 8)
-                if let subject = heroSubject {
-                    subjectLabel(subject)
-                }
             } else {
                 // Same gray ring the tile and the core-stat tiles wear while they wait for data.
                 TrendPlaceholder(
@@ -116,12 +120,30 @@ struct StrengthScreen: View {
                     alignment: .leading,
                     diameter: 40
                 )
-                .padding(.vertical, 16)
+                .padding(.vertical, 12)
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .animation(.snappy, value: selectedGroup)
         .animation(.snappy, value: selectedExerciseID)
+    }
+
+    @ViewBuilder
+    private var caption: some View {
+        if let selected = selectedChange {
+            Text(selected.exercise.displayName)
+                .font(.caption.weight(.bold))
+                .tracking(0.3)
+                .foregroundStyle(selected.muscleGroup.color)
+                .lineLimit(1)
+                .minimumScaleFactor(0.7)
+        } else {
+            Text(NSLocalizedString("strengthBasis", comment: ""))
+                .font(.caption.weight(.medium))
+                .tracking(0.3)
+                .foregroundStyle(.tertiary)
+                .lineLimit(1)
+        }
     }
 
     /// Selected exercise wins, then the selected group, then the whole training.
@@ -131,12 +153,6 @@ struct StrengthScreen: View {
 
     private var heroColor: Color {
         selectedChange?.muscleGroup.color ?? selectedGroup?.color ?? .accentColor
-    }
-
-    /// The exercise the hero is naming: the selected one, or the scope's biggest gainer.
-    private var heroSubject: StrengthProgress.ExerciseChange? {
-        selectedChange ?? progress.exerciseChanges(in: selectedGroup)
-            .max { $0.percentChange < $1.percentChange }
     }
 
     private var selectedChange: StrengthProgress.ExerciseChange? {
@@ -171,57 +187,27 @@ struct StrengthScreen: View {
         return Text(NSLocalizedString("trendFlat", comment: ""))
     }
 
-    /// The exercise beside the figure. Tapping it opens that exercise, which is why the whole label
-    /// is a button rather than the separate readout row it replaces.
-    private func subjectLabel(_ change: StrengthProgress.ExerciseChange) -> some View {
-        Button {
-            homeNavigationCoordinator.path.append(.exercise(change.exercise))
-        } label: {
-            VStack(alignment: .trailing, spacing: 2) {
-                Text(
-                    selectedExerciseID == nil
-                        ? NSLocalizedString("strengthBestMover", comment: "")
-                        : String(format: NSLocalizedString("nSets", comment: ""), change.setCount)
-                )
-                .font(.caption2.weight(.bold))
-                .textCase(.uppercase)
-                .foregroundStyle(.tertiary)
-                HStack(spacing: 4) {
-                    Text(change.exercise.displayName)
-                        .font(.subheadline.weight(.bold))
-                        .foregroundStyle(change.muscleGroup.color)
-                        .lineLimit(2)
-                        .multilineTextAlignment(.trailing)
-                        .minimumScaleFactor(0.8)
-                    NavigationChevron()
-                        .foregroundStyle(.secondary)
-                }
-            }
-            .frame(maxWidth: 165, alignment: .trailing)
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(TileButtonStyle())
-    }
-
     // MARK: Group grid
 
-    /// The scope selector: "All" plus every muscle group. Groups without data stay in the grid,
-    /// dimmed and disabled, so the grid keeps a stable shape instead of reshuffling as the window
-    /// changes.
+    /// The scope selector: "All" plus every muscle group, **groups with data first**. A cell you
+    /// can't tap has no claim on a position near the top, and sinking them keeps the live options
+    /// together instead of interleaved with dead ones.
+    ///
+    /// No section heading. "Tap a group to focus" is an instruction, and a grid of tappable pills
+    /// doesn't need to be told it is tappable.
     private var groupGrid: some View {
-        VStack(alignment: .leading, spacing: SECTION_HEADER_SPACING) {
-            Text(NSLocalizedString("strengthTapGroup", comment: ""))
-                .font(.caption.weight(.bold))
-                .textCase(.uppercase)
-                .foregroundStyle(.secondary)
-            LazyVGrid(
-                columns: [GridItem(.flexible(), spacing: 8), GridItem(.flexible(), spacing: 8)],
-                spacing: 8
-            ) {
-                cell(for: nil, percent: progress.overallPercentChange)
-                ForEach(MuscleGroup.allCases, id: \.self) { group in
-                    cell(for: group, percent: progress.percentChange(in: group))
-                }
+        let cells: [(group: MuscleGroup?, percent: Double?)] =
+            [(nil, progress.overallPercentChange)]
+            + MuscleGroup.allCases
+                .map { (Optional($0), progress.percentChange(in: $0)) }
+                // Stable within each half: canonical order, data first.
+                .sorted { ($0.1 != nil ? 0 : 1) < ($1.1 != nil ? 0 : 1) }
+        return LazyVGrid(
+            columns: [GridItem(.flexible(), spacing: 8), GridItem(.flexible(), spacing: 8)],
+            spacing: 8
+        ) {
+            ForEach(Array(cells.enumerated()), id: \.offset) { _, item in
+                cell(for: item.group, percent: item.percent)
             }
         }
     }
@@ -233,6 +219,7 @@ struct StrengthScreen: View {
         Button {
             selectedGroup = selectedGroup == group ? nil : group
             selectedExerciseID = nil
+            showsAllBests = false
         } label: {
             HStack(spacing: 6) {
                 Text(group?.description ?? NSLocalizedString("all", comment: ""))
@@ -251,7 +238,10 @@ struct StrengthScreen: View {
             }
             .padding(.horizontal, 12)
             .padding(.vertical, 10)
-            .frame(maxWidth: .infinity, alignment: .leading)
+            // A no-data cell has no pill in it, so it would otherwise stand shorter than its
+            // neighbours and break the grid's rhythm. Matching the pill's height keeps every cell
+            // the same size whatever it contains.
+            .frame(maxWidth: .infinity, minHeight: Self.groupCellHeight, alignment: .leading)
             .background(
                 RoundedRectangle(cornerRadius: 18, style: .continuous)
                     .fill(isSelected ? color.opacity(0.15) : Color.secondaryBackground)
@@ -309,6 +299,103 @@ struct StrengthScreen: View {
         .foregroundStyle(.tertiary)
         .lineLimit(1)
         .minimumScaleFactor(0.8)
+    }
+
+    // MARK: Strongest lifts
+
+    /// What you can actually lift, heaviest first — the question the rest of the screen never
+    /// answers. Everything above is *change*: a percentage says a lift moved, not that it is heavy,
+    /// and a beginner adding 20% to a light press outranks a hard-won 2% on a heavy squat all the
+    /// way down the chart. This is the standing that the ranking is relative to.
+    ///
+    /// Unlike the chart, a lift needs no prior-window best to appear: one you only started this
+    /// month still has a weight, and leaving it out of a "strongest" list would be plainly wrong.
+    @ViewBuilder
+    private var strongest: some View {
+        let all = scopedBests
+        if !all.isEmpty {
+            let shown = showsAllBests ? all : Array(all.prefix(Self.collapsedBestsCount))
+            VStack(alignment: .leading, spacing: SECTION_HEADER_SPACING) {
+                Text(NSLocalizedString("strengthStrongestLifts", comment: ""))
+                    .font(.caption.weight(.bold))
+                    .textCase(.uppercase)
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 4)
+                VStack(spacing: 0) {
+                    ForEach(Array(shown.enumerated()), id: \.element.id) { index, best in
+                        Button {
+                            homeNavigationCoordinator.path.append(.exercise(best.exercise))
+                        } label: {
+                            bestRow(best, rank: index + 1)
+                        }
+                        .buttonStyle(.plain)
+                        if index < shown.count - 1 {
+                            Divider().padding(.leading, 44)
+                        }
+                    }
+                }
+                .tileStyle()
+                if all.count > Self.collapsedBestsCount {
+                    Button {
+                        withAnimation(.snappy) { showsAllBests.toggle() }
+                    } label: {
+                        HStack {
+                            Text(
+                                showsAllBests
+                                    ? NSLocalizedString("showLess", comment: "")
+                                    : String(format: NSLocalizedString("strengthShowAllLifts", comment: ""), all.count)
+                            )
+                            .foregroundStyle(Color.label)
+                            Spacer()
+                            Image(systemName: showsAllBests ? "chevron.up" : "chevron.down")
+                                .foregroundStyle(Color.secondaryLabel)
+                                .font(.footnote.weight(.bold))
+                        }
+                        .padding(.vertical, 12)
+                        .padding(.horizontal, 14)
+                        .frame(maxWidth: .infinity)
+                        .secondaryTileStyle(insetShadow: true)
+                    }
+                    .buttonStyle(TileButtonStyle())
+                }
+            }
+        }
+    }
+
+    /// Narrowed to the selected group, so the list answers the same scope the rest of the screen is
+    /// showing rather than quietly reporting the whole training.
+    private var scopedBests: [StrengthProgress.ExerciseBest] {
+        guard let selectedGroup else { return progress.bests }
+        return progress.bests.filter { $0.muscleGroup == selectedGroup }
+    }
+
+    private func bestRow(_ best: StrengthProgress.ExerciseBest, rank: Int) -> some View {
+        HStack(spacing: 12) {
+            Text("\(rank)")
+                .font(.system(.footnote, design: .rounded, weight: .bold))
+                .foregroundStyle(.tertiary)
+                .monospacedDigit()
+                .frame(width: 16, alignment: .trailing)
+            Circle()
+                .fill(best.muscleGroup.color)
+                .frame(width: 8, height: 8)
+            Text(best.exercise.displayName)
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(Color.label)
+                .lineLimit(1)
+            Spacer(minLength: 8)
+            // `formatWeightForDisplay` keeps up to three decimals so a logged weight round-trips
+            // through integer grams. An e1RM is *derived*, so that precision is noise —
+            // `formatEstimatedOneRepMax` rounds it, which is what every other e1RM surface shows.
+            UnitView(
+                value: formatEstimatedOneRepMax(best.oneRepMax),
+                unit: WeightUnit.used.rawValue,
+                configuration: .small
+            )
+        }
+        .padding(.horizontal, CELL_PADDING)
+        .padding(.vertical, 12)
+        .contentShape(Rectangle())
     }
 
     private var footnote: some View {

--- a/LOGIT/Features/Home/StrengthTile.swift
+++ b/LOGIT/Features/Home/StrengthTile.swift
@@ -91,6 +91,9 @@ struct StrengthTile: View {
         .padding(CELL_PADDING)
         .frame(maxWidth: .infinity, alignment: .leading)
         .tileStyle()
+        // The whole card is the target. Without this the tile is only tappable where its own
+        // subviews are, so the gaps between the figure and the chart did nothing.
+        .contentShape(Rectangle())
     }
 
     private var header: some View {

--- a/LOGIT/Features/Home/Tiles/MuscleBalanceGoalTile.swift
+++ b/LOGIT/Features/Home/Tiles/MuscleBalanceGoalTile.swift
@@ -61,6 +61,9 @@ struct MuscleBalanceGoalTile: View {
         .padding(CELL_PADDING)
         .frame(maxWidth: .infinity, alignment: .leading)
         .tileStyle()
+        // The whole card is the target. Without this the tile is only tappable where its own
+        // subviews are, so the gaps between the figure and the chart did nothing.
+        .contentShape(Rectangle())
     }
 
     private var header: some View {


### PR DESCRIPTION
Nine adjustments across two commits. Three were bugs rather than polish.

## Bugs

**The chart was eating the tile's taps.** `StrengthBarChart` carries a `contentShape(Rectangle())` and a gesture so the detail screen can select bars — but on the Summary tile the chart fills most of the card and `selection` is nil, so that shape swallowed every touch and did nothing with it. The tile only opened where a label happened to be. The chart now hit-tests solely when selection is wired up, and both half-tiles take a full-card content shape.

**e1RM rendered as `160.417 KG`.** `formatWeightForDisplay` keeps three decimals so a *logged* weight round-trips through integer grams; an e1RM is derived, so that precision is noise. `formatEstimatedOneRepMax` rounds it, matching every other e1RM surface.

**Declines had stopped being grey.** Last round they kept their hue at low opacity, which made a decline read as a faint *gain* of the same thing. Grey is what every other trend surface in the app uses for down.

## The hero stops naming a second exercise

"Best mover Squat" sat beside the headline, and two figures side by side get read as one statement — next to a falling percentage it parsed as a verdict on Squat, and no label above it could undo that. The right-hand slot is gone.

In its place, the tile's own anatomy: a caption over the figure. It reads "Estimated 1RM" normally and, while a bar is held, that exercise's name in its muscle colour, with the figure below switching to that lift's own change. The chart's axis ends already say which end is which.

## Strongest lifts

Everything else on this screen is *change*, and change can't tell you what is heavy — a beginner adding 20% to a light press outranks a hard-won 2% on a heavy squat all the way down the chart. The new list is the standing that ranking is relative to: top five by best e1RM in the window, expandable, each row opening its exercise, scoped to the selected group.

`StrengthProgress` gained `bests` for it, computed in the same pass over the sets. It deliberately does **not** require a prior-window best the way `changes` does: a lift you only started this month still has a weight, and excluding it from a "strongest" list would be plainly wrong.

## Smaller

| | |
| --- | --- |
| Selection | releasing clears it — the hold is a peek, not a mode you must leave |
| Detail density | "Biggest movers", its hint, and the eight per-bar names all gone; two labels now name the ranking's *ends*, switching to "Most declined" when declines exist |
| Group grid | no heading (a grid of tappable pills needn't be told it's tappable); every cell one height whatever it holds; no-data groups sorted to the end |

## Verification

432 unit tests, the four scenario roots and the accessibility guard, on a private simulator — a concurrent session is running tests against the shared device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)