### PR TITLE
Strength detail: About section, lift tiles, selection-scoped colour

### DIFF
--- a/LOGIT/Features/Home/StrengthBarChart.swift
+++ b/LOGIT/Features/Home/StrengthBarChart.swift
@@ -48,6 +48,12 @@ struct StrengthBarChart: View {
     /// Declines are grey at this weight — solid enough to read as a bar, muted enough that the
     /// accent side stays the thing you look at.
     private static let declineOpacity: Double = 0.55
+    /// A decline *inside* the selected scope keeps its colour and loses solidity instead of turning
+    /// grey: once something is highlighted, dropping its own declines to the same grey as everything
+    /// it was highlighted against would hide the half of the picture the selection is asking about.
+    private static let selectedDeclineOpacity: Double = 0.45
+    /// Everything outside the selection.
+    private static let dimmedOpacity: Double = 0.28
     /// Shortest a bar can be drawn. Every exercise in the ranking keeps one: a flat lift is part of
     /// the ranking and should hold its column, and columns that render nothing leave the movers
     /// crowded into a corner of an otherwise empty chart.
@@ -136,18 +142,6 @@ struct StrengthBarChart: View {
                 )
                 .fill(color(for: change, maxGain: maxGain))
                 .frame(height: max(magnitude, Self.minimumBarHeight))
-                .overlay {
-                    if isSelected {
-                        UnevenRoundedRectangle(
-                            topLeadingRadius: change.percentChange > 0 ? 2 : 0,
-                            bottomLeadingRadius: change.percentChange > 0 ? 0 : 2,
-                            bottomTrailingRadius: change.percentChange > 0 ? 0 : 2,
-                            topTrailingRadius: change.percentChange > 0 ? 2 : 0,
-                            style: .continuous
-                        )
-                        .strokeBorder(Color.label, lineWidth: 1.5)
-                    }
-                }
                 Spacer(minLength: 0)
             }
             .frame(height: height, alignment: .top)
@@ -155,25 +149,42 @@ struct StrengthBarChart: View {
         .frame(height: height)
     }
 
-    /// Gains carry identity and rank; declines are always neutral grey.
+    /// Three states, one rule: whatever is *in scope* wears a hue, everything else is dim grey.
     ///
-    /// Identity is the hue of a *gain* — the accent normally, the muscle group's own colour once a
-    /// group is highlighted, dim grey for gains outside that group. A decline never takes a hue at
-    /// all: tinting it in the same colour made it read as a faint gain of the same thing, and grey
-    /// is what every other trend surface in the app already uses for "down".
+    /// With nothing selected the scope is the whole training, so gains take the accent ramp and
+    /// declines are grey — the app's standing treatment for "down". Selecting an exercise narrows the
+    /// scope to that one bar; selecting a group narrows it to that group. In both cases the scope
+    /// wears the muscle group's own colour and everything outside drops to grey.
+    ///
+    /// A decline *inside* the scope keeps that colour and loses solidity rather than turning grey.
+    /// Grey is what "not what you asked about" already means here, so spending it on the selection's
+    /// own declines would hide exactly the half of the picture the selection is asking about.
     private func color(for change: StrengthProgress.ExerciseChange, maxGain: Double) -> Color {
-        guard change.percentChange > 0 else { return Color.secondaryLabel.opacity(Self.declineOpacity) }
-        let base: Color
+        // An exercise selection is narrower than a group's, so it wins.
+        if let selectedID = selection?.wrappedValue {
+            guard change.id == selectedID else { return Color.secondaryLabel.opacity(Self.dimmedOpacity) }
+            return scopedColor(change.muscleGroup.color, percent: change.percentChange, maxGain: maxGain)
+        }
         if let highlightedGroup {
             guard change.muscleGroup == highlightedGroup else {
-                return Color.secondaryLabel.opacity(0.28)
+                return Color.secondaryLabel.opacity(Self.dimmedOpacity)
             }
-            base = highlightedGroup.color
-        } else {
-            base = .accentColor
+            return scopedColor(highlightedGroup.color, percent: change.percentChange, maxGain: maxGain)
         }
+        guard change.percentChange > 0 else { return Color.secondaryLabel.opacity(Self.declineOpacity) }
+        return rampedColor(.accentColor, percent: change.percentChange, maxGain: maxGain)
+    }
+
+    /// In-scope: ramped when up, translucent when down — never grey.
+    private func scopedColor(_ base: Color, percent: Double, maxGain: Double) -> Color {
+        percent > 0
+            ? rampedColor(base, percent: percent, maxGain: maxGain)
+            : base.opacity(Self.selectedDeclineOpacity)
+    }
+
+    private func rampedColor(_ base: Color, percent: Double, maxGain: Double) -> Color {
         guard maxGain > 0 else { return base }
-        let step = min(Int(change.percentChange / maxGain * Double(Self.rampSteps)), Self.rampSteps - 1)
+        let step = min(Int(percent / maxGain * Double(Self.rampSteps)), Self.rampSteps - 1)
         let t = Double(step) / Double(Self.rampSteps - 1)
         return base.opacity(Self.rampFloor + (1 - Self.rampFloor) * t)
     }

--- a/LOGIT/Features/Home/StrengthScreen.swift
+++ b/LOGIT/Features/Home/StrengthScreen.swift
@@ -38,6 +38,9 @@ struct StrengthScreen: View {
     private static let groupCellHeight: CGFloat = 44
     /// Strongest lifts shown before the list collapses.
     private static let collapsedBestsCount = 5
+    /// Matches `StrengthBarChart`'s in-scope decline weight, so the figure and the bar it describes
+    /// fade by the same amount.
+    private static let scopedDeclineOpacity: Double = 0.45
 
     init(workouts: [Workout], initialGroup: MuscleGroup? = nil) {
         self.workouts = workouts
@@ -54,7 +57,7 @@ struct StrengthScreen: View {
                     groupGrid
                     strongest
                 }
-                footnote
+                about
             }
             .padding(.horizontal)
             .padding(.top)
@@ -171,9 +174,18 @@ struct StrengthScreen: View {
                 .minimumScaleFactor(0.6)
                 .lineLimit(1)
         }
-        .foregroundStyle(strengthTrendIsDown(percent) ? Color.secondaryLabel : color)
+        // A decline goes grey only when nothing is selected. Inside a scope it keeps that scope's
+        // colour and loses solidity instead — the same rule the bars follow, so the figure and the
+        // chart never disagree about what the selection is.
+        .foregroundStyle(figureColor(percent, color: color))
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(figureAccessibilityLabel(percent))
+    }
+
+    private func figureColor(_ percent: Double, color: Color) -> Color {
+        guard strengthTrendIsDown(percent) else { return color }
+        let isScoped = selectedExerciseID != nil || selectedGroup != nil
+        return isScoped ? color.opacity(Self.scopedDeclineOpacity) : Color.secondaryLabel
     }
 
     private func figureAccessibilityLabel(_ percent: Double) -> Text {
@@ -317,24 +329,18 @@ struct StrengthScreen: View {
             let shown = showsAllBests ? all : Array(all.prefix(Self.collapsedBestsCount))
             VStack(alignment: .leading, spacing: SECTION_HEADER_SPACING) {
                 Text(NSLocalizedString("strengthStrongestLifts", comment: ""))
-                    .font(.caption.weight(.bold))
-                    .textCase(.uppercase)
-                    .foregroundStyle(.secondary)
-                    .padding(.horizontal, 4)
-                VStack(spacing: 0) {
-                    ForEach(Array(shown.enumerated()), id: \.element.id) { index, best in
+                    .sectionHeaderStyle2()
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                VStack(spacing: CELL_SPACING) {
+                    ForEach(shown) { best in
                         Button {
                             homeNavigationCoordinator.path.append(.exercise(best.exercise))
                         } label: {
-                            bestRow(best, rank: index + 1)
+                            bestRow(best)
                         }
-                        .buttonStyle(.plain)
-                        if index < shown.count - 1 {
-                            Divider().padding(.leading, 44)
-                        }
+                        .buttonStyle(TileButtonStyle())
                     }
                 }
-                .tileStyle()
                 if all.count > Self.collapsedBestsCount {
                     Button {
                         withAnimation(.snappy) { showsAllBests.toggle() }
@@ -369,44 +375,56 @@ struct StrengthScreen: View {
         return progress.bests.filter { $0.muscleGroup == selectedGroup }
     }
 
-    private func bestRow(_ best: StrengthProgress.ExerciseBest, rank: Int) -> some View {
-        HStack(spacing: 12) {
-            Text("\(rank)")
-                .font(.system(.footnote, design: .rounded, weight: .bold))
-                .foregroundStyle(.tertiary)
-                .monospacedDigit()
-                .frame(width: 16, alignment: .trailing)
-            Circle()
-                .fill(best.muscleGroup.color)
-                .frame(width: 8, height: 8)
-            Text(best.exercise.displayName)
-                .font(.subheadline.weight(.semibold))
-                .foregroundStyle(Color.label)
-                .lineLimit(1)
+    /// The exercise-cell anatomy — name over its muscle group in the group's colour — with the value
+    /// trailing. The colour lives in the muscle-group line the way it does everywhere else in the
+    /// app, so the row needs no separate dot to carry identity.
+    ///
+    /// Each row states "e1RM" itself: the section header says which lifts these are, not what the
+    /// number is, and a column of bare weights beside exercise names reads as *lifted* weight.
+    private func bestRow(_ best: StrengthProgress.ExerciseBest) -> some View {
+        HStack(alignment: .center, spacing: 12) {
+            VStack(alignment: .leading, spacing: 0) {
+                Text(best.exercise.displayName)
+                    .font(.body.weight(.bold))
+                    .foregroundStyle(Color.label)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.8)
+                Text(best.muscleGroup.description)
+                    .font(.system(.footnote, design: .rounded, weight: .bold))
+                    .foregroundStyle(best.muscleGroup.color.gradient)
+            }
             Spacer(minLength: 8)
-            // `formatWeightForDisplay` keeps up to three decimals so a logged weight round-trips
-            // through integer grams. An e1RM is *derived*, so that precision is noise —
-            // `formatEstimatedOneRepMax` rounds it, which is what every other e1RM surface shows.
-            UnitView(
-                value: formatEstimatedOneRepMax(best.oneRepMax),
-                unit: WeightUnit.used.rawValue,
-                configuration: .small
-            )
+            VStack(alignment: .trailing, spacing: 1) {
+                Text(NSLocalizedString("e1RM", comment: ""))
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(.tertiary)
+                // `formatWeightForDisplay` keeps up to three decimals so a logged weight round-trips
+                // through integer grams. An e1RM is *derived*, so that precision is noise —
+                // `formatEstimatedOneRepMax` rounds it, like every other e1RM surface.
+                UnitView(
+                    value: formatEstimatedOneRepMax(best.oneRepMax),
+                    unit: WeightUnit.used.rawValue,
+                    configuration: .small
+                )
+            }
         }
-        .padding(.horizontal, CELL_PADDING)
-        .padding(.vertical, 12)
+        .padding(CELL_PADDING)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .tileStyle()
         .contentShape(Rectangle())
     }
 
-    private var footnote: some View {
-        HStack(alignment: .top, spacing: 6) {
-            Image(systemName: "info.circle")
-            Text(String(format: NSLocalizedString("strengthInfo", comment: ""), window.rawValue, window.rawValue))
-        }
-        .font(.footnote)
-        .foregroundStyle(.secondary)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(.horizontal, 4)
+    /// The same "About <metric>" tile every other metric detail screen ends on. Two paragraphs,
+    /// because this screen depends on two things a reader has no reason to know: how the percentage
+    /// is built, and what an estimated 1RM even is — the unit every figure and the whole strongest
+    /// list are quoted in, and which was never explained anywhere on the way here.
+    private var about: some View {
+        AboutSection(
+            metricTitle: NSLocalizedString("strength", comment: ""),
+            text: String(format: NSLocalizedString("strengthInfo", comment: ""), window.rawValue, window.rawValue)
+                + "\n\n"
+                + NSLocalizedString("e1RMInfo", comment: "")
+        )
     }
 }
 


### PR DESCRIPTION
## An About section at the bottom

The same `AboutSection` tile every other metric detail screen ends on. Two paragraphs, because this screen leans on two things a reader has no reason to know: how the percentage is built, and **what an estimated 1RM is** — the unit every figure and the whole strongest-lifts list are quoted in, and which was never explained anywhere on the way here.

The second paragraph reuses the existing `e1RMInfo` string rather than writing a second explanation of the same formula.

## Strongest lifts become tiles

A section header in the app's own style, and one tile per lift in `ExerciseCell`'s anatomy — name over its muscle group in the group's colour, value trailing.

The colour dot goes: the muscle-group line already carries identity the way it does everywhere else in the app, so the dot was doing that job twice. Each row states **"e1RM"** above its value, because the header says *which* lifts these are, not what the number is — and a column of bare weights beside exercise names reads as *lifted* weight.

## Colour follows the selection

One rule, three states: **whatever is in scope wears a hue, everything else is dim grey.**

| State | In scope | Everything else |
| --- | --- | --- |
| Nothing selected | gains take the accent ramp, declines grey | — |
| Bar held | that exercise, in its muscle group's colour | dim grey |
| Group selected | that group, in its colour | dim grey |

A decline **inside** the scope keeps that colour at reduced opacity rather than turning grey. Grey already means "not what you asked about" here, so spending it on the selection's own declines would hide exactly the half of the picture the selection is asking about.

The large figure follows the identical rule, so it and the chart can never disagree about what is selected. The selected bar's white outline goes with it — colour marks the selection unmistakably now.

> One interpretation worth checking: the brief said "translucent accent" for the held-exercise case and "translucent muscle colour" for the group case, joined by "similarly". I read those as the same treatment and used the **muscle colour** in both — an exercise always belongs to a group, and using the accent there would contradict the muscle colour on the same bar. One line to switch if the accent was meant literally.

## Verification

432 unit tests, the four scenario roots and the accessibility guard, on a private simulator. Exercise-selection colouring was photographed by temporarily suspending release-clearing; that change is reverted and the build confirms it. The `many` fixture has no declines in a 4-week window, so the in-scope-decline branch is code-verified rather than photographed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)