### PR TITLE
Summary: the weekly goal becomes a clear-glass ring with the count inside

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -24,6 +24,7 @@ The states, all driven by launch arguments (DEBUG builds only, implemented in
 | One workout (single data points, fresh trends) | `-SCENARIO one` |
 | Many workouts (long-time user, rich history) | `-SCENARIO many` |
 | Free tier (Pro locked) | add `-UITEST_FORCE_FREE` to any scenario |
+| Goal set but nothing logged yet (every user's Monday) | `-SCENARIO empty -workoutPerWeekTarget 4` — an explicit target beats the scenario's own, like `-weightUnit` |
 | Stress (2 years dense history + in-progress workout; for performance work, not part of the standard matrix) | `-SCENARIO stress`, add `-UITEST_SHOW_RECORDER 1` to land in the recorder |
 
 Standard matrix for a change: **empty, one, many (Pro implied on the

--- a/LOGIT/App/TestScenarios.swift
+++ b/LOGIT/App/TestScenarios.swift
@@ -70,8 +70,13 @@ enum TestScenario: String {
         if overrides["distanceUnit"] == nil {
             overrides["distanceUnit"] = DistanceUnit.km.rawValue
         }
-        // `empty` shows the no-goal state, the other scenarios a realistic goal.
-        overrides["workoutPerWeekTarget"] = self == .empty ? -1 : self == .stress ? 2 : 4
+        // `empty` shows the no-goal state, the other scenarios a realistic goal. An explicit
+        // `-workoutPerWeekTarget` wins, the way `-weightUnit` does: pairing a target with `empty` is
+        // the only way to reach the goal-set-but-nothing-logged-yet state — every user's Monday
+        // morning, and the one the weekly-goal ring's zero styling is about.
+        if overrides["workoutPerWeekTarget"] == nil {
+            overrides["workoutPerWeekTarget"] = self == .empty ? -1 : self == .stress ? 2 : 4
+        }
         // Per-user layout state stored as Data (object URIs / JSON) must not
         // leak in from the real store — the URIs wouldn't resolve against the
         // in-memory store anyway. A string value makes the Data reads fail so

--- a/LOGIT/Features/Home/WeeklyGoalCountPill.swift
+++ b/LOGIT/Features/Home/WeeklyGoalCountPill.swift
@@ -7,16 +7,18 @@
 
 import SwiftUI
 
-/// The Summary's weekly goal, reduced to a title-row control: a completion ring and the `2/4` fraction.
+/// The Summary's weekly goal, reduced to a title-row control: the week's count inside a completion
+/// ring.
 ///
 /// It replaces the weekly-goal hero tile. Once This Week and Progress became one scroll, the week
 /// stopped being the screen's subject and became one fact among many — and a fact that already had a
 /// whole screen behind it. A tile was too much furniture for that; a control on the title row is the
 /// right size, and it puts the week where the eye already starts.
 ///
-/// The count wears the label colour and the `/4` the secondary one: that split is what makes it read
-/// as a *goal* rather than a score. Day-level muscle colours deliberately don't come along — those
-/// are something you look at on purpose, and `WorkoutGoalScreen` renders them full size one tap away.
+/// The target is no longer spelled out: the ring *is* the target, so `3` inside a nearly closed ring
+/// says everything `3/4` did in half the width. VoiceOver still hears the full fraction. Day-level
+/// muscle colours deliberately don't come along — those are something you look at on purpose, and
+/// `WorkoutGoalScreen` renders them full size one tap away.
 struct WeeklyGoalCountPill: View {
     let workouts: [Workout]
     /// Opens the goal screen — used whenever a target exists.
@@ -26,8 +28,13 @@ struct WeeklyGoalCountPill: View {
 
     @AppStorage("workoutPerWeekTarget") private var target: Int = -1
 
-    private static let ringSize: CGFloat = 22
+    private static let ringSize: CGFloat = 28
     private static let ringWidth: CGFloat = 3
+    /// A zero week still gets a mark: trimmed this short and drawn with round caps, the arc renders as
+    /// a single dot at twelve o'clock. It reads as where the ring *starts*, not as progress — one
+    /// workout would already sweep a quarter of the circle at the usual targets — and it keeps the
+    /// control from looking switched off on the one day of the week it matters most.
+    private static let minimumArc: Double = 0.005
 
     private var hasGoal: Bool { target > 0 }
     private var count: Int {
@@ -37,8 +44,8 @@ struct WeeklyGoalCountPill: View {
 
     private var isMet: Bool { hasGoal && count >= target }
     private var streak: Int { SummaryViewModel.currentWeeklyStreak(workouts: workouts, target: target) }
-    /// Once the week is won the check already says so, so the text slot is spent on the streak — the
-    /// one number that lost its home when the hero tile went away.
+    /// Once the week is won the closed ring already says so, so the pill grows a text slot for the
+    /// streak — the one number that lost its home when the hero tile went away.
     private var showsStreak: Bool { isMet && streak >= 2 }
 
     var body: some View {
@@ -49,63 +56,60 @@ struct WeeklyGoalCountPill: View {
                 if hasGoal {
                     HStack(spacing: 6) {
                         ring
-                        label
+                        if showsStreak { streakLabel }
                     }
                 } else {
                     Text(NSLocalizedString("setGoal", comment: ""))
-                        .font(.subheadline.weight(.semibold))
+                        .font(.body.weight(.semibold))
                 }
             }
+            // The style's own vertical padding is roughly half its horizontal one, which reads as a
+            // squat pill around content this tall. The extra 5 pt evens the inset out on both axes.
+            .padding(.vertical, 5)
             // Collapsed inside the label, not on the Button: `.accessibilityElement(children: .ignore)`
             // applied to the Button replaces its element and drops the button trait with it, so
             // `app.buttons["weeklyGoalPill"]` finds nothing. Flattening the label instead leaves one
-            // button element that reads as a sentence rather than "2", "/", "4".
+            // button element that reads as a sentence rather than a bare "2".
             .accessibilityElement(children: .ignore)
             .accessibilityLabel(accessibilityLabel)
         }
-        .contentShape(Capsule())
+        // Liquid glass, so the control reads as a control: the pill sits on the same scroll surface as
+        // the tiles below it, and without a material of its own it looked like loose text that happened
+        // to be tappable. Clear rather than regular, because it sits over the muscle wash at the top of
+        // the screen and should let that colour through instead of frosting it. `.glass` also gives it
+        // the standard press feedback for free.
+        .buttonStyle(.glass(.clear))
         .accessibilityIdentifier("weeklyGoalPill")
     }
 
+    /// The count sits in the ring's middle rather than beside it: the ring already carries the target,
+    /// so the two belong to one mark. No checkmark for a met week — a closed ring says that, and the
+    /// number keeps saying something the clamped arc can't, namely that five workouts beat a four.
     private var ring: some View {
-        ZStack {
-            // Clamped, so an over-delivered week can't wrap round and read as a fresh one.
-            CompletionRing(
-                progress: target > 0 ? min(Double(count) / Double(target), 1) : 0,
-                lineWidth: Self.ringWidth,
-                color: count > 0 ? .accentColor : .secondaryLabel
-            )
-            if isMet {
-                Image(systemName: "checkmark")
-                    .font(.system(size: 9, weight: .black))
-                    .foregroundStyle(Color.accentColor)
-            }
+        CompletionRing(
+            // Clamped, so an over-delivered week can't wrap round and read as a fresh one, and floored
+            // so a fresh week still shows its starting dot.
+            progress: max(target > 0 ? min(Double(count) / Double(target), 1) : 0, Self.minimumArc),
+            lineWidth: Self.ringWidth,
+            color: .accentColor
+        ) {
+            Text("\(count)")
+                .font(.subheadline.weight(.bold))
+                .monospacedDigit()
+                .foregroundStyle(Color.accentColor)
         }
         .frame(width: Self.ringSize, height: Self.ringSize)
     }
 
-    @ViewBuilder
-    private var label: some View {
-        if showsStreak {
-            HStack(spacing: 3) {
-                Image(systemName: "flame.fill")
-                    .font(.caption2.weight(.bold))
-                Text("\(streak)")
-                    .font(.subheadline.weight(.semibold))
-                    .monospacedDigit()
-            }
-            .foregroundStyle(Color.accentColor)
-        } else {
-            HStack(spacing: 0) {
-                Text("\(count)")
-                    // A zero week is a quiet nothing, not an accent-coloured one.
-                    .foregroundStyle(count > 0 ? Color.label : Color.secondaryLabel)
-                Text("/\(target)")
-                    .foregroundStyle(Color.secondaryLabel)
-            }
-            .font(.subheadline.weight(.semibold))
-            .monospacedDigit()
+    private var streakLabel: some View {
+        HStack(spacing: 3) {
+            Image(systemName: "flame.fill")
+                .font(.caption.weight(.bold))
+            Text("\(streak)")
+                .font(.body.weight(.semibold))
+                .monospacedDigit()
         }
+        .foregroundStyle(Color.accentColor)
     }
 
     private var accessibilityLabel: Text {


### PR DESCRIPTION
The Summary's weekly-goal control, reworked in three steps.

**A clear liquid-glass button.** It was loose text that happened to be tappable, sitting on the same scroll surface as the tiles below it. Now it is `.buttonStyle(.glass(.clear))` — clear rather than regular, so the muscle wash at the top of the screen shows through instead of being frosted — a little larger, and inset evenly on both axes (the style's own vertical padding is roughly half its horizontal one, which read as squat around content this tall).

**The count moved inside the ring.** The `3/4` fraction is gone: the ring already carries the target, so `3` in the middle of a nearly closed ring says the same thing in half the width. VoiceOver still hears the full fraction. The met-week checkmark went with it — a closed ring says "done", and keeping the number means an over-delivered week still reads honestly, which the clamped arc cannot show.

**A zero week is never empty.** The arc has a trim floor of `0.005`, which the ring's round caps render as a single dot at twelve o'clock, and it is accent-coloured now at every count. It cannot be misread as progress — one workout already sweeps a quarter of the circle at the usual targets — and it keeps the control from looking switched off on the one morning of the week it matters most. This reverses the old "a zero week is a quiet nothing" rule; a grey dot on a grey track would have defeated the point.

### Test scenarios

The zero-with-goal state was unreachable, because `empty` hard-codes "no goal". An explicit `-workoutPerWeekTarget` now beats the scenario's own value — the same escape hatch `-weightUnit` already had — so `-SCENARIO empty -workoutPerWeekTarget 4` lands on it. Documented in the AGENT.md scenario table.

### Verification

iOS 26.4 simulator, `ScenarioScreenshots`: `empty`, `one`, `many`, the new zero-with-goal state, and `testSummaryNavigationBarAccessible` (the regression guard that the pill stays reachable as `app.buttons["weeklyGoalPill"]` and still pushes the goal screen) — all passing.

| state | pill |
| --- | --- |
| goal set, nothing logged | accent dot at twelve o'clock, accent `0` |
| 1 of 4 | quarter arc, accent `1` |
| 4 of 4 | closed ring, accent `4` |
| no goal | unchanged "Set Goal" capsule, now in clear glass |

🤖 Generated with [Claude Code](https://claude.com/claude-code)